### PR TITLE
Add address-styles post script

### DIFF
--- a/lib/map/post.js
+++ b/lib/map/post.js
@@ -10,7 +10,8 @@ const defaults = [ // Mandatory Steps
     require('../post/sort').post,
     require('../post/centre').post,
     require('../post/internal').post,
-    require('../post/props').post
+    require('../post/props').post,
+    require('../post/address-styles').post
 ];
 
 /**

--- a/lib/post/address-styles.js
+++ b/lib/post/address-styles.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/**
+ * Exposes a post function to add a property denoting which address styles are in a feature
+ * @param {Object} feat     GeoJSON Feature to apply address styles prop to
+ * @return {Object}         Output GeoJSON feature to write to output
+ */
+function post(feat) {
+    if (!feat) return feat;
+
+    if (feat.properties.address_props) throw new Error('address-styles must be run after the props post script');
+
+    const styles = new Set();
+
+    if (feat.properties['carmen:address_style']) {
+        styles.add(feat.properties['carmen:address_style']);
+    }
+
+    if (feat.properties['carmen:addressprops'] && feat.properties['carmen:addressprops']['carmen:address_style']) {
+        Object.values(feat.properties['carmen:addressprops']['carmen:address_style'])
+            .forEach((val) => {
+                styles.add(val);
+            });
+    }
+
+    if (styles.size > 0) feat.properties['carmen:address_styles'] = Array.from(styles);
+
+    return feat;
+}
+
+module.exports.post = post;

--- a/test/post.address-styles.test.js
+++ b/test/post.address-styles.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const post = require('../lib/post/address-styles').post;
+const test = require('tape');
+
+test('Post: Style', (t) => {
+    t.deepEquals(post({
+        type: 'Feature',
+        properties: {
+            'carmen:address_style': 'queens',
+            'carmen:addressprops': {
+                'carmen:address_style': {
+                    1: 'standard'
+                }
+            }
+        },
+        geometry: {}
+    }).properties['carmen:address_styles'].sort(), ['queens', 'standard']
+    , 'returns all address styles under the address_style properties');
+
+    t.deepEquals(post({
+        type: 'Feature',
+        properties: {
+            'carmen:address_style': 'standard',
+            'carmen:addressprops': {
+                'carmen:address_style': {
+                    1: 'queens',
+                    2: 'queens',
+                    5: 'kings',
+                    6: 'jacks'
+                }
+            }
+        },
+        geometry: {}
+    }).properties['carmen:address_styles'].sort(), ['jacks', 'kings', 'queens', 'standard']
+    , 'returns all unique address styles if there are several listed in addressprops');
+
+    t.deepEquals(post(), undefined, 'returns undefined if no feature was passed in');
+
+    t.deepEquals(post({
+        type: 'Feature',
+        properties: {
+            'carmen:address_style': 'standard',
+            'carmen:addressprops': {}
+        },
+        geometry: {}
+    }).properties['carmen:address_styles'], ['standard']
+    , 'returns only the style for address_style if none are under addressprops');
+
+    t.deepEquals(post({
+        type: 'Feature',
+        properties: {},
+        geometry: {}
+    }).properties['carmen:address_styles'], undefined
+    , 'does not apply address_styles property if no address_style properties are found');
+
+    t.throws(() => {
+        post({
+            type: 'Feature',
+            properties: {
+                address_props: [{
+                    'carmen:address_style': 'standard'
+                }]
+            },
+            geometry: {}
+        });
+    }, 'throws error if input does not match the output format of the post.props script');
+
+    t.end();
+});


### PR DESCRIPTION
### Context

To better support a variety of address styles, we can take advantage of the address_style prop passed though for each address and generate an address_styles prop for each cluster. This will denote which address styles are contained in the cluster, and does not contain duplicates.

### Summary of changes

- [ ] Adds a post script for building the address_styles array for each cluster.
- [ ] Flips the post script on for map mode after props.

cc @ingalls @samely @lizziegooding @miccolis 