### PR TITLE
Build binaries on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,6 @@ jobs:
         docker:
             - image: ubuntu:18.04
             - image: mdillon/postgis:11
-              environment:
-                POSTGRES_USER: postgres
-                POSTGRES_DB: pt_test
         steps:
             - run:
                 name: "Add ubuntu-toolchain"
@@ -55,7 +52,7 @@ jobs:
             - run:
                 name: "Yarn Coverage"
                 command: "yarn run coverage"
-                no_output_timeout: "12000s"
+                no_output_timeout: "2m"
             - run:
                 name: "Yarn Coverage-Upload"
                 command: "yarn run coverage-upload"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,8 @@ jobs:
                 name: "Install Rust"
                 command: |
                   curl https://sh.rustup.rs -sSf > /tmp/rustup.sh \
-                  && sh /tmp/rustup.sh -y
+                  && sh /tmp/rustup.sh -y \
+                  && echo "export PATH=$HOME/.cargo/bin:$PATH" >> $BASH_ENV
 
             - run:
                 name: "Install NodeJS"
@@ -33,6 +34,7 @@ jobs:
                   && cp ./node-v10.15.3-linux-x64/bin/node /usr/bin/ \
                   && ./node-v10.15.3-linux-x64/bin/npm install -g yarn \
                   && ./node-v10.15.3-linux-x64/bin/npm install -g npm \
+                  && echo "export PATH=$(yarn global bin):$PATH" >> $BASH_ENV \
                   yarn install
 
             - run:
@@ -40,10 +42,10 @@ jobs:
                 command: "yarn global add neon-cli"
             - run:
                 name: "Yarn Install"
-                command: PATH="$HOME/.cargo/bin:$(yarn global bin)/:$PATH" yarn build && yarn install
+                command: yarn build && yarn install
             - run:
                 name: "Cargo Test"
-                command: cd native/ && PATH="$HOME/.cargo/bin:$PATH" cargo test --release
+                command: cd native/ && cargo test --release
             - run:
                 name: "Yarn Lint"
                 command: "yarn run lint"
@@ -52,7 +54,7 @@ jobs:
                 command: "yarn run pretest"
             - run:
                 name: "Publish release"
-                command: PATH="$HOME/.cargo/bin:$PATH" ./scripts/publish.sh
+                command: ./scripts/publish.sh
             - run:
                 name: "Yarn Coverage"
                 command: "yarn run coverage"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,8 @@ jobs:
                 name: "Install Rust"
                 command: |
                   curl https://sh.rustup.rs -sSf > /tmp/rustup.sh \
-                  && sh /tmp/rustup.sh -y
+                  && sh /tmp/rustup.sh -y \
+                  && source $HOME/.cargo/env
 
             - run:
                 name: "Install NodeJS"
@@ -52,7 +53,7 @@ jobs:
                 command: "yarn run pretest"
             - run:
                 name: "Publish release"
-                command: "echo $CIRCLE_TAG && ./scripts/publish.sh"
+                command: "./scripts/publish.sh"
             - run:
                 name: "Yarn Coverage"
                 command: "yarn run coverage"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
                 command: "yarn run pretest"
             - run:
                 name: "Publish release"
-                command: "./scripts/publish.sh"
+                command: "echo $CIRCLE_TAG && ./scripts/publish.sh"
             - run:
                 name: "Yarn Coverage"
                 command: "yarn run coverage"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
                 name: "Yarn PreTest"
                 command: "yarn run pretest"
             - run:
-                name: "Publish release"
+                name: "Publish Release"
                 command: ./scripts/publish.sh
             - run:
                 name: "Yarn Coverage"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,9 +82,9 @@ workflows:
     build:
         jobs:
             - build
-    deploy:
+    publish:
         jobs:    
-            - deploy:
+            - publish:
                 filters:
                     tags:
                         only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,7 @@
-version: 2
+version: 2.1
 
-jobs:
-    build:
-        docker:
-            - image: ubuntu:18.04
-            - image: mdillon/postgis:11
-              environment:
-                - POSTGRES_USER=postgres
-                - POSTGRES_DB=pt_test
+commands:
+    install-dependencies:
         steps:
             - run:
                 name: "Add ubuntu-toolchain"
@@ -42,7 +36,18 @@ jobs:
                 command: "yarn global add neon-cli"
             - run:
                 name: "Yarn Install"
-                command: yarn build && yarn install
+                command: yarn build && yarn install          
+
+jobs:
+    build:
+        docker:
+            - image: ubuntu:18.04
+            - image: mdillon/postgis:11
+              environment:
+                POSTGRES_USER: postgres
+                POSTGRES_DB: pt_test
+        steps:
+            - install-dependencies
             - run:
                 name: "Cargo Test"
                 command: cd native/ && cargo test --release
@@ -53,21 +58,35 @@ jobs:
                 name: "Yarn PreTest"
                 command: "yarn run pretest"
             - run:
-                name: "Publish Release"
-                command: ./scripts/publish.sh
-            - run:
                 name: "Yarn Coverage"
                 command: "yarn run coverage"
-                no_output_timeout: 12000
+                no_output_timeout: "12000s"
             - run:
                 name: "Yarn Coverage-Upload"
                 command: "yarn run coverage-upload"
+    publish:
+        docker:
+            - image: ubuntu:18.04
+            - image: mdillon/postgis:11
+              environment:
+                POSTGRES_USER: postgres
+                POSTGRES_DB: pt_test
+        steps:
+            - install-dependencies
+            - run:
+                name: "Publish Release"
+                command: ./scripts/publish.sh
 
 workflows:
-  version: 2
-  build-workflow:
-    jobs:
-      - build:
-          filters:
-            tags:
-              only: /.*/
+    version: 2
+    build:
+        jobs:
+            - build
+    deploy:
+        jobs:    
+            - deploy:
+                filters:
+                    tags:
+                        only: /.*/
+                    branches:
+                        ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,3 +60,12 @@ jobs:
             - run:
                 name: "Yarn Coverage-Upload"
                 command: "yarn run coverage-upload"
+
+workflows:
+  version: 2
+  build-workflow:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,9 @@ jobs:
                 name: "Yarn PreTest"
                 command: "yarn run pretest"
             - run:
+                name: "Publish release"
+                command: "./scripts/publish.sh"
+            - run:
                 name: "Yarn Coverage"
                 command: "yarn run coverage"
                 no_output_timeout: 12000

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,7 @@ jobs:
                 command: "yarn run pretest"
             - run:
                 name: "Publish release"
-                environment:
-                    PATH: $HOME/.cargo/bin:$PATH
-                command: "./scripts/publish.sh"
+                command: PATH="$HOME/.cargo/bin:$PATH" ./scripts/publish.sh
             - run:
                 name: "Yarn Coverage"
                 command: "yarn run coverage"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,13 @@
-version: 2.1
+version: 2  
 
-commands:
-    install-dependencies:
+jobs:
+    build:
+        docker:
+            - image: ubuntu:18.04
+            - image: mdillon/postgis:11
+              environment:
+                POSTGRES_USER: postgres
+                POSTGRES_DB: pt_test
         steps:
             - run:
                 name: "Add ubuntu-toolchain"
@@ -36,18 +42,7 @@ commands:
                 command: "yarn global add neon-cli"
             - run:
                 name: "Yarn Install"
-                command: yarn build && yarn install          
-
-jobs:
-    build:
-        docker:
-            - image: ubuntu:18.04
-            - image: mdillon/postgis:11
-              environment:
-                POSTGRES_USER: postgres
-                POSTGRES_DB: pt_test
-        steps:
-            - install-dependencies
+                command: yarn build && yarn install   
             - run:
                 name: "Cargo Test"
                 command: cd native/ && cargo test --release
@@ -64,15 +59,6 @@ jobs:
             - run:
                 name: "Yarn Coverage-Upload"
                 command: "yarn run coverage-upload"
-    publish:
-        docker:
-            - image: ubuntu:18.04
-            - image: mdillon/postgis:11
-              environment:
-                POSTGRES_USER: postgres
-                POSTGRES_DB: pt_test
-        steps:
-            - install-dependencies
             - run:
                 name: "Publish Release"
                 command: ./scripts/publish.sh
@@ -81,12 +67,7 @@ workflows:
     version: 2
     build:
         jobs:
-            - build
-    publish:
-        jobs:    
-            - publish:
+            - build:
                 filters:
                     tags:
-                        only: /.*/
-                    branches:
-                        ignore: /.*/
+                        only: /.*/             

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2  
+version: 2
 
 jobs:
     build:
@@ -42,7 +42,7 @@ jobs:
                 command: "yarn global add neon-cli"
             - run:
                 name: "Yarn Install"
-                command: yarn build && yarn install   
+                command: yarn build && yarn install
             - run:
                 name: "Cargo Test"
                 command: cd native/ && cargo test --release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,7 @@ jobs:
                 name: "Install Rust"
                 command: |
                   curl https://sh.rustup.rs -sSf > /tmp/rustup.sh \
-                  && sh /tmp/rustup.sh -y \
-                  && source $HOME/.cargo/env
+                  && sh /tmp/rustup.sh -y
 
             - run:
                 name: "Install NodeJS"
@@ -53,6 +52,8 @@ jobs:
                 command: "yarn run pretest"
             - run:
                 name: "Publish release"
+                environment:
+                    PATH: $HOME/.cargo/bin:$PATH
                 command: "./scripts/publish.sh"
             - run:
                 name: "Yarn Coverage"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,4 +14,6 @@ All PRs to master _must_ have a corresponding versioned release
   - When in doubt - numbers are cheap
 - `git push`
 - `git push --tags`
-- CI will publish your release on tag push.
+- CI will publish a draft release to GitHub on tag push.
+- push to the npm registry
+  - `yarn publish`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,5 +14,4 @@ All PRs to master _must_ have a corresponding versioned release
   - When in doubt - numbers are cheap
 - `git push`
 - `git push --tags`
-- `yarn publish`
-- `NODE_PRE_GYP_GITHUB_TOKEN=$NODE_PRE_GYP_GITHUB_TOKEN yarn package`
+- CI will publish your release on tag push.

--- a/cloudformation/ci.template.js
+++ b/cloudformation/ci.template.js
@@ -13,16 +13,20 @@ module.exports = {
         User: {
             Type: 'AWS::IAM::User',
             Properties: {
-                PolicyName: 'github-apps',
-                PolicyDocument: {
-                    Statement: [
-                        {
-                            Effect: 'Allow',
-                            Action: 'secretsmanager:GetSecretValue',
-                            Resource: cf.join(':', ['arn:aws:secretsmanager', cf.region, cf.accountId, 'secret', `${cf.ref('SecretPrefix')}/*`])
+                Policies: [
+                    {
+                        PolicyName: 'github-apps',
+                        PolicyDocument: {
+                            Statement: [
+                                {
+                                    Effect: 'Allow',
+                                    Action: 'secretsmanager:GetSecretValue',
+                                    Resource: cf.join(':', ['arn:aws:secretsmanager', cf.region, cf.accountId, 'secret', `${cf.ref('SecretPrefix')}/*`])
+                                }
+                            ]
                         }
-                    ]
-                }
+                    }
+                ]
             }
         },
         AccessKey: {

--- a/cloudformation/ci.template.js
+++ b/cloudformation/ci.template.js
@@ -21,7 +21,13 @@ module.exports = {
                                 {
                                     Effect: 'Allow',
                                     Action: 'secretsmanager:GetSecretValue',
-                                    Resource: cf.join(':', ['arn:aws:secretsmanager', cf.region, cf.accountId, 'secret', `${cf.ref('SecretPrefix')}/*`])
+                                    Resource: cf.join(':', [
+                                        'arn:aws:secretsmanager',
+                                        cf.region,
+                                        cf.accountId,
+                                        'secret',
+                                        cf.join([cf.ref('SecretPrefix'), '/*'])
+                                    ])
                                 }
                             ]
                         }

--- a/cloudformation/ci.template.js
+++ b/cloudformation/ci.template.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const cf = require('@mapbox/cloudfriend');
+
+module.exports = {
+    Parameters: {
+        SecretPrefix: {
+            Type: 'String',
+            Description: 'Prefix of GitHub App'
+        }
+    },
+    Resources: {
+        User: {
+            Type: 'AWS::IAM::User',
+            Properties: {
+                PolicyName: 'github-apps',
+                PolicyDocument: {
+                    Statement: [
+                        {
+                            Effect: 'Allow',
+                            Action: 'secretsmanager:GetSecretValue',
+                            Resource: cf.join(':', ['arn:aws:secretsmanager', cf.region, cf.accountId, 'secret', `${cf.ref('SecretPrefix')}/*`])
+                        }
+                    ]
+                }
+            }
+        },
+        AccessKey: {
+            Type: 'AWS::IAM::AccessKey',
+            Properties: {
+                UserName: cf.ref('User')
+            }
+        }
+    },
+    Outputs: {
+        AccessKeyId: {
+            Value: cf.ref('AccessKey')
+        },
+        SecretAccessKey: {
+            Value: cf.getAtt('AccessKey', 'SecretAccessKey')
+        }
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "24.1.20-binary-test",
+  "version": "24.1.21-binary-test",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "24.1.19-binary-test",
+  "version": "24.1.20-binary-test",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "24.1.6-binary-test",
+  "version": "24.1.8-binary-test",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "24.1.13-binary-test",
+  "version": "24.1.14-binary-test",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "24.1.17-binary-test",
+  "version": "24.1.18-binary-test",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",
@@ -20,7 +20,7 @@
   "binary": {
     "module_name": "index",
     "host": "https://github.com/ingalls/pt2itp/releases/download/",
-    "remote_path": "{version}",
+    "remote_path": "v{version}",
     "package_name": "{node_abi}-{platform}-{arch}.tar.gz",
     "module_path": "./native/",
     "pkg_path": "."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "24.1.10-binary-test",
+  "version": "24.1.12-binary-test",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "24.1.18-binary-test",
+  "version": "24.1.19-binary-test",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",
@@ -19,7 +19,7 @@
   },
   "binary": {
     "module_name": "index",
-    "host": "https://github.com/ingalls/pt2itp/releases/download/",
+    "host": "https://github.com/mapbox/pt2itp/releases/download/",
     "remote_path": "v{version}",
     "package_name": "{node_abi}-{platform}-{arch}.tar.gz",
     "module_path": "./native/",
@@ -78,6 +78,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ingalls/pt2itp.git"
+    "url": "git+https://github.com/mapbox/pt2itp.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "24.1.14-binary-test",
+  "version": "24.1.15-binary-test",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "24.1.21-binary-test",
+  "version": "25.0.3",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "24.1.12-binary-test",
+  "version": "24.1.13-binary-test",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "24.1.15-binary-test",
+  "version": "24.1.17-binary-test",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "25.0.3",
+  "version": "24.1.6-binary-test",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "24.1.8-binary-test",
+  "version": "24.1.10-binary-test",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "wellknown": "^0.5.0"
   },
   "devDependencies": {
+    "@mapbox/cloudfriend": "^3.1.1",
+    "@octokit/app": "^4.1.0",
     "coveralls": "^3.0.0",
     "eslint": "^6.0.1",
     "nyc": "^14.0.0",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eo pipefail
+
+if [[ -z ${CIRCLE_TAG} ]]; then
+  echo "ok - No tag, skipping release.";
+  exit
+fi
+
+echo "ok - Publishing release.";
+
+export NODE_PRE_GYP_GITHUB_TOKEN=$(node ./scripts/token.js ${GITHUB_APP_PREFIX})
+if [[ -z ${NODE_PRE_GYP_GITHUB_TOKEN} ]]; then
+  echo "not ok - Unable to retrieve GitHub token.";
+  exit 1
+fi
+
+yarn package

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,16 +2,17 @@
 
 set -eo pipefail
 
+echo $CIRCLE_TAG
 if [[ -z ${CIRCLE_TAG} ]]; then
-  echo "ok - No tag, skipping release.";
+  echo "ok - No tag, skipping release."
   exit
 fi
 
-echo "ok - Publishing release.";
+echo "ok - Publishing release."
 
 export NODE_PRE_GYP_GITHUB_TOKEN=$(node ./scripts/token.js ${GITHUB_APP_PREFIX})
 if [[ -z ${NODE_PRE_GYP_GITHUB_TOKEN} ]]; then
-  echo "not ok - Unable to retrieve GitHub token.";
+  echo "not ok - Unable to retrieve GitHub token."
   exit 1
 fi
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,7 +2,6 @@
 
 set -eo pipefail
 
-echo $CIRCLE_TAG
 if [[ -z ${CIRCLE_TAG} ]]; then
   echo "ok - No tag, skipping release."
   exit

--- a/scripts/token.js
+++ b/scripts/token.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 'use strict';
 
 const AWS = require('aws-sdk');

--- a/scripts/token.js
+++ b/scripts/token.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+const { promisify } = require('util');
+const { App } = require('@octokit/app');
+
+async function getCredentials(secretPrefix) {
+    const options = {
+        region: 'us-east-1'
+    };
+
+    const sm = new AWS.SecretsManager(options);
+
+    const [
+        { SecretString: id },
+        { SecretString: installationId },
+        { SecretBinary: privateKey }
+    ] = await Promise.all([
+        sm.getSecretValue({ SecretId: `${secretPrefix}/app-id` }).promise(),
+        sm.getSecretValue({ SecretId: `${secretPrefix}/installation-id` }).promise(),
+        sm.getSecretValue({ SecretId: `${secretPrefix}/secret` }).promise()
+    ]);
+
+    return { id, installationId, privateKey };
+}
+
+async function getGitHubToken(secretPrefix) {
+    const { id, installationId, privateKey } = await getCredentials(secretPrefix);
+
+    const app = new App({ id, privateKey });
+
+    const getToken = async (attempts = 0) => {
+        attempts++;
+        try { return await app.getInstallationAccessToken({ installationId }); }
+        catch (err) {
+            if (err.status > 499 && err.status < 600 && attempts < 5) {
+                await promisify(setTimeout)(Math.pow((Math.random() * 2), attempts));
+                return await getToken(attempts);
+            } else {
+                throw err;
+            }
+        }
+    };
+
+    return await getToken();
+}
+
+(async function() {
+    const secretPrefix = process.argv[2];
+    if (!secretPrefix) throw new Error('Prefix value required.');
+    const token = await getGitHubToken(secretPrefix);
+    console.log(token);
+})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,11 +289,6 @@
   resolved "https://registry.yarnpkg.com/@mapbox/tiletype/-/tiletype-0.3.1.tgz#1a1498f6a1b777630e0b4d3a2fed9d94959560cc"
   integrity sha1-GhSY9qG3d2MOC006L+2dlJWVYMw=
 
-"@mapbox/title-case@^1.3.0":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/title-case/-/title-case-1.3.1.tgz#44336e30cb8fbd266e6ac067ff3f358224364118"
-  integrity sha1-RDNuMMuPvSZuasBn/z81giQ2QRg=
-
 "@octokit/app@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@octokit/app/-/app-4.1.0.tgz#1fc147ca4278e4815cc33cf1d0c2867fe5a9feaf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -176,6 +176,15 @@
   dependencies:
     aws-sdk "^2.4.11"
 
+"@mapbox/cloudfriend@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/cloudfriend/-/cloudfriend-3.1.1.tgz#781eee9d37e60c56f63bb02190bb4b5b519573f3"
+  integrity sha512-8L+NrBxvMMeGeocwMX9axBxhSr1s1DubvHWPJsUZar8AMVN38SwRFklNLKviA91i8SvK7ZU8Nr5YKAVKvoaWGQ==
+  dependencies:
+    aws-sdk "^2.4.11"
+    minimist "^1.2.0"
+    redent "^2.0.0"
+
 "@mapbox/eslint-config-geocoding@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@mapbox/eslint-config-geocoding/-/eslint-config-geocoding-2.0.2.tgz#0dab7b9cc7827f4426dcff707e06e6b7be134136"
@@ -279,6 +288,51 @@
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@mapbox/tiletype/-/tiletype-0.3.1.tgz#1a1498f6a1b777630e0b4d3a2fed9d94959560cc"
   integrity sha1-GhSY9qG3d2MOC006L+2dlJWVYMw=
+
+"@mapbox/title-case@^1.3.0":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/title-case/-/title-case-1.3.1.tgz#44336e30cb8fbd266e6ac067ff3f358224364118"
+  integrity sha1-RDNuMMuPvSZuasBn/z81giQ2QRg=
+
+"@octokit/app@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/app/-/app-4.1.0.tgz#1fc147ca4278e4815cc33cf1d0c2867fe5a9feaf"
+  integrity sha512-V8/JIviFsa1p2tWzOveJYJm42Mm7aELR+beXvx3EUZ3kCTQnNsM/FbQ3YV+I5UlBo0XmtmqNr31LrMoRj218qw==
+  dependencies:
+    "@octokit/request" "^5.0.0"
+    jsonwebtoken "^8.3.0"
+    lru-cache "^5.1.1"
+
+"@octokit/endpoint@^5.1.0":
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-5.3.2.tgz#2deda2d869cac9ba7f370287d55667be2a808d4b"
+  integrity sha512-gRjteEM9I6f4D8vtwU2iGUTn9RX/AJ0SVXiqBUEuYEWVGGAVjSXdT0oNmghH5lvQNWs8mwt6ZaultuG6yXivNw==
+  dependencies:
+    deepmerge "4.0.0"
+    is-plain-object "^3.0.0"
+    universal-user-agent "^3.0.0"
+    url-template "^2.0.8"
+
+"@octokit/request-error@^1.0.1":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-1.0.4.tgz#15e1dc22123ba4a9a4391914d80ec1e5303a23be"
+  integrity sha512-L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==
+  dependencies:
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.0.2.tgz#59a920451f24811c016ddc507adcc41aafb2dca5"
+  integrity sha512-z1BQr43g4kOL4ZrIVBMHwi68Yg9VbkRUyuAgqCp1rU3vbYa69+2gIld/+gHclw15bJWQnhqqyEb7h5a5EqgZ0A==
+  dependencies:
+    "@octokit/endpoint" "^5.1.0"
+    "@octokit/request-error" "^1.0.1"
+    deprecation "^2.0.0"
+    is-plain-object "^3.0.0"
+    node-fetch "^2.3.0"
+    once "^1.4.0"
+    universal-user-agent "^3.0.0"
 
 "@octokit/rest@^15.9.5":
   version "15.18.1"
@@ -1824,6 +1878,11 @@ btoa-lite@^1.0.0:
   resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
   integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
+
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -2282,6 +2341,11 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deepmerge@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.0.0.tgz#3e3110ca29205f120d7cb064960a39c3d2087c09"
+  integrity sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww==
+
 default-require-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
@@ -2327,6 +2391,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+deprecation@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
+  integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
 dequeue@^1.0.5:
   version "1.0.5"
@@ -2395,6 +2464,13 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -3292,6 +3368,13 @@ is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
+is-plain-object@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-3.0.0.tgz#47bfc5da1b5d50d64110806c199359482e75a928"
+  integrity sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==
+  dependencies:
+    isobject "^4.0.0"
+
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
@@ -3335,6 +3418,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
+isobject@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
+  integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -3495,6 +3583,22 @@ jsonlint-lines@1.7.1:
     JSV ">= 4.0.x"
     nomnom ">= 1.5.x"
 
+jsonwebtoken@^8.3.0:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -3504,6 +3608,23 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 lcov-parse@^0.0.10:
   version "0.0.10"
@@ -3563,6 +3684,41 @@ lodash.get@~4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash.padend@^4.6.1:
   version "4.6.1"
@@ -3897,7 +4053,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@^2.1.1:
+node-fetch@^2.1.1, node-fetch@^2.3.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
@@ -5473,6 +5629,13 @@ universal-user-agent@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-2.1.0.tgz#5abfbcc036a1ba490cb941f8fd68c46d3669e8e4"
   integrity sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==
+  dependencies:
+    os-name "^3.0.0"
+
+universal-user-agent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-3.0.0.tgz#4cc88d68097bffd7ac42e3b7c903e7481424b4b9"
+  integrity sha512-T3siHThqoj5X0benA5H0qcDnrKGXzU8TKoX15x/tQHw1hQBvIEBHjxQ2klizYsqBOO/Q+WuxoQUihadeeqDnoA==
   dependencies:
     os-name "^3.0.0"
 


### PR DESCRIPTION
## Context

Currently our releases are created manually, and cannot be run on all types of machines due to the node-pre-gyp build step. This PR automates the process by building the Rust binaries and pushing releases to GitHub through CI.

## Summary of Changes

- Inserts a conditional step in the Circle config to publish a release if the commit is tagged.
- Adds a CFN template to manage an IAM user. This provides Circle access to Secrets Manager.
- Adds a node script to retrieve the GitHub token necessary for node-pre-gyp-github.
- Adds a bash script to call the node script for the token and run `yarn package`.
- Updates the node-pre-gyp `remote_path` setting to establish consistency around tags and releases.

### Next Steps

- [x] Validate releases on CI
- [x] Clean up test releases