### PR TITLE
Only consider modifying addresses where output==true in conflate

### DIFF
--- a/native/src/conflate/mod.rs
+++ b/native/src/conflate/mod.rs
@@ -139,7 +139,9 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         match compare(&addr, &mut persistents) {
             Some(link) => {
                 let mut link: Vec<&mut Address> = persistents.iter_mut().filter(|persistent| {
-                    if link == persistent.id.unwrap() {
+                    // only consider modifying persistent addresses that match a new address
+                    // and have output set to true
+                    if link == persistent.id.unwrap() && persistent.output == true {
                         true
                     } else {
                         false

--- a/native/src/conflate/mod.rs
+++ b/native/src/conflate/mod.rs
@@ -144,11 +144,7 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
             Some(link_id) => {
                 let mut pmatches: Vec<&mut Address> = persistents.iter_mut().filter(|persistent| {
                     // addresses with output set to false should not be modified
-                    if link_id == persistent.id.unwrap() && persistent.output == true {
-                        true
-                    } else {
-                        false
-                    }
+                    link_id == persistent.id.unwrap() && persistent.output
                 }).collect();
 
                 match pmatches.len() {
@@ -214,7 +210,7 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
             modified_obj.insert(String::from("properties"), props);
         } else {
-            // if the same feature is modified multiple times
+            // if a single persistent address matches multiple new addresses and should be updated
 
             // Future TODO: This currently just grabs the first property
             // and merges names together, it does not attempt to merge

--- a/native/src/conflate/mod.rs
+++ b/native/src/conflate/mod.rs
@@ -34,7 +34,7 @@ struct ConflateArgs {
 impl ConflateArgs {
     pub fn new() -> Self {
         ConflateArgs {
-            db: String::from("dedupe"),
+            db: String::from("conflate"),
             context: None,
             in_address: None,
             in_persistent: None,
@@ -52,12 +52,19 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
             if arg.is_a::<JsUndefined>() || arg.is_a::<JsNull>() {
                 ConflateArgs::new()
             } else {
-                let arg_val = cx.argument::<JsValue>(0)?;
+                let arg_obj = cx.argument::<JsObject>(0)?;
+
+                let db = arg_obj.get(&mut cx, "db")?;
+                if db.is_a::<JsUndefined>() || db.is_a::<JsNull>() {
+                    let default = cx.string("conflate");
+                    arg_obj.set(&mut cx, "db", default)?;
+                }
+
+                let arg_val = arg_obj.as_value(&mut cx);
                 neon_serde::from_value(&mut cx, arg_val)?
             }
         }
     };
-
     if args.in_persistent.is_none() {
         panic!("in_persistent argument is required");
     } else if args.in_address.is_none() {
@@ -103,6 +110,8 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     pgaddress.index(&conn);
 
     for addr in AddrStream::new(GeoStream::new(args.in_address), context.clone(), args.error_address) {
+        // find all persistent addresses with the same address
+        // within 0.01 decimal degrees (~ 1 km) of the new address
         let rows = conn.query("
             SELECT
                 ST_Distance(ST_SetSRID(ST_Point($2, $3), 4326), p.geom),
@@ -126,49 +135,53 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         let mut persistents: Vec<Address> = Vec::with_capacity(rows.len());
 
         for row in rows.iter() {
-            let dist: f64 = row.get(0);
-            if dist > 0.5 {
-                continue
-            }
-
             let paddr: serde_json::Value = row.get(1);
             let paddr = Address::from_value(paddr).unwrap();
             persistents.push(paddr);
         }
 
         match compare(&addr, &mut persistents) {
-            Some(link) => {
-                let mut link: Vec<&mut Address> = persistents.iter_mut().filter(|persistent| {
+            // persistent address matches new address, consider modifying persistent address
+            Some(link_id) => {
+                let mut pmatches: Vec<&mut Address> = persistents.iter_mut().filter(|persistent| {
                     // only consider modifying persistent addresses that match a new address
                     // and have output set to true
-                    if link == persistent.id.unwrap() && persistent.output == true {
+                    if link_id == persistent.id.unwrap() && persistent.output == true {
                         true
                     } else {
                         false
                     }
                 }).collect();
 
-                if link.len() != 1 {
+                if pmatches.len() != 1 {
                     panic!("Duplicate IDs are not allowed in input data");
                 }
 
-                let link = link.pop().unwrap();
+                let paddr = pmatches.pop().unwrap();
 
-                if link.names.has_diff(&addr.names) {
-                    let mut new_names: Vec<InputName> = Vec::with_capacity(addr.names.names.len());
-                    for name in addr.names.names {
-                        if name.source != Some(Source::Generated) {
-                            new_names.push(InputName::from(name));
-                        }
+                // if the new address has names the persistent address does not, modify persistent
+                if paddr.names.has_diff(&addr.names) {
+                    // preference new names over persistent names
+                    let mut combined_names = addr.names;
+                    combined_names.concat(paddr.names.clone());
+                    combined_names.empty();
+                    combined_names.sort();
+                    combined_names.dedupe();
+
+                    let mut new_names: Vec<InputName> = Vec::with_capacity(combined_names.names.len());
+                    for name in combined_names.names {
+                        new_names.push(InputName::from(name));
                     }
 
                     let new_names = serde_json::to_value(new_names).unwrap();
 
-                    link.props.insert(String::from("street"), new_names);
-
-                    link.to_db(&conn, "modified").unwrap();
+                    // overwrite the persistent street property with the combined names
+                    // retain all other persistent address properties
+                    paddr.props.insert(String::from("street"), new_names);
+                    paddr.to_db(&conn, "modified").unwrap();
                 }
             },
+            // no match in persistent addresses, write new address to output
             None => {
                 output.write(format!("{}\n", GeoJson::Feature(addr.to_geojson(hecate::Action::Create, false)).to_string()).as_bytes()).unwrap();
             }
@@ -191,28 +204,27 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
             id,
             version,
             geom
-    ")).unwrap();
+    ")).unwrap(); // why do we also group by version and geometry? what if these are different?
 
     for mut modified in modifieds {
         let modified_obj = modified.as_object_mut().unwrap();
         let mut props = modified_obj.remove(&String::from("properties")).unwrap();
-
-        if props.as_array().unwrap().len() == 1 {
-            let props = props.as_array_mut().unwrap().pop().unwrap();
+        let props_arr = props.as_array_mut().unwrap();
+        if props_arr.len() == 1 {
+            let props = props_arr.pop().unwrap();
 
             modified_obj.insert(String::from("properties"), props);
         } else {
+            // if the same feature is modified multiple times
+
             // Future TODO: This currently just grabs the first property
             // and merges names together, it does not attempt to merge
             // other properties
-            let props_arr = props.as_array_mut().unwrap();
             let mut props_base = props_arr.pop().unwrap();
             let props_base_obj = props_base.as_object_mut().unwrap();
-
             let names_base: Vec<InputName> = serde_json::from_value(props_base_obj.remove(&String::from("street")).unwrap()).unwrap();
 
             let mut names_base = Names::from_input(names_base, &context);
-
             for prop in props_arr {
                 let prop_obj = prop.as_object_mut().unwrap();
 
@@ -220,23 +232,27 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
                 let names_new = Names::from_input(names_new, &context);
 
                 names_base.concat(names_new);
-                names_base.empty();
-                names_base.sort();
-                names_base.dedupe();
+            }
+            names_base.empty();
+            names_base.sort();
+            names_base.dedupe();
+            let mut names_final = Vec::with_capacity(names_base.names.len());
+            for name in names_base.names {
+                names_final.push(InputName::from(name));
             }
 
-            props_base_obj.insert(String::from("street"), serde_json::to_value(names_base.names).unwrap());
+            props_base_obj.insert(String::from("street"), serde_json::to_value(names_final).unwrap());
             modified_obj.insert(String::from("properties"), props_base);
         }
 
         let modified = match modified {
             serde_json::Value::Object(modified) => modified,
-            _ => { panic!("Modified should always be an object"); }
+            _ => panic!("Modified should always be an object")
         };
 
         let modified: geojson::Feature = match geojson::Feature::from_json_object(modified) {
             Ok(m) => m,
-            Err(e) => { panic!(e); }
+            Err(e) => panic!(e)
         };
 
         output.write(format!("{}\n", modified.to_string()).as_bytes()).unwrap();
@@ -258,9 +274,7 @@ pub fn compare(potential: &Address, persistents: &mut Vec<Address>) -> Option<i6
     if persistents.len() == 0 {
         return None;
     }
-
     let potential_link = linker::Link::new(0, &potential.names);
-
     let persistent_links: Vec<linker::Link> = persistents.iter().map(|persistent| {
         linker::Link::new(persistent.id.unwrap(), &persistent.names)
     }).collect();

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -26,7 +26,7 @@ impl From<Name> for InputName {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Names {
     pub names: Vec<Name>
 }
@@ -660,6 +660,10 @@ mod tests {
         let a_name = Names::new(vec![Name::new("us route 1", 0, None, &context)], &context);
         let b_name = Names::new(vec![Name::new("highway 1", 0, None, &context), Name::new("US Route 1", 0, None, &context)], &context);
         assert_eq!(a_name.has_diff(&b_name), true);
+
+        let a_name = Names::new(vec![Name::new("us route 1", 0, None, &context), Name::new("Main St", 0, None, &context)], &context);
+        let b_name = Names::new(vec![Name::new("us route 1", 0, None, &context)], &context);
+        assert_eq!(a_name.has_diff(&b_name), false);
     }
 
     #[test]

--- a/test/conflate.test.js
+++ b/test/conflate.test.js
@@ -10,8 +10,144 @@ const fs = require('fs');
 const db = require('./lib/db');
 db.init(test);
 
-test('Compare - CREATE', (t) => {
+test('conflate - in_persistent argument error', (t) => {
+    t.throws(() => worker(), /in_persistent argument is required/);
+    t.end();
+});
 
+test('conflate - in_address argument error', (t) => {
+    t.throws(() => worker({
+        'in_persistent': path.resolve(__dirname, './fixtures/dc-persistent.geojson')
+    }), /in_address argument is required/);
+    t.end();
+});
+
+test('conflate - output argument error', (t) => {
+    t.throws(() => worker({
+        'in_persistent': path.resolve(__dirname, './fixtures/dc-persistent.geojson'),
+        'in_address': path.resolve(__dirname, './fixtures/dc-new.geojson')
+    }), /Output file required/);
+    t.end();
+});
+
+test('conflate - CREATE finds only exact duplicate features, adds nothing', (t) => {
+    // Ensure files don't exist before test
+    try {
+        fs.unlinkSync('/tmp/output.geojson');
+        fs.unlinkSync('/tmp/error-persistent');
+    } catch (err) {
+        console.error('ok - cleaned tmp files');
+    }
+
+    worker({
+        'in_persistent': path.resolve(__dirname, './fixtures/dc-persistent.geojson'),
+        'in_address': path.resolve(__dirname, './fixtures/dc-persistent.geojson'),
+        output: '/tmp/output.geojson',
+        'error_persistent': '/tmp/error-persistent',
+        context: {
+            country: 'us',
+            region: 'dc',
+            languages: ['en']
+        },
+        db: 'pt_test'
+    });
+
+    const rl = new ReadLine('/tmp/output.geojson');
+
+    t.notOk(rl.next(), 'no output features');
+    t.doesNotThrow(() => {
+        fs.accessSync('/tmp/error-persistent');
+    });
+
+    fs.unlinkSync('/tmp/output.geojson');
+    fs.unlinkSync('/tmp/error-persistent');
+    t.end();
+});
+
+test('conflate - CREATE finds features with same address number and street less than 1km away, adds nothing', (t) => {
+    // Ensure files don't exist before test
+    try {
+        fs.unlinkSync('/tmp/output.geojson');
+        fs.unlinkSync('/tmp/error-persistent');
+    } catch (err) {
+        console.error('ok - cleaned tmp files');
+    }
+
+    worker({
+        'in_persistent': path.resolve(__dirname, './fixtures/dc-persistent.geojson'),
+        'in_address': path.resolve(__dirname, './fixtures/dc-new-close.geojson'),
+        output: '/tmp/output.geojson',
+        'error_persistent': '/tmp/error-persistent',
+        context: {
+            country: 'us',
+            region: 'dc',
+            languages: ['en']
+        },
+        db: 'pt_test'
+    });
+
+    const rl = new ReadLine('/tmp/output.geojson');
+
+    t.notOk(rl.next(), 'no output features');
+    t.doesNotThrow(() => {
+        fs.accessSync('/tmp/error-persistent');
+    });
+
+    fs.unlinkSync('/tmp/output.geojson');
+    fs.unlinkSync('/tmp/error-persistent');
+    t.end();
+});
+
+test('conflate - CREATE finds features with same address number and street more than 1km away, add new address', (t) => {
+    // Ensure files don't exist before test
+    try {
+        fs.unlinkSync('/tmp/output.geojson');
+        fs.unlinkSync('/tmp/error-persistent');
+    } catch (err) {
+        console.error('ok - cleaned tmp files');
+    }
+
+    worker({
+        'in_persistent': path.resolve(__dirname, './fixtures/dc-persistent.geojson'),
+        'in_address': path.resolve(__dirname, './fixtures/dc-new-far.geojson'),
+        output: '/tmp/output.geojson',
+        'error_persistent': '/tmp/error-persistent',
+        context: {
+            country: 'us',
+            region: 'dc',
+            languages: ['en']
+        },
+        db: 'pt_test'
+    });
+
+    const rl = new ReadLine('/tmp/output.geojson');
+    t.deepEquals(JSON.parse(rl.next()), {
+        action: 'create',
+        type: 'Feature',
+        properties: {
+            number: '108',
+            street: [{
+                display: '4th St NE',
+                priority: -1
+            }]
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [-77.00055599212646, 38.880443352851955]
+        }
+    });
+
+    t.notOk(rl.next(), '1 output feature');
+    t.doesNotThrow(() => {
+        fs.accessSync('/tmp/error-persistent');
+    });
+
+    fs.unlinkSync('/tmp/output.geojson');
+    fs.unlinkSync('/tmp/error-persistent');
+    t.end();
+});
+
+test('conflate - CREATE finds feature with different address number and street, adds new address', (t) => {
     // Ensure files don't exist before test
     try {
         fs.unlinkSync('/tmp/output.geojson');
@@ -51,6 +187,7 @@ test('Compare - CREATE', (t) => {
         }
     });
 
+    t.notOk(rl.next(), 'output 1 feature');
     t.doesNotThrow(() => {
         fs.accessSync('/tmp/error-persistent');
     });
@@ -60,8 +197,99 @@ test('Compare - CREATE', (t) => {
     t.end();
 });
 
-test('Compare - MODIFY', (t) => {
+test('conflate - MODIFY adds new names to existing address names preferencing new names', (t) => {
+    // Ensure files don't exist before test
+    try {
+        fs.unlinkSync('/tmp/output.geojson');
+        fs.unlinkSync('/tmp/error-persistent');
+    } catch (err) {
+        console.error('ok - cleaned tmp files');
+    }
 
+    worker({
+        'in_persistent': path.resolve(__dirname, './fixtures/dc-persistent-syns.geojson'),
+        'in_address': path.resolve(__dirname, './fixtures/dc-modify.geojson'),
+        output: '/tmp/output.geojson',
+        'error_persistent': '/tmp/error-persistent',
+        context: {
+            country: 'us',
+            region: 'dc',
+            languages: ['en']
+        },
+        db: 'pt_test'
+    });
+
+    const rl = new ReadLine('/tmp/output.geojson');
+
+    t.deepEquals(JSON.parse(rl.next()), {
+        id: 1,
+        version: 2,
+        action: 'modify',
+        type: 'Feature',
+        properties: {
+            number: 108,
+            street: [{
+                display: '4th Street Northeast',
+                priority: -1
+            }, {
+                display: 'DC Route 101',
+                priority: -2
+            }, {
+                display: 'Main St',
+                priority: -2
+            }]
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [-77.0008054375648, 38.8912875223052]
+        }
+    });
+
+    t.notOk(rl.next(), 'output 1 feature');
+    t.doesNotThrow(() => {
+        fs.accessSync('/tmp/error-persistent');
+    });
+
+    fs.unlinkSync('/tmp/output.geojson');
+    fs.unlinkSync('/tmp/error-persistent');
+    t.end();
+});
+
+test('conflate - MODIFY does not update existing address no new names are added', (t) => {
+    // Ensure files don't exist before test
+    try {
+        fs.unlinkSync('/tmp/output.geojson');
+        fs.unlinkSync('/tmp/error-persistent');
+    } catch (err) {
+        console.error('ok - cleaned tmp files');
+    }
+
+    worker({
+        'in_persistent': path.resolve(__dirname, './fixtures/dc-persistent-syns.geojson'),
+        'in_address': path.resolve(__dirname, './fixtures/dc-persistent.geojson'),
+        output: '/tmp/output.geojson',
+        'error_persistent': '/tmp/error-persistent',
+        context: {
+            country: 'us',
+            region: 'dc',
+            languages: ['en']
+        },
+        db: 'pt_test'
+    });
+
+    const rl = new ReadLine('/tmp/output.geojson');
+
+    t.notOk(rl.next(), 'no output features');
+    t.doesNotThrow(() => {
+        fs.accessSync('/tmp/error-persistent');
+    });
+
+    fs.unlinkSync('/tmp/output.geojson');
+    fs.unlinkSync('/tmp/error-persistent');
+    t.end();
+});
+
+test('conflate - MODIFY handles multiple updates to the same feature', (t) => {
     // Ensure files don't exist before test
     try {
         fs.unlinkSync('/tmp/output.geojson');
@@ -72,7 +300,7 @@ test('Compare - MODIFY', (t) => {
 
     worker({
         'in_persistent': path.resolve(__dirname, './fixtures/dc-persistent.geojson'),
-        'in_address': path.resolve(__dirname, './fixtures/dc-new-modify.geojson'),
+        'in_address': path.resolve(__dirname, './fixtures/dc-modify-multiple.geojson'),
         output: '/tmp/output.geojson',
         'error_persistent': '/tmp/error-persistent',
         context: {
@@ -95,7 +323,10 @@ test('Compare - MODIFY', (t) => {
             street: [{
                 display: '4th St NE',
                 priority: -1
-            },{
+            }, {
+                display: 'Main St',
+                priority: -2
+            }, {
                 display: 'DC Route 101',
                 priority: -2
             }]
@@ -106,6 +337,99 @@ test('Compare - MODIFY', (t) => {
         }
     });
 
+    t.notOk(rl.next(), 'output 1 feature');
+    t.doesNotThrow(() => {
+        fs.accessSync('/tmp/error-persistent');
+    });
+
+    fs.unlinkSync('/tmp/output.geojson');
+    fs.unlinkSync('/tmp/error-persistent');
+    t.end();
+});
+
+test('conflate - MODIFY all properties (including overrides) on the existing address except street names are preserved', (t) => {
+    // Ensure files don't exist before test
+    try {
+        fs.unlinkSync('/tmp/output.geojson');
+        fs.unlinkSync('/tmp/error-persistent');
+    } catch (err) {
+        console.error('ok - cleaned tmp files');
+    }
+
+    worker({
+        'in_persistent': path.resolve(__dirname, './fixtures/dc-persistent-override.geojson'),
+        'in_address': path.resolve(__dirname, './fixtures/dc-modify.geojson'),
+        output: '/tmp/output.geojson',
+        'error_persistent': '/tmp/error-persistent',
+        context: {
+            country: 'us',
+            region: 'dc',
+            languages: ['en']
+        },
+        db: 'pt_test'
+    });
+
+    const rl = new ReadLine('/tmp/output.geojson');
+
+    t.deepEquals(JSON.parse(rl.next()), {
+        id: 1,
+        version: 2,
+        action: 'modify',
+        type: 'Feature',
+        properties: {
+            postcode: '00000',
+            accuracy: 'rooftop',
+            source: 'original-source',
+            number: 108,
+            street: [{
+                display: '4th Street Northeast',
+                priority: -1
+            }, {
+                display: 'DC Route 101',
+                priority: -2
+            }]
+        },
+        geometry: {
+            type: 'Point',
+            coordinates: [-77.0008054375648, 38.8912875223052]
+        }
+    });
+
+    t.notOk(rl.next(), 'output 1 feature');
+    t.doesNotThrow(() => {
+        fs.accessSync('/tmp/error-persistent');
+    });
+
+    fs.unlinkSync('/tmp/output.geojson');
+    fs.unlinkSync('/tmp/error-persistent');
+    t.end();
+});
+
+test('conflate - MODIFY non-street properties on the new address are not included in updates', (t) => {
+    // Ensure files don't exist before test
+    try {
+        fs.unlinkSync('/tmp/output.geojson');
+        fs.unlinkSync('/tmp/error-persistent');
+    } catch (err) {
+        console.error('ok - cleaned tmp files');
+    }
+
+    worker({
+        'in_persistent': path.resolve(__dirname, './fixtures/dc-persistent.geojson'),
+        'in_address': path.resolve(__dirname, './fixtures/dc-persistent-override.geojson'),
+        output: '/tmp/output.geojson',
+        'error_persistent': '/tmp/error-persistent',
+        context: {
+            country: 'us',
+            region: 'dc',
+            languages: ['en']
+        },
+        db: 'pt_test'
+    });
+
+    const rl = new ReadLine('/tmp/output.geojson');
+
+    t.notOk(rl.next(), 'no features output');
     t.doesNotThrow(() => {
         fs.accessSync('/tmp/error-persistent');
     });

--- a/test/conflate.test.js
+++ b/test/conflate.test.js
@@ -438,3 +438,37 @@ test('conflate - MODIFY non-street properties on the new address are not include
     fs.unlinkSync('/tmp/error-persistent');
     t.end();
 });
+
+test('conflate - MODIFY existing addresses with output==false are not modified', (t) => {
+    // Ensure files don't exist before test
+    try {
+        fs.unlinkSync('/tmp/output.geojson');
+        fs.unlinkSync('/tmp/error-persistent');
+    } catch (err) {
+        console.error('ok - cleaned tmp files');
+    }
+
+    worker({
+        'in_persistent': path.resolve(__dirname, './fixtures/dc-persistent-output.geojson'),
+        'in_address': path.resolve(__dirname, './fixtures/dc-modify.geojson'),
+        output: '/tmp/output.geojson',
+        'error_persistent': '/tmp/error-persistent',
+        context: {
+            country: 'us',
+            region: 'dc',
+            languages: ['en']
+        },
+        db: 'pt_test'
+    });
+
+    const rl = new ReadLine('/tmp/output.geojson');
+
+    t.notOk(rl.next(), 'no features output');
+    t.doesNotThrow(() => {
+        fs.accessSync('/tmp/error-persistent');
+    });
+
+    fs.unlinkSync('/tmp/output.geojson');
+    fs.unlinkSync('/tmp/error-persistent');
+    t.end();
+});

--- a/test/fixtures/dc-modify-multiple.geojson
+++ b/test/fixtures/dc-modify-multiple.geojson
@@ -1,0 +1,2 @@
+{ "type": "Feature", "properties": { "number": 108, "street": [ { "display": "4th ST NE", "priority": 0 }, { "display": "DC Route 101", "priority": -1 } ] }, "geometry": { "type": "Point", "coordinates": [ -77.00080543756485, 38.89128752230519 ] } }
+{ "type": "Feature", "properties": { "number": 108, "street": [ { "display": "4th ST NE", "priority": 0 }, { "display": "Main St", "priority": -1 } ] }, "geometry": { "type": "Point", "coordinates": [ -77.00080543756485, 38.89128752230519 ] } }

--- a/test/fixtures/dc-modify.geojson
+++ b/test/fixtures/dc-modify.geojson
@@ -1,0 +1,1 @@
+{ "type": "Feature", "properties": { "number": 108, "street": [ { "display": "DC Route 101", "priority": -1 }, { "display": "4th Street Northeast", "priority": 0 } ] }, "geometry": { "type": "Point", "coordinates": [ -77.00080543756485, 38.89128752230519 ] } }

--- a/test/fixtures/dc-new-close.geojson
+++ b/test/fixtures/dc-new-close.geojson
@@ -1,0 +1,1 @@
+{ "type": "Feature", "properties": { "number": 108, "street": [ { "display": "4th ST NE", "priority": 0 } ] }, "geometry": { "type": "Point", "coordinates": [-77.00055599212646, 38.88425173647755 ] } }

--- a/test/fixtures/dc-new-far.geojson
+++ b/test/fixtures/dc-new-far.geojson
@@ -1,0 +1,1 @@
+{ "type": "Feature", "properties": { "number": 108, "street": [ { "display": "4th ST NE", "priority": 0 } ] }, "geometry": { "type": "Point", "coordinates": [ -77.00055599212646, 38.880443352851955 ] } }

--- a/test/fixtures/dc-new-modify.geojson
+++ b/test/fixtures/dc-new-modify.geojson
@@ -1,1 +1,0 @@
-{ "type": "Feature", "properties": { "number": 108, "street": [ { "display": "4th ST NE", "priority": 0 }, { "display": "DC Route 101", "priority": -1 } ] }, "geometry": { "type": "Point", "coordinates": [ -77.00080543756485, 38.89128752230519 ] } }

--- a/test/fixtures/dc-persistent-output.geojson
+++ b/test/fixtures/dc-persistent-output.geojson
@@ -1,0 +1,1 @@
+{ "id": 1, "version": 2, "type": "Feature", "properties": { "output": false, "number": 108, "street": [ { "display": "4th ST NE", "priority": 0 } ] }, "geometry": { "type": "Point", "coordinates": [ -77.00080543756485, 38.89128752230519 ] } }

--- a/test/fixtures/dc-persistent-override.geojson
+++ b/test/fixtures/dc-persistent-override.geojson
@@ -1,0 +1,1 @@
+{ "id": 1, "version": 2, "type": "Feature", "properties": { "postcode": "00000", "accuracy": "rooftop", "source": "original-source", "number": 108, "street": [ { "display": "4th ST NE", "priority": 0 } ] }, "geometry": { "type": "Point", "coordinates": [ -77.00080543756485, 38.89128752230519 ] } }

--- a/test/fixtures/dc-persistent-syns.geojson
+++ b/test/fixtures/dc-persistent-syns.geojson
@@ -1,0 +1,1 @@
+{ "id": 1, "version": 2, "type": "Feature", "properties": { "number": 108, "street": [ { "display": "4th ST NE", "priority": 0 }, { "display": "Main St", "priority": -1 } ] }, "geometry": { "type": "Point", "coordinates": [ -77.00080543756485, 38.89128752230519 ] } }

--- a/test/fixtures/dc-persistent.geojson
+++ b/test/fixtures/dc-persistent.geojson
@@ -1,2 +1,1 @@
 { "id": 1, "version": 2, "type": "Feature", "properties": { "number": 108, "street": [ { "display": "4th ST NE", "priority": 0 } ] }, "geometry": { "type": "Point", "coordinates": [ -77.00080543756485, 38.89128752230519 ] } }
-{ "id": 2, "version": 2, "type": "Feature", "properties": { "number": 110, "street": [ { "display": "4th ST NE", "priority": 0 } ] }, "geometry": { "type": "Point", "coordinates": [ -77.00087249279022, 38.89133136329628 ] } }


### PR DESCRIPTION
## Context

As part of conflate mode, we consider modifying persistent addresses if a new address contains names the persistent address does not. We do not, however, filter out persistent addresses with `output` set to `false`. We want to add addresses with `output: false` downstream when running conflate so we don't add new addresses that we've already updated or deleted during conflate. Without adding this check, it's possible for multiple versions of the same feature to match to the link id and for conflate to attempt to modify multiple features with the same id (which `panic`s)

## Summary of changes 
- [ ] only consider modifying addresses where output==true in conflate

## Next steps
- [ ] add tests
- [ ] review
- [ ] merge
- [ ] release

cc @mattciferri @ingalls @miccolis @samely 