### PR TITLE
Remove Empty Names

### DIFF
--- a/native/src/map/mod.rs
+++ b/native/src/map/mod.rs
@@ -233,6 +233,7 @@ pub fn dedupe_syn(mut cx: FunctionContext) -> JsResult<JsArray> {
         names: names
     };
 
+    names.empty();
     names.sort();
     names.dedupe();
 


### PR DESCRIPTION
https://github.com/mapbox/pt2itp/pull/495 resulted in > 10 synonyms being added to individual output features. [Carmen](https://github.com/mapbox/carmen) currently limits indexable features to a maximum of 10 synonyms. 

This has resulted in hard fails from our indexing pipeline on the latest address builds where these features are found.

This adds a call to `names.empty()` as part of the text post script to ensure that 0 length strings are removed.