### PR TITLE
Syn Limit

### DIFF
--- a/lib/post/text.js
+++ b/lib/post/text.js
@@ -27,7 +27,7 @@ function post(feat, opts = {}) {
             }
 
             // Names should never exceed 10 syns
-            feat.properties[k] = names.splice(0, 10).names.join(',');
+            feat.properties[k] = names.splice(0, 10).join(',');
         });
 
 

--- a/lib/post/text.js
+++ b/lib/post/text.js
@@ -13,21 +13,32 @@ function post(feat, opts = {}) {
     if (!feat || !feat.properties || !feat.properties['carmen:text']) return feat;
 
     Object.keys(feat.properties)
-        .filter((k) => { return k.indexOf('carmen:text') === 0; })
+        .filter((k) => {
+            // Support multi-lingual carmen:text tags
+            return k.indexOf('carmen:text') === 0;
+        })
         .forEach((k) => {
             let names = dedupe_syn(feat.properties[k]);
-
-            if (k === 'carmen:text' && names.length === 0) return;
 
             if (names.length > 10) {
                 if (opts.warn) {
                     opts.warn.write(`WARN: too many synonyms - truncating!: ${feat.properties[k]}\n`);
                 }
-
-                names = names.splice(0, 10);
             }
-            feat.properties[k] = names.join(',');
+
+            // Names should never exceed 10 syns
+            feat.properties[k] = names.splice(0, 10).names.join(',');
         });
+
+
+    if (feat.properties["carmen:text"].length === 0) {
+        if (opts.warn) {
+            opts.warn.write(`WARN: no text values - omitting!\n`);
+        }
+
+        return;
+    }
+
 
     return feat;
 }

--- a/lib/post/text.js
+++ b/lib/post/text.js
@@ -18,7 +18,7 @@ function post(feat, opts = {}) {
             return k.indexOf('carmen:text') === 0;
         })
         .forEach((k) => {
-            let names = dedupe_syn(feat.properties[k]);
+            const names = dedupe_syn(feat.properties[k]);
 
             if (names.length > 10) {
                 if (opts.warn) {
@@ -31,9 +31,9 @@ function post(feat, opts = {}) {
         });
 
 
-    if (feat.properties["carmen:text"].length === 0) {
+    if (feat.properties['carmen:text'].length === 0) {
         if (opts.warn) {
-            opts.warn.write(`WARN: no text values - omitting!\n`);
+            opts.warn.write('WARN: no text values - omitting!\n');
         }
 
         return;

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -254,7 +254,10 @@ impl Name {
     ///
     /// ```
     pub fn new(display: impl ToString, mut priority: i8, source: Option<Source>, context: &Context) -> Self {
-        let mut display = display.to_string().replace(r#"""#, "");
+        let mut display = display
+            .to_string()
+            .replace(r#"""#, "");
+            .replace(r#","#, ""); // commas are not allowed as they are used to delimit synonyms on output
 
         // only title case non-generated names
         if source != Some(Source::Generated) {

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -387,6 +387,22 @@ mod tests {
                 Tokenized::new(String::from("1"), None)],
             freq: 1
         });
+
+        assert_eq!(Name::new(String::from("\""), 0, None, &context), Name {
+            display: String::from(""),
+            priority: 0,
+            source: None,
+            tokenized: vec![],
+            freq: 1
+        });
+
+        assert_eq!(Name::new(String::from(","), 0, None, &context), Name {
+            display: String::from(""),
+            priority: 0,
+            source: None,
+            tokenized: vec![],
+            freq: 1
+        });
     }
 
     #[test]

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -256,7 +256,7 @@ impl Name {
     pub fn new(display: impl ToString, mut priority: i8, source: Option<Source>, context: &Context) -> Self {
         let mut display = display
             .to_string()
-            .replace(r#"""#, "");
+            .replace(r#"""#, "")
             .replace(r#","#, ""); // commas are not allowed as they are used to delimit synonyms on output
 
         // only title case non-generated names


### PR DESCRIPTION
Identified the true root cause of the synonym limit, a name that contained a `,` character.

When it was stringified with `join(',')` it was subsequently serialized with `.split(',')`, resulting in an error