### PR TITLE
Split words on graphemes not bytes during titlecasing

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -575,6 +575,7 @@ dependencies = [
  "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -861,6 +862,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
+"checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -28,6 +28,7 @@ serde = "1.0"
 fancy-regex = "0.1.0"
 memchr = "2.0.2"
 geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "master" }
+unicode-segmentation = "1.3.0"
 
 [dependencies.geojson]
 version = "0.16.0"


### PR DESCRIPTION
## Context

In the previous implementation of the Rust port of titlecasing, we were indexing into strings using bytes rather than chars or graphemes. This PR changes our titlecasing implementation to capitalize words based on [graphemes](https://en.wikipedia.org/wiki/Grapheme) instead. Issues with indexing into strings in Rust are clearly documented in https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings (which I've definitely read, but conveniently forgot). I've used the [unicode_segmentation](https://docs.rs/unicode-segmentation/1.3.0/unicode_segmentation/index.html) crate for grapheme detection, which was ported from the now deprecated core Rust implementation.

## Next steps
- [ ] review
- [ ] merge
- [ ] release

cc @miccolis @ingalls @samely @mattciferri 