### PR TITLE
Only run splitter once

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -179,11 +179,8 @@ function main(argv, cb) {
                 child.stderr.pipe(process.stderr);
 
                 child.on('exit', () => {
-                    const active = nursery.some((instance) => {
-                        return (!instance.killed);
-                    });
                     // Only run splitter once
-                    if (!active && !splitRan) {
+                    if (!splitRan && !nursery.some((v) => !v.killed)) {
                         splitRan = true;
                         console.timeEnd('ok - cross matched data');
 

--- a/lib/map.js
+++ b/lib/map.js
@@ -167,7 +167,7 @@ function main(argv, cb) {
             const nursery = [];
 
             let addrNum_it = 1; // Postgis SERIAL begins at 1
-
+            let splitRan = false;
             while (cpu_spawn--) {
                 const child = CP.fork(path.resolve(__dirname, './map/match'), {
                     stdio: ['pipe', 'pipe', 'pipe', 'ipc']
@@ -182,8 +182,9 @@ function main(argv, cb) {
                     const active = nursery.some((instance) => {
                         return (!instance.killed);
                     });
-
-                    if (!active) {
+                    // Only run splitter once
+                    if (!active && !splitRan) {
+                        splitRan = true;
                         console.timeEnd('ok - cross matched data');
 
                         console.time('ok - clustered addresses');

--- a/lib/map.js
+++ b/lib/map.js
@@ -180,7 +180,7 @@ function main(argv, cb) {
 
                 child.on('exit', () => {
                     // Only run splitter once
-                    if (!splitRan && !nursery.some((v) => !v.killed)) {
+                    if (!splitRan && nursery.every((v) => v.killed)) {
                         splitRan = true;
                         console.timeEnd('ok - cross matched data');
 
@@ -247,9 +247,8 @@ function main(argv, cb) {
                 let cpu_spawn = Math.min(Math.ceil(res.rows.length / 1000), CPUS); // number of 1000 groups or # of CPUs, whichever is smaller
                 const nursery = [];
 
-                const ids = res.rows.map((row) => {
-                    return row.id;
-                });
+                const ids = res.rows.map((row) => row.id);
+                let orphansRan = false;
 
                 while (cpu_spawn--) {
                     const child = CP.fork(path.resolve(__dirname, './map/split'), {
@@ -278,11 +277,9 @@ function main(argv, cb) {
                                 // nursery[message.id].active = false;
                                 nursery[message.id].kill();
 
-                                const active = nursery.some((instance) => {
-                                    return (!instance.killed);
-                                });
-
-                                if (!active) {
+                                // Only run orphans once
+                                if (!orphansRan && nursery.every((v) => v.killed)) {
+                                    orphansRan = true;
                                     console.timeEnd('ok - split data');
                                     return orphans();
                                 }


### PR DESCRIPTION
## Context

As part of debugging why we're occasionally seeing duplicate address clusters in output, adds a condition to ensure the `splitter()` function is only ever run once.

cc @miccolis @samely @ingalls 