### PR TITLE
[phase 4] support regex token replacements

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -5,7 +5,15 @@ name = "aho-corasick"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -261,11 +269,11 @@ dependencies = [
 [[package]]
 name = "geocoder-abbreviations"
 version = "0.1.0"
-source = "git+https://github.com/mapbox/geocoder-abbreviations?rev=master#fd0bb1e885fa812958a15bbe9aa040477ef11c36"
+source = "git+https://github.com/mapbox/geocoder-abbreviations?rev=regex#003b67537269841db07b21e0519f38a5fb263622"
 dependencies = [
  "alphanumeric-sort 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fancy-regex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -351,12 +359,8 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "memoffset"
@@ -500,17 +504,17 @@ version = "0.1.0"
 dependencies = [
  "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fancy-regex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=master)",
+ "geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=regex)",
  "geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgis 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -577,7 +581,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -585,12 +589,12 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.1.0"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -605,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -809,6 +813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
+"checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
 "checksum alphanumeric-sort 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7cd2580c95c654d681db0194a310af67a293f5e1c8bafa5b35b63269c4665a39"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
@@ -843,7 +848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-cprng 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81f7f8eb465745ea9b02e2704612a9946a59fa40572086c6fd49d6ddcf30bf31"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
-"checksum geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=master)" = "<none>"
+"checksum geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=regex)" = "<none>"
 "checksum geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22b37e57c7f498be81360116a489ebad0b133557e87d8b4f82d51bebd1c3ef9e"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
@@ -856,7 +861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
-"checksum memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1dd4eaac298c32ce07eb6ed9242eda7d82955b9170b7d6db59b2e02cc63fcb8"
+"checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum neon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2e4dcd1e15c5944d89d283ec7c3b1b4ef83b5d2227b3b5d91d33224a45c7a3"
 "checksum neon-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "870c8f0b18ce83d8af6d95b9b723678aef55c047f29e09ac3e3d10ceecf57fd0"
@@ -880,9 +885,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-"checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
+"checksum regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
-"checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
+"checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -25,8 +25,8 @@ serde_json = "1.0"
 serde_derive = "1.0"
 serde = "1.0"
 fancy-regex = "0.1.0"
-memchr = "2.0.2"
-geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "master" }
+memchr = "2.2.0"
+geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "regex" }
 
 [dependencies.postgres]
 version = "0.15.2"

--- a/native/src/classify/mod.rs
+++ b/native/src/classify/mod.rs
@@ -1,7 +1,6 @@
 use postgres::{Connection, TlsMode};
 use std::{
     io::{Write, BufWriter},
-    collections::HashMap,
     fs::File,
     convert::From
 };
@@ -69,7 +68,7 @@ pub fn classify(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         &conn,
         AddrStream::new(
             GeoStream::new(args.input),
-            crate::Context::new(String::from("xx"), None, Tokens::new(HashMap::new())),
+            crate::Context::new(String::from("xx"), None, Tokens::new(Vec::new())),
             None
         )
     );

--- a/native/src/conflate/mod.rs
+++ b/native/src/conflate/mod.rs
@@ -1,6 +1,5 @@
 use std::convert::From;
 use postgres::{Connection, TlsMode};
-use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use geojson::GeoJson;
@@ -10,6 +9,7 @@ use neon::prelude::*;
 use crate::{
     Names,
     Address,
+    Tokens,
     hecate,
     util::linker,
     types::name::InputName,
@@ -93,7 +93,7 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
     let context = match args.context {
         Some(context) => crate::Context::from(context),
-        None => crate::Context::new(String::from(""), None, crate::Tokens::new(HashMap::new()))
+        None => crate::Context::new(String::from(""), None, Tokens::new(Vec::new()))
     };
 
     let pgaddress = pg::Address::new();

--- a/native/src/dedupe/mod.rs
+++ b/native/src/dedupe/mod.rs
@@ -1,9 +1,9 @@
 use std::convert::From;
 use postgres::{Connection, TlsMode};
-use std::collections::HashMap;
 use std::thread;
 use std::fs::File;
 use std::io::{BufWriter, Write};
+use crate::Tokens;
 
 use neon::prelude::*;
 
@@ -58,7 +58,7 @@ pub fn dedupe(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
     let context = match args.context {
         Some(context) => crate::Context::from(context),
-        None => crate::Context::new(String::from(""), None, crate::Tokens::new(HashMap::new()))
+        None => crate::Context::new(String::from(""), None, Tokens::new(Vec::new()))
     };
 
     let address = pg::Address::new();

--- a/native/src/map/mod.rs
+++ b/native/src/map/mod.rs
@@ -1,6 +1,5 @@
 use std::convert::From;
 use postgres::{Connection, TlsMode};
-use std::collections::HashMap;
 
 use crate::Context as CrateContext;
 use crate::Tokens;
@@ -104,7 +103,7 @@ pub fn import_addr(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
     let context = match args.context {
         Some(context) => CrateContext::from(context),
-        None => CrateContext::new(String::from(""), None, Tokens::new(HashMap::new()))
+        None => CrateContext::new(String::from(""), None, Tokens::new(Vec::new()))
     };
 
     let address = pg::Address::new();
@@ -135,7 +134,7 @@ pub fn import_net(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
     let context = match args.context {
         Some(context) => CrateContext::from(context),
-        None => CrateContext::new(String::from(""), None, Tokens::new(HashMap::new()))
+        None => CrateContext::new(String::from(""), None, Tokens::new(Vec::new()))
     };
 
     let network = pg::Network::new();

--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -12,7 +12,6 @@ mod replace;
 pub use self::diacritics::diacritics;
 pub use self::tokens::Tokens;
 pub use self::tokens::Tokenized;
-pub use self::tokens::ParsedToken;
 
 use std::collections::HashMap;
 use regex::{Regex, RegexSet};
@@ -526,7 +525,7 @@ mod tests {
 
     #[test]
     fn test_is_drivethrough() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(Vec::new()));
 
         assert_eq!(is_drivethrough(
             &String::from("Main St NE"),
@@ -538,7 +537,7 @@ mod tests {
             &context
         ), false);
 
-        let context = Context::new(String::from("de"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("de"), None, Tokens::new(Vec::new()));
         assert_eq!(is_drivethrough(
             &String::from("McDonalds einfahrt"),
             &context
@@ -567,7 +566,7 @@ mod tests {
 
     #[test]
     fn test_syn_us_cr() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(Vec::new()));
 
         assert_eq!(syn_us_cr(&Name::new(String::from(""), 0, &context), &context), vec![]);
 
@@ -582,7 +581,7 @@ mod tests {
 
     #[test]
     fn test_syn_ca_french() {
-        let context = Context::new(String::from("ca"), Some(String::from("qc")), Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("ca"), Some(String::from("qc")), Tokens::new(Vec::new()));
 
         assert_eq!(syn_ca_french(&Name::new(String::from(""), 0, &context), &context), vec![]);
 
@@ -600,7 +599,7 @@ mod tests {
 
     #[test]
     fn test_syn_ca_hwy() {
-        let context = Context::new(String::from("ca"), Some(String::from("on")), Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("ca"), Some(String::from("on")), Tokens::new(Vec::new()));
 
         assert_eq!(syn_ca_hwy(&Name::new(String::from(""), 0, &context), &context), vec![]);
 
@@ -621,7 +620,7 @@ mod tests {
 
     #[test]
     fn test_syn_us_hwy() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(Vec::new()));
 
         assert_eq!(syn_us_hwy(&Name::new(String::from(""), 0, &context), &context), vec![]);
 
@@ -648,7 +647,7 @@ mod tests {
 
     #[test]
     fn test_syn_state_highway() {
-        let context = Context::new(String::from("us"), Some(String::from("PA")), Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), Some(String::from("PA")), Tokens::new(Vec::new()));
 
         assert_eq!(
             syn_state_hwy(
@@ -726,7 +725,7 @@ mod tests {
 
     #[test]
     fn test_syn_number_suffix() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(Vec::new()));
 
         assert_eq!(
             syn_number_suffix(&Name::new(String::from("1st Avenue"), 0, &context), &context),
@@ -766,7 +765,7 @@ mod tests {
 
     #[test]
     fn test_syn_written_numeric() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(Vec::new()));
 
         assert_eq!(
             syn_written_numeric(&Name::new(String::from("Twenty-third Avenue NW"), 0, &context), &context),
@@ -799,7 +798,7 @@ mod tests {
 
     #[test]
     fn test_is_numbered() {
-        let context = Context::new(String::from("us"), Some(String::from("PA")), Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), Some(String::from("PA")), Tokens::new(Vec::new()));
 
         assert_eq!(
             is_numbered(&Name::new(String::from("main st"), 0, &context)),
@@ -864,7 +863,7 @@ mod tests {
 
     #[test]
     fn test_is_routish() {
-        let context = Context::new(String::from("us"), Some(String::from("PA")), Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), Some(String::from("PA")), Tokens::new(Vec::new()));
 
         assert_eq!(
             is_routish(&Name::new(String::from("main st"), 0, &context)),

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -37,7 +37,7 @@ impl Tokens {
 
         let mut tokenized: Vec<Tokenized> = Vec::with_capacity(tokens.len());
 
-        for token in tokens {
+        for token in &tokens {
             match self.tokens.iter().find(|&tk| {
                 let tokens_lc: Vec<String> = tk.tokens.iter().map(|x| x.to_lowercase()).collect();
                 tokens_lc.contains(&token.to_lowercase())
@@ -92,7 +92,7 @@ impl Tokens {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Tokenized {
     pub token: String,
     pub token_type: Option<TokenType>

--- a/native/src/types/context.rs
+++ b/native/src/types/context.rs
@@ -20,7 +20,7 @@ impl From<InputContext> for Context {
         let country = input.country.unwrap_or(String::from(""));
         let region = input.region;
         let tokens = match input.languages {
-            None => Tokens::new(HashMap::new()),
+            None => Tokens::new(Vec::new()),
             Some(languages) =>  Tokens::generate(languages)
         };
 
@@ -145,19 +145,19 @@ mod tests {
 
     #[test]
     fn context_test() {
-        assert_eq!(Context::new(String::from("us"), None, Tokens::new(HashMap::new())), Context {
+        assert_eq!(Context::new(String::from("us"), None, Tokens::new(Vec::new())), Context {
             country: String::from("US"),
             region: None,
-            tokens: Tokens::new(HashMap::new())
+            tokens: Tokens::new(Vec::new())
         });
 
-        assert_eq!(Context::new(String::from("uS"), Some(String::from("wv")), Tokens::new(HashMap::new())), Context {
+        assert_eq!(Context::new(String::from("uS"), Some(String::from("wv")), Tokens::new(Vec::new())), Context {
             country: String::from("US"),
             region: Some(String::from("WV")),
-            tokens: Tokens::new(HashMap::new())
+            tokens: Tokens::new(Vec::new())
         });
 
-        let cntx = Context::new(String::from("uS"), Some(String::from("wv")), Tokens::new(HashMap::new()));
+        let cntx = Context::new(String::from("uS"), Some(String::from("wv")), Tokens::new(Vec::new()));
 
         assert_eq!(cntx.region_code(), Some(String::from("US-WV")));
 

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -334,12 +334,11 @@ impl Name {
 mod tests {
     use serde_json::json;
     use super::*;
-    use std::collections::HashMap;
     use crate::Tokens;
 
     #[test]
     fn test_name() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(Vec::new()));
 
         assert_eq!(Name::new(String::from("Main St NW"), 0, &context), Name {
             display: String::from("Main St NW"),
@@ -355,7 +354,7 @@ mod tests {
 
     #[test]
     fn test_names_sort() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(Vec::new()));
 
         let mut names = Names::new(vec![
             Name::new(String::from("Highway 123"), -1, &context),
@@ -376,7 +375,7 @@ mod tests {
 
     #[test]
     fn test_names_concat() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(Vec::new()));
 
         let mut names = Names::new(vec![
             Name::new(String::from("Highway 123"), -1, &context),
@@ -398,7 +397,7 @@ mod tests {
 
     #[test]
     fn test_names_dedupe() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(Vec::new()));
 
         let mut names = Names::new(vec![
             Name::new(String::from("Highway 123"), -1, &context),
@@ -416,7 +415,7 @@ mod tests {
 
     #[test]
     fn test_names_from_value() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(Vec::new()));
 
         let expected = Names::new(vec![Name::new(String::from("Main St NE"), 0, &context)], &context);
 
@@ -430,7 +429,7 @@ mod tests {
 
     #[test]
     fn test_names_has_diff() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(Vec::new()));
 
         let a_name = Names::new(vec![Name::new("Main St", 0, &context)], &context);
         let b_name = Names::new(vec![Name::new("Main St", 0, &context)], &context);
@@ -451,7 +450,7 @@ mod tests {
 
     #[test]
     fn test_names() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(Vec::new()));
 
         assert_eq!(Names::new(vec![], &context), Names {
             names: Vec::new()

--- a/native/src/types/network.rs
+++ b/native/src/types/network.rs
@@ -146,7 +146,6 @@ impl Network {
 mod tests {
     use super::*;
     use crate::{Tokens, Context};
-    use std::collections::HashMap;
 
     #[test]
     fn test_network_simple_geom() {
@@ -164,7 +163,7 @@ mod tests {
         let context = Context::new(
             String::from("us"),
             Some(String::from("dc")),
-            Tokens::new(HashMap::new())
+            Tokens::new(Vec::new())
         );
 
         let net = Network::new(feat, &context).unwrap();

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -313,6 +313,15 @@ mod tests {
 
         {
             let a_name = Names::new(vec![Name::new("Main Street", 0, &context)], &context);
+
+            let b_name = Names::new(vec![Name::new("Main St", 0, &context)], &context);
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 100.0)));
+        }
+
+        {
+            let a_name = Names::new(vec![Name::new("Main Street", 0, &context)], &context);
             let b_name = Names::new(vec![Name::new("Maim Street", 0, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
@@ -540,6 +549,15 @@ mod tests {
             let a_name = Names::new(vec![Name::new("Main Street", 0, &context)], &context);
 
             let b_name = Names::new(vec![Name::new("Main Street", 0, &context)], &context);
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));
+        }
+
+        {
+            let a_name = Names::new(vec![Name::new("Main Street", 0, &context)], &context);
+
+            let b_name = Names::new(vec![Name::new("Main St", 0, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -180,31 +180,29 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
     use crate::{Context, Tokens, Name, Names};
-    use crate::text::ParsedToken;
-    use geocoder_abbreviations::TokenType;
+    use geocoder_abbreviations::{Token, TokenType};
 
     #[test]
     fn test_linker() {
-        let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
-        tokens.insert(String::from("saint"), ParsedToken::new(String::from("st"), None));
-        tokens.insert(String::from("street"), ParsedToken::new(String::from("st"), Some(TokenType::Way)));
-        tokens.insert(String::from("st"), ParsedToken::new(String::from("st"), Some(TokenType::Way)));
-        tokens.insert(String::from("lake"), ParsedToken::new(String::from("lk"), None));
-        tokens.insert(String::from("lk"), ParsedToken::new(String::from("lk"), None));
-        tokens.insert(String::from("road"), ParsedToken::new(String::from("rd"), Some(TokenType::Way)));
-        tokens.insert(String::from("rd"), ParsedToken::new(String::from("rd"), Some(TokenType::Way)));
-        tokens.insert(String::from("avenue"), ParsedToken::new(String::from("ave"), Some(TokenType::Way)));
-        tokens.insert(String::from("ave"), ParsedToken::new(String::from("ave"), Some(TokenType::Way)));
-        tokens.insert(String::from("west"), ParsedToken::new(String::from("w"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("east"), ParsedToken::new(String::from("e"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("south"), ParsedToken::new(String::from("s"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("northwest"), ParsedToken::new(String::from("nw"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("nw"), ParsedToken::new(String::from("nw"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("s"), ParsedToken::new(String::from("s"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("w"), ParsedToken::new(String::from("w"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("e"), ParsedToken::new(String::from("e"), Some(TokenType::Cardinal)));
+        let mut tokens: Vec<Token> = Vec::new();
+        tokens.push(Token::new(String::from("saint"), String::from("st"), None, false).unwrap());
+        tokens.push(Token::new(String::from("street"), String::from("st"), Some(TokenType::Way), false).unwrap());
+        tokens.push(Token::new(String::from("st"), String::from("st"), Some(TokenType::Way), false).unwrap());
+        tokens.push(Token::new(String::from("lake"), String::from("lk"), None, false).unwrap());
+        tokens.push(Token::new(String::from("lk"), String::from("lk"), None, false).unwrap());
+        tokens.push(Token::new(String::from("road"), String::from("rd"), Some(TokenType::Way), false).unwrap());
+        tokens.push(Token::new(String::from("rd"), String::from("rd"), Some(TokenType::Way), false).unwrap());
+        tokens.push(Token::new(String::from("avenue"), String::from("ave"), Some(TokenType::Way), false).unwrap());
+        tokens.push(Token::new(String::from("ave"), String::from("ave"), Some(TokenType::Way), false).unwrap());
+        tokens.push(Token::new(String::from("west"), String::from("w"), Some(TokenType::Cardinal), false).unwrap());
+        tokens.push(Token::new(String::from("east"), String::from("e"), Some(TokenType::Cardinal), false).unwrap());
+        tokens.push(Token::new(String::from("south"), String::from("s"), Some(TokenType::Cardinal), false).unwrap());
+        tokens.push(Token::new(String::from("northwest"), String::from("nw"), Some(TokenType::Cardinal), false).unwrap());
+        tokens.push(Token::new(String::from("nw"), String::from("nw"), Some(TokenType::Cardinal), false).unwrap());
+        tokens.push(Token::new(String::from("s"), String::from("s"), Some(TokenType::Cardinal), false).unwrap());
+        tokens.push(Token::new(String::from("w"), String::from("w"), Some(TokenType::Cardinal), false).unwrap());
+        tokens.push(Token::new(String::from("e"), String::from("e"), Some(TokenType::Cardinal), false).unwrap());
 
         let context = Context::new(String::from("us"), None, Tokens::new(tokens));
 


### PR DESCRIPTION
## Context

Ref https://github.com/ingalls/pt2itp/issues/457. Phase 4 of the work to port pt2itp token replacements to Rust and improve token handling. Adds support for regex rather than whole word token replacements and uses geocoder-abbreviations' `Token` struct directly rather than mutating into the `ParsedTokens` intermediate format. See https://github.com/mapbox/geocoder-abbreviations/pull/52 for upstream updates.

## Blockers
Tests are current failing because there are tokens (so far only `Street => St` and `Saint => St` which have non-unique abbreviated forms. This means that the `TokenType` associated to that particular token is arbitrary depending on which token happens to come first in geocoder-abbreviations. Because `Saint => St` is before `Street => St`, any street name that contains the abbreviated form `St` is not detected as a `TokenType::Way`. This leads to unexpected results when we generate the `tokenless` form of a street name in the linker code, and means that in both strict and loose modes, we can't match the abbreviated form of `St` to `Street`:
https://github.com/ingalls/pt2itp/blob/bf84efa8916d6221ca8a2e54372f174918d81ebb/native/src/util/linker.rs#L315

## Next steps
- [x] see if geocoder-abbreviations contains any other tokens with non-unique abbreviated forms
- [x] figure out how to handle tokens with non-unique abbreviated forms, get tests passing
- [x] make sure we're handling these cases correctly in both the Rust and the JS code
- [ ] remove regex filtering, actually perform replacements in both Rust and JS
- [ ] revisit how you're handling lowercasing when matching inputs to tokens

cc @ingalls @samely @miccolis