### PR TITLE
Delete `version` key/value for action `create`

### DIFF
--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -293,6 +293,7 @@ impl Address {
         match action {
             hecate::Action::Create => {
                 members.insert(String::from("action"), serde_json::value::Value::String("create".to_string()));
+                members.remove(&String::from("version"));
             },
             hecate::Action::Modify => {
                 members.insert(String::from("action"), serde_json::value::Value::String("modify".to_string()));

--- a/test/conflate.test.js
+++ b/test/conflate.test.js
@@ -38,7 +38,6 @@ test('Compare - CREATE', (t) => {
     t.deepEquals(JSON.parse(rl.next()), {
         action: 'create',
         type: 'Feature',
-        version: 0,
         properties: {
             number: '112',
             street: [{


### PR DESCRIPTION
## Context
The output of conflate includes in the address features a `version` key/value that causes conflicts when trying to upload this output to Hecate that doesn't allow a `version` key/value if the `"action":"create"`.

This PR removes the `version` key/value from the output for new features.

@ingalls @lizziegooding @miccolis @mattciferri 