### PR TITLE
Run ci on xlarge, increase no output timeout to 12m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
         docker:
             - image: ubuntu:18.04
             - image: mdillon/postgis:11
+        resource_class: xlarge
         steps:
             - run:
                 name: "Add ubuntu-toolchain"
@@ -52,7 +53,7 @@ jobs:
             - run:
                 name: "Yarn Coverage"
                 command: "yarn run coverage"
-                no_output_timeout: "10m"
+                no_output_timeout: "12m"
             - run:
                 name: "Yarn Coverage-Upload"
                 command: "yarn run coverage-upload"


### PR DESCRIPTION
We're having some trouble with the current map mode tests timing out during the `matcher` process on a good run. This increases the instance type we're using to xlarge and increases the `no_output_timeout` from 10m to 12m.

cc @ingalls @mattciferri @miccolis @samely 