### PR TITLE
Linker: Cardinaled Address => Non Cardinaled Street

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
 
             - run:
                 name: "Install Neon"
-                command: "yarn global add neon-cli"
+                command: "yarn global add neon-cli@0.3.1"
             - run:
                 name: "Yarn Install"
                 command: yarn build && yarn install

--- a/native/src/text/replace.rs
+++ b/native/src/text/replace.rs
@@ -136,7 +136,7 @@ fn find_cap_ref<T: ?Sized + AsRef<[u8]>>(
 /// Modified to only support numbered capture groups
 fn is_valid_cap(b: &u8) -> bool {
     match *b {
-        b'0' ... b'9' => true,
+        b'0' ..= b'9' => true,
         _ => false,
     }
 }

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -274,6 +274,7 @@ pub enum Source {
 }
 
 impl Name {
+
     /// Returns a representation of a street name
     ///
     /// # Arguments
@@ -337,17 +338,27 @@ impl Name {
         self
     }
 
-
+    ///
+    /// Tokenize the name object and return it as a string
+    ///
     pub fn tokenized_string(&self) -> String {
         let tokens: Vec<String> = self.tokenized
             .iter()
             .map(|x| x.token.to_owned())
             .collect();
+
         let tokenized = String::from(tokens.join(" ").trim());
 
         tokenized
     }
 
+    ///
+    /// Return a String representation of a Name
+    /// object with all known tokens removed
+    ///
+    /// IE:
+    /// N Main St => Main
+    ///
     pub fn tokenless_string(&self) -> String {
         let tokens: Vec<String> = self.tokenized
             .iter()
@@ -359,6 +370,24 @@ impl Name {
         tokenless
     }
 
+    ///
+    /// Remove instances of a given type from the Name type and return
+    /// the remaining tokens as a String
+    ///
+    pub fn remove_type_string(&self, token_type: Option<TokenType>) -> String {
+        let tokens: Vec<String> = self.tokenized
+            .iter()
+            .filter(|x| x.token_type != token_type)
+            .map(|x| x.token.to_string())
+            .collect();
+
+        tokens.join(" ").trim().to_string()
+    }
+
+    ///
+    /// Given a token type, return whether or not the Name object
+    /// contains the given token
+    ///
     pub fn has_type(&self, token_type: Option<TokenType>) -> bool {
         let tokens: Vec<&Tokenized> = self.tokenized
             .iter()
@@ -797,6 +826,16 @@ mod tests {
         assert_eq!(Name::new(String::from("East College Road"), 0, None, &context).tokenless_string(),
             String::from("coll")
         );
+    }
+
+    #[test]
+    fn test_remove_type_string() {
+        let context = Context::new(String::from("us"), None, Tokens::generate(vec![String::from("en")]));
+
+        assert_eq!(Name::new(String::from("Main St NW"), 0, None, &context).remove_type_string(Some(TokenType::Way)), String::from("main nw"));
+        assert_eq!(Name::new(String::from("Main St NW"), 0, None, &context).remove_type_string(Some(TokenType::Cardinal)), String::from("main st"));
+        assert_eq!(Name::new(String::from("Main St NW"), 0, None, &context).remove_type_string(None), String::from("st nw"));
+        assert_eq!(Name::new(String::from("Main St NW"), 0, None, &context).remove_type_string(Some(TokenType::PostalBox)), String::from("main st nw"));
     }
 
     #[test]

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -64,7 +64,6 @@ impl LinkResult {
 /// reasons.
 ///
 pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<LinkResult> {
-    println!("{:?}", primary);
     for name in &primary.names.names {
         let tokenized = name.tokenized_string();
         let tokenless = name.tokenless_string();
@@ -76,6 +75,9 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                 if name.tokenized == potential_name.tokenized {
                     return Some(LinkResult::new(potential.id, 100.0));
                 }
+
+                // A cardinaled primary can exactly match a non-cardinaled potention
+                // if
 
                 if strict {
                     for tk in &name.tokenized {

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -109,7 +109,6 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                     }
                 }
 
-
                 // Don't bother considering if the tokenless forms don't share a starting letter
                 // this might require adjustment for countries with addresses that have leading tokens
                 // which aren't properly stripped from the token list
@@ -245,8 +244,6 @@ mod tests {
 
         // === Intentional Matches ===
         // The following tests should match one of the given potential matches
-
-        /*
         {
             let a_name = Names::new(vec![Name::new("S STREET NW", 0, None, &context)], &context);
 
@@ -340,7 +337,6 @@ mod tests {
             ];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(14, 100.0)));
         }
-        */
 
         /*
          * | Umpqua St
@@ -370,7 +366,6 @@ mod tests {
             assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 100.0)));
         }
 
-        /*
         {
             let a_name = Names::new(vec![Name::new("Main Street", 0, None, &context)], &context);
             let b_name = Names::new(vec![Name::new("Main Street", 0, None, &context)], &context);
@@ -504,7 +499,7 @@ mod tests {
                 Link::new(3, &b_name2),
                 Link::new(4, &b_name3)
             ];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(4, 93.75)));
+            assert_eq!(linker(a, b, false), Some(LinkResult::new(4, 100.0)));
         }
 
         {
@@ -635,7 +630,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 93.75)));
+            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -671,7 +666,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 90.0)));
+            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -690,6 +685,15 @@ mod tests {
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 80.77)));
+        }
+
+        {
+            let a_name = Names::new(vec![Name::new("East Main", 0, None, &context)], &context);
+            let b_name = Names::new(vec![Name::new("Main North East", 0, None, &context)], &context);
+
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 78.57)));
         }
 
         // === Intentional Strict Non-Matches ===
@@ -746,14 +750,5 @@ mod tests {
             assert_eq!(linker(a, b, true), None);
         }
 
-        {
-            let a_name = Names::new(vec![Name::new("East Main", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("Main North East", 0, None, &context)], &context);
-
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), None);
-        }
-        */
     }
 }

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -44,6 +44,7 @@ impl LinkResult {
 /// Geometric proximity must be determined/filtered by the caller
 ///
 pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<LinkResult> {
+    println!("{:?}", primary);
     for name in &primary.names.names {
         let tokenized = name.tokenized_string();
         let tokenless = name.tokenless_string();
@@ -201,8 +202,10 @@ mod tests {
         tokens.insert(String::from("west"), ParsedToken::new(String::from("w"), Some(TokenType::Cardinal)));
         tokens.insert(String::from("east"), ParsedToken::new(String::from("e"), Some(TokenType::Cardinal)));
         tokens.insert(String::from("south"), ParsedToken::new(String::from("s"), Some(TokenType::Cardinal)));
+        tokens.insert(String::from("north"), ParsedToken::new(String::from("n"), Some(TokenType::Cardinal)));
         tokens.insert(String::from("northwest"), ParsedToken::new(String::from("nw"), Some(TokenType::Cardinal)));
         tokens.insert(String::from("nw"), ParsedToken::new(String::from("nw"), Some(TokenType::Cardinal)));
+        tokens.insert(String::from("n"), ParsedToken::new(String::from("n"), Some(TokenType::Cardinal)));
         tokens.insert(String::from("s"), ParsedToken::new(String::from("s"), Some(TokenType::Cardinal)));
         tokens.insert(String::from("w"), ParsedToken::new(String::from("w"), Some(TokenType::Cardinal)));
         tokens.insert(String::from("e"), ParsedToken::new(String::from("e"), Some(TokenType::Cardinal)));
@@ -212,6 +215,7 @@ mod tests {
         // === Intentional Matches ===
         // The following tests should match one of the given potential matches
 
+        /*
         {
             let a_name = Names::new(vec![Name::new("S STREET NW", 0, None, &context)], &context);
 
@@ -305,7 +309,37 @@ mod tests {
             ];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(14, 100.0)));
         }
+        */
 
+        /*
+         * | Umpqua St
+         * |
+         * | . (N Umpqua St)
+         * | . (N Unpqua St)
+         * | S Umpqua St
+         * | . (S Umpqua St)
+         *
+         * Cardinaled addresses should match a proximal non-cardinaled street
+         * before they are matched againts a further away mismatched cardinal street
+         *
+         * In the above example (N Umpsqua St) should always match Umpqua St
+         * and not S Umpqua St (previous behavior)
+         */
+        {
+            let a_name = Names::new(vec![Name::new("N Umpqua St", 0, None, &context)], &context);
+
+            let b_1_name = Names::new(vec![Name::new("Umpqua Street", 0, None, &context)], &context);
+            let b_2_name = Names::new(vec![Name::new("South Umpqua Street", 0, None, &context)], &context);
+
+            let a = Link::new(1, &a_name);
+            let b = vec![
+                Link::new(2, &b_1_name),
+                Link::new(3, &b_2_name)
+            ];
+            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 100.0)));
+        }
+
+        /*
         {
             let a_name = Names::new(vec![Name::new("Main Street", 0, None, &context)], &context);
             let b_name = Names::new(vec![Name::new("Main Street", 0, None, &context)], &context);
@@ -689,6 +723,6 @@ mod tests {
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, true), None);
         }
-
+        */
     }
 }

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -70,14 +70,26 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
 
         for potential in potentials.iter_mut() {
             'outer: for potential_name in &potential.names.names {
-
                 // Ensure exact matches are always returned before potential short-circuits
+                //
+                // N Main St == N Main St
                 if name.tokenized == potential_name.tokenized {
                     return Some(LinkResult::new(potential.id, 100.0));
                 }
 
+                let potential_tokenized = potential_name.tokenized_string();
+                let potential_tokenless = potential_name.tokenless_string();
+
                 // A cardinaled primary can exactly match a non-cardinaled potention
-                // if
+                //
+                // N Main St => Main St
+                if
+                    name.has_type(Some(TokenType::Cardinal))
+                    && !potential_name.has_type(Some(TokenType::Cardinal))
+                    && name.remove_type_string(Some(TokenType::Cardinal)) == potential_tokenized
+                {
+                    return Some(LinkResult::new(potential.id, 100.0));
+                }
 
                 if strict {
                     for tk in &name.tokenized {
@@ -97,9 +109,6 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                     }
                 }
 
-
-                let potential_tokenized = potential_name.tokenized_string();
-                let potential_tokenless = potential_name.tokenless_string();
 
                 // Don't bother considering if the tokenless forms don't share a starting letter
                 // this might require adjustment for countries with addresses that have leading tokens

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -43,6 +43,26 @@ impl LinkResult {
 /// Determines if there is a match between any of two given set of name values
 /// Geometric proximity must be determined/filtered by the caller
 ///
+/// The potentials input array should be ordered from most proximal to least
+///
+/// The linker module has two distinct modes controlled by the strict arg
+///
+/// # Strict Mode (strict: true)
+///
+/// Cardinal & Way Type must match in order for a primary to be able to match
+/// to a given potential
+///
+/// IE:
+///
+/// North Main St cannot match South Main St
+/// Main St cannot match Main Av
+///
+/// # Default Mode (strict: false)
+///
+/// Although exact matches are always prioritized, matches can fallback to
+/// being matched with a slightly less desirable match, usually due to data
+/// reasons.
+///
 pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<LinkResult> {
     println!("{:?}", primary);
     for name in &primary.names.names {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pt2itp",
-  "version": "26.1.1",
+  "version": "26.1.1-cardinal",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lodash": "^4.17.4",
     "minimist": "^1.2.0",
     "n-readlines": "^1.0.0",
-    "neon-cli": "^0.3.1",
+    "neon-cli": "0.3.1",
     "node-pre-gyp": "~0.13.0",
     "node-pre-gyp-github": "^1.4.3",
     "pg": "^7.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4012,17 +4012,17 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-neon-cli@^0.1.23:
-  version "0.1.23"
-  resolved "https://registry.yarnpkg.com/neon-cli/-/neon-cli-0.1.23.tgz#2eb517bd665718a983b7ef45b2640662fa631741"
-  integrity sha512-C5Rw82cDsQFuvFBlql3cuMm0UGRFdBOvcjSA6Di59EFnrqEnajeqF2Z1X6/tJK3VdhrNyWieYr8L27Qfxj3Gvg==
+neon-cli@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/neon-cli/-/neon-cli-0.3.1.tgz#be82c0b57a024080f712abb648abcd2f680f9636"
+  integrity sha512-OBrJbDD0BNDPxWwh88kWd2dJkXWEZ/mrCPF/ADrsLgHmF2qDdbXagli48I7yVl1ngMtItrvI7JqBeiNQNtN1ww==
   dependencies:
     chalk "~2.1.0"
     command-line-args "^4.0.2"
     command-line-commands "^2.0.0"
     command-line-usage "^4.0.0"
     git-config "0.0.7"
-    handlebars "^4.0.3"
+    handlebars "^4.1.0"
     inquirer "^3.0.6"
     mkdirp "^0.5.1"
     quickly-copy-file "^1.0.0"
@@ -4034,17 +4034,17 @@ neon-cli@^0.1.23:
     validate-npm-package-license "^3.0.1"
     validate-npm-package-name "^3.0.0"
 
-neon-cli@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/neon-cli/-/neon-cli-0.3.1.tgz#be82c0b57a024080f712abb648abcd2f680f9636"
-  integrity sha512-OBrJbDD0BNDPxWwh88kWd2dJkXWEZ/mrCPF/ADrsLgHmF2qDdbXagli48I7yVl1ngMtItrvI7JqBeiNQNtN1ww==
+neon-cli@^0.1.23:
+  version "0.1.23"
+  resolved "https://registry.yarnpkg.com/neon-cli/-/neon-cli-0.1.23.tgz#2eb517bd665718a983b7ef45b2640662fa631741"
+  integrity sha512-C5Rw82cDsQFuvFBlql3cuMm0UGRFdBOvcjSA6Di59EFnrqEnajeqF2Z1X6/tJK3VdhrNyWieYr8L27Qfxj3Gvg==
   dependencies:
     chalk "~2.1.0"
     command-line-args "^4.0.2"
     command-line-commands "^2.0.0"
     command-line-usage "^4.0.0"
     git-config "0.0.7"
-    handlebars "^4.1.0"
+    handlebars "^4.0.3"
     inquirer "^3.0.6"
     mkdirp "^0.5.1"
     quickly-copy-file "^1.0.0"


### PR DESCRIPTION
```
| Umpqua St
|
| . (N Umpqua St)
| . (N Unpqua St)
| S Umpqua St
| . (S Umpqua St)

Cardinaled addresses should match a proximal non-cardinaled street
before they are matched againts a further away mismatched cardinal street

In the above example (N Umpsqua St) should always match Umpqua St
and not S Umpqua St (previous behavior)
```

cc/ @mapbox/search 