### PR TITLE
Revitalize analyze mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ Full Options:
 ./index.js convert --help
 ```
 
+## `analyze` Mode
+
+### Basic Usage
+
+Analyzes the name field of a set of address and network data from either the database or a GeoJSON file. Outputs a CSV and markdown summary of the frequency distribution of each token in the data. Also includes a comparison mode for comparing address and network tokens.
+
+Basic Usage:
+```
+./index.js analyze --cc us_ia --type address --output=/tmp/us_ia.text-analysis/address
+```
+
 ## Version Numbers
 
 PT2ITP follows the [Semver](http://semver.org/) spec for it's **CLI interface**.

--- a/index.js
+++ b/index.js
@@ -80,6 +80,13 @@ if (require.main === module) {
                 process.exit(0);
             });
             break;
+        case ('analyze'):
+            require('./lib/analyze')(process.argv, (err) => {
+                if (err) throw err;
+
+                process.exit(0);
+            });
+            break;
         case ('convert'): {
             const convert_arg = require('minimist')(process.argv, {
                 string: ['input', 'output']
@@ -196,6 +203,7 @@ if (require.main === module) {
         map: require('./lib/map'),
         test: require('./lib/test'),
         testcsv: require('./lib/testcsv'),
-        strip: require('./lib/strip')
+        strip: require('./lib/strip'),
+        analyze: require('./lib/analyze')
     };
 }

--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -195,7 +195,7 @@ function buildCollocationTables(argv, pool, cb) {
  */
 function writeUnigram(argv, pool, bigrams, cb) {
     const unigramOutput = path.resolve(argv.output) + '-unigram.csv';
-    const unigramCSVStream = csv.createWriteStream({ headers: true });
+    const unigramCSVStream = csv.format({ headers: true });
     const unigramWriteStream = fs.createWriteStream(unigramOutput, { encoding: 'utf8' });
     unigramWriteStream.on('error', (err) => {
         cb(err);
@@ -247,7 +247,7 @@ function writeUnigram(argv, pool, bigrams, cb) {
  */
 function writeBigram(argv, pool, bigrams, cb) {
     const bigramOutput = path.resolve(argv.output) + '-bigram.csv';
-    const bigramCSVStream = csv.createWriteStream({ headers: true });
+    const bigramCSVStream = csv.format({ headers: true });
     const bigramWriteStream = fs.createWriteStream(bigramOutput, { encoding: 'utf8' });
     bigramCSVStream.pipe(bigramWriteStream);
 

--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -1,0 +1,620 @@
+'use strict';
+
+const fs = require('fs');
+const pg = require('pg');
+const path = require('path');
+const Queue = require('d3-queue').queue;
+const csv = require('fast-csv');
+const collocation = require('./analyze/collocation.js');
+const tokenize = require('./util/tokenize.js');
+const copyFrom = require('pg-copy-streams').from;
+const copyTo = require('pg-copy-streams').to;
+const BiGramCollocationTable = collocation.BiGramCollocationTable;
+
+/**
+ * This module analyzes the 'name' fields of address and network data. It
+ * assumes they have been loaded into the database already. The output is a CSV
+ * file with statistics on the frequency distribution of each token in that
+ * data. Those statistics will be useful for surfacing important patterns in
+ * street names and spotting potential near-misses when matching address and
+ * network entries.
+ *
+ * Generally speaking, this command should be run three times per country. Once
+ * for network, once for address, and then once for the comparison. eg:
+ *
+ *     pt2itp analyze --cc us_ia --type address --output=/tmp/us_ia.text-analysis/address
+ *     pt2itp analyze --cc us_ia --type network --output=/tmp/us_ia.text-analysis/network
+ *     pt2itp analyze --cc us_ia --compare true --output=/tmp/us_ia.text-analysis/comparison
+ *
+ * @param {Object} argv - command line arguments passed when calling `pt2itp analyze`
+ * @param {string} argv.cc - country code with optional region code (eg. `es` or `us ny`)
+ * @param {string} argv.type - one of "network" or "address"
+ * @param {boolean} argv.compare - when true, run a comparison analysis.
+ * @param {number} argv.limit - limit analysis to just this many text values
+ * @param {string} argv.output - the file path prefix to be used when writing CSV outputs
+ * @param {function} callback - callback function to surface any thrown errors
+ */
+function analyze(argv, callback) {
+    if (Array.isArray(argv)) {
+        argv = require('minimist')(argv, {
+            string: [
+                'cc',
+                'type',
+                'limit',
+                'output'
+            ],
+            boolean: [
+                'compare'
+            ],
+            default: {
+                'compare': false
+            }
+        });
+    }
+    if (!argv.cc) {
+        console.error('--cc=<country code> argument required');
+        process.exit(1);
+    }
+    // note: you can limit results/rows with --limit <number>
+    if (argv.limit) {
+        argv.limit = parseInt(argv.limit);
+    }
+
+    const cc = argv.cc;
+    let database;
+
+    const country = cc.split('_')[0];
+    if (cc.indexOf('_') > -1) {
+        const region = cc.split('_')[1];
+        database = `mbpl_${country}_${region}_address_both`;
+    } else if (cc === 'test') {
+        database = 'pt_test';
+    } else {
+        database = `mbpl_${country}_address_both`;
+    }
+
+    const pool = new pg.Pool({
+        max: 1,
+        user: 'postgres',
+        database: database,
+        idleTimeoutMillis: 30
+    });
+
+    if (argv.compare) {
+        compareAddressAndNetwork(argv, pool, (err) => {
+            if (err) callback(err);
+            pool.end((err) => {
+                if (err) callback(err);
+                callback(null);
+            });
+        });
+    } else {
+        buildCollocationTables(argv, pool, (err) =>{
+            if (err) callback(err);
+            pool.end((err) => {
+                if (err) callback(err);
+                callback(null);
+            });
+        });
+    }
+
+}
+
+
+/**
+ * Builds the bigram and unigram tables for a given country and type.
+ *
+ * @param {Object} argv - CLI arguments, parsed into an object
+ * @param {Pool} pool - A pg connection pool
+ * @param {function} cb - done
+ */
+function buildCollocationTables(argv, pool, cb) {
+    if (!argv.type) {
+        console.error('--type=<type> argument required');
+        process.exit(1);
+    } else if (!argv.output) {
+        console.error('--output=<output file location> argument required');
+        process.exit(1);
+    }
+
+    const type = argv.type;
+    const limit = argv.limit;
+
+    extractTextField(type, limit, pool, (err, text) => {
+        if (err) cb(err);
+        frequencyDistributionMunger(text, (err, bigrams) => {
+            if (err) cb(err);
+
+            const popQ = new Queue(1);
+
+            popQ.defer((done) => {
+                pool.query(`
+                    BEGIN;
+                    DROP TABLE IF EXISTS ${type}_unigrams;
+                    CREATE TABLE ${type}_unigrams (
+                        word VARCHAR NOT NULL,
+                        frequency INTEGER,
+                        relative_frequency DOUBLE PRECISION
+                    );
+
+                    DROP TABLE IF EXISTS ${type}_bigrams;
+                    CREATE TABLE ${type}_bigrams (
+                        w1 VARCHAR NOT NULL,
+                        w2 VARCHAR NOT NULL,
+                        frequency INTEGER,
+                        likelihood_ratio DOUBLE PRECISION
+                    );
+
+                    COMMIT;
+                    `,
+                (err) => {
+                    return done(err);
+                }
+                );
+            });
+
+            popQ.defer((done) => {
+                writeUnigram(argv, pool, bigrams, (err) => {
+                    return done(err);
+                });
+            });
+
+            popQ.defer((done) => {
+                writeBigram(argv, pool, bigrams, (err) => {
+                    return done(err);
+                });
+            });
+
+            popQ.defer((done) => {
+                pool.query(`
+                    BEGIN;
+                    CREATE INDEX ON ${type}_unigrams (word);
+                    CREATE INDEX ON ${type}_bigrams (w1, w2);
+                    COMMIT;
+                    `, (err) => {
+                    return done(err);
+                }
+                );
+            });
+
+            popQ.await((err) => {
+                return cb(err);
+            });
+        });
+    });
+
+}
+
+/**
+ * Writes unigram frequencies to CSV and also to a table in the database
+ *
+ * @param {Object} argv - arguments from the command line
+ * @param {Pool} pool - postgres connection pool
+ * @param {BiGramCollocationTable} bigrams - a collocation table of order 2 (bigram)
+ * @param {function} cb - callback
+ */
+function writeUnigram(argv, pool, bigrams, cb) {
+    const unigramOutput = path.resolve(argv.output) + '-unigram.csv';
+    const unigramCSVStream = csv.createWriteStream({ headers: true });
+    const unigramWriteStream = fs.createWriteStream(unigramOutput, { encoding: 'utf8' });
+    unigramWriteStream.on('error', (err) => {
+        cb(err);
+    });
+    unigramWriteStream.on('finish', () => {
+        cb(null);
+    });
+
+    unigramCSVStream.pipe(unigramWriteStream);
+
+    const unigramN = bigrams.unigram_fd.n();
+
+    for (const [word, frequency] of bigrams.unigram_fd.entries()) {
+        const relativeFrequency = frequency / unigramN;
+        unigramCSVStream.write(
+            { 'word': word,'frequency': frequency, 'relative_frequency': relativeFrequency },
+            { 'headers': true }
+        );
+    }
+
+    unigramCSVStream.end(null, 'utf8', () => {
+        pool.connect((err, client, release) => {
+            if (err) cb(err);
+            const queryString = `COPY ${argv.type}_unigrams from STDIN CSV HEADER`;
+            const copyStream = client.query(copyFrom(queryString));
+            const readStream = fs.createReadStream(unigramOutput, { encoding: 'utf8' });
+            readStream.on('error', cb);
+            copyStream.on('error', (err) =>{
+                release();
+                cb(err);
+            });
+            copyStream.on('end', (err) => {
+                if (err) cb(err);
+                release();
+                cb(null);
+            });
+            readStream.pipe(copyStream);
+        });
+    });
+}
+
+/**
+ * Writes bigram frequencies and likelihoods to CSV and also to a table in the database
+ *
+ * @param {Object} argv - arguments from the command line
+ * @param {Pool} pool - postgres connection pool
+ * @param {BiGramCollocationTable} bigrams - a collocation table of order 2 (bigram)
+ * @param {function} cb - callback
+ */
+function writeBigram(argv, pool, bigrams, cb) {
+    const bigramOutput = path.resolve(argv.output) + '-bigram.csv';
+    const bigramCSVStream = csv.createWriteStream({ headers: true });
+    const bigramWriteStream = fs.createWriteStream(bigramOutput, { encoding: 'utf8' });
+    bigramCSVStream.pipe(bigramWriteStream);
+
+    for (const score of bigrams.score_ngrams('likelihoodRatio')) {
+        bigramCSVStream.write(score, { headers: true });
+    }
+
+    bigramCSVStream.end(null, 'utf8', () => {
+        pool.connect((err, client, release) => {
+            if (err) cb(err);
+            const queryString = `COPY ${argv.type}_bigrams from STDIN CSV HEADER`;
+            const copyStream = client.query(copyFrom(queryString));
+            const readStream = fs.createReadStream(bigramOutput, { encoding: 'utf8' });
+            readStream.on('error', cb);
+            copyStream.on('error', (err) =>{
+                release();
+                cb(err);
+            });
+            copyStream.on('end', (err) => {
+                if (err) cb(err);
+                release();
+                cb(null);
+            });
+            readStream.pipe(copyStream);
+        });
+    });
+}
+
+/**
+ * This method queries the appropriate table in the postgres database, returns
+ * the name field for each row, passes each value through {@link formatData},
+ * and calls callback on an array of the results.
+ *
+ * @param {string} type - one of "network" or "address"
+ * @param {numeric} limit - for dev/testing purposes, limit to this many rows
+ * @param {Pool} pool - postgres pool object, connected to the database
+ * @param {function} callback - callback function
+ */
+function extractTextField(type, limit, pool, callback) {
+    const table = (type === 'address') ? 'address_cluster' : 'network_cluster';
+    const limitClause = limit ? ' LIMIT ' + limit : '';
+
+    pool.query('SELECT names AS name FROM ' + table + limitClause + ';', (err, data) => {
+        if (err) {
+            pool.end();
+            return callback(err);
+        }
+        const textFields = formatData(data.rows);
+        return callback(null, textFields);
+    });
+}
+
+/**
+ * This function formats each result
+ *
+ * @param {Array<any>} data - an array of rows from a sql query result
+ * @returns {Array<string>} an array of formatted name fields
+ */
+function formatData(data) {
+    const results = [];
+
+    if (!data.length) return [];
+
+    data.forEach((d) => {
+        if (!d.name || !d.name.length) return;
+        d.name.forEach((name) => {
+            return results.push(name.display);
+        });
+    });
+
+    return results;
+}
+
+/**
+ * This function tokenizes each text value and uses the token arrays to update
+ * a {@link BiGramCollocationTable}. Then it returns an array of scored ngrams.
+ *
+ * @param {Array<string>} textfields - An array of _text values
+ * @param {function} callback - callback function
+ */
+function frequencyDistributionMunger(textfields, callback) {
+    const bigrams = new BiGramCollocationTable();
+
+    for (const textField in textfields) {
+        const tokens = tokenize.main(textfields[textField]);
+        bigrams.update(tokens);
+    }
+    return callback(null, bigrams);
+}
+
+/**
+ * After the collocation tables have been built for network and address data,
+ * this function can be called to compare the two
+ *
+ * @param {Object} argv - CLI arguments, parsed into an object
+ * @param {Pool} pool - A pg connection Pool
+ * @param {function} callback - callback
+ */
+function compareAddressAndNetwork(argv, pool, callback) {
+
+    const outputPrefix = path.resolve(argv.output);
+
+    const popQ = new Queue(1);
+
+    popQ.defer((done) => {
+        pool.query(`
+            BEGIN;
+
+            DROP TABLE IF EXISTS bigram_side_by_side;
+
+            CREATE TABLE bigram_side_by_side AS
+                SELECT
+                    n.w1 AS network_w1,
+                    n.w2 AS network_w2,
+                    n.frequency AS network_frequency,
+                    n.likelihood_ratio AS network_likelihood_ratio,
+                    a.w1 AS address_w1,
+                    a.w2 AS address_w2,
+                    a.frequency AS address_frequency,
+                    a.likelihood_ratio AS address_likelihood_ratio,
+                    COALESCE(n.frequency,0) - COALESCE(a.frequency,0) AS frequency_diff,
+                    COALESCE(n.likelihood_ratio,0) - COALESCE(a.likelihood_ratio,0) AS likelihood_ratio_diff
+                FROM
+                    network_bigrams n
+                        FULL OUTER JOIN
+                    address_bigrams a ON n.w1 = a.w1 AND n.w2 = a.w2;
+            COMMIT;`,
+        (err) => {
+            if (err) {
+                pool.end();
+                return callback(err);
+            }
+            done();
+        }
+        );
+    });
+
+    popQ.defer((done) => {
+        pool.query(`
+            BEGIN;
+
+            DROP TABLE IF EXISTS bigram_comparison;
+
+            CREATE TABLE bigram_comparison AS
+                SELECT
+                    COALESCE(bc.network_w1, bc.address_w1) as w1,
+                    COALESCE(bc.network_w2, bc.address_w2) as w2,
+                    bc.network_frequency,
+                    bc.network_likelihood_ratio,
+                    bc.address_frequency,
+                    bc.address_likelihood_ratio,
+                    bc.frequency_diff,
+                    bc.likelihood_ratio_diff,
+                    (bc.likelihood_ratio_diff - ss.avg_lrd) / ss.stddev_lrd AS zscore
+                FROM
+                    bigram_side_by_side AS bc
+                        CROSS JOIN
+                    (SELECT
+                        AVG(likelihood_ratio_diff) AS avg_lrd,
+                        GREATEST(STDDEV(likelihood_ratio_diff), 1) AS stddev_lrd
+                     FROM
+                        bigram_side_by_side) AS ss;
+            COMMIT;`,
+        (err) => {
+            if (err) {
+                pool.end();
+                return callback(err);
+            }
+            done();
+        }
+        );
+    });
+
+    popQ.defer((done) => {
+        pool.query(`
+            BEGIN;
+
+            DROP TABLE IF EXISTS significant_network_bigrams;
+
+            CREATE TABLE significant_network_bigrams AS
+                SELECT
+                    w1,
+                    w2,
+                    network_frequency,
+                    zscore
+                FROM
+                    bigram_comparison
+                WHERE
+                    zscore > 1
+                ORDER BY
+                    zscore DESC, w1, w2;
+
+            DROP TABLE IF EXISTS significant_address_bigrams;
+
+            CREATE TABLE significant_address_bigrams AS
+                SELECT
+                    w1,
+                    w2,
+                    address_frequency,
+                    zscore
+                FROM
+                    bigram_comparison
+                WHERE
+                    zscore < -1
+                ORDER BY
+                    zscore, w1, w2;
+            COMMIT;`,
+        (err) => {
+            if (err) {
+                pool.end();
+                return callback(err);
+            }
+            done();
+        }
+        );
+    });
+
+    popQ.defer((done) => {
+        pool.query(`
+            BEGIN;
+
+            DROP TABLE IF EXISTS unigram_side_by_side;
+
+            CREATE TABLE unigram_side_by_side AS
+                SELECT
+                    n.word as network_word,
+                    n.frequency AS network_frequency,
+                    n.relative_frequency AS network_relative_frequency,
+                    a.word AS address_word,
+                    a.frequency AS address_frequency,
+                    a.relative_frequency AS address_relative_frequency,
+                    COALESCE(n.frequency, 0) - COALESCE(a.frequency, 0) AS frequency_diff,
+                    COALESCE(n.relative_frequency, 0) - COALESCE(a.relative_frequency, 0) AS relative_frequency_diff
+                FROM
+                    network_unigrams n
+                        FULL OUTER JOIN
+                    address_unigrams a USING (word);
+            COMMIT;`,
+        (err) => {
+            if (err) {
+                pool.end();
+                return callback(err);
+            }
+            done();
+        }
+        );
+    });
+
+    popQ.defer((done) => {
+        pool.query(`
+            BEGIN;
+
+            DROP TABLE IF EXISTS unigram_comparison;
+
+            CREATE TABLE unigram_comparison AS
+                SELECT
+                    COALESCE(network_word, address_word) as word,
+                    network_frequency,
+                    address_frequency,
+                    network_relative_frequency,
+                    address_relative_frequency,
+                    relative_frequency_diff,
+                    (relative_frequency_diff - avg_diff) / stddev_diff as zscore
+                FROM
+                    unigram_side_by_side uc
+                        CROSS JOIN
+                    (SELECT
+                        AVG(relative_frequency_diff) AS avg_diff,
+                        STDDEV(relative_frequency_diff) as stddev_diff
+                     FROM
+                        unigram_side_by_side) as ss order by zscore;
+            COMMIT;`,
+        (err) => {
+            if (err) {
+                pool.end();
+                return callback(err);
+            }
+            done();
+        }
+        );
+    });
+
+    popQ.defer((done) => {
+        pool.query(`
+            BEGIN;
+
+            DROP TABLE IF EXISTS significant_network_unigrams;
+
+            CREATE TABLE significant_network_unigrams AS
+                SELECT
+                    word,
+                    network_frequency,
+                    zscore
+                FROM
+                    unigram_comparison
+                WHERE
+                    zscore > 1
+                ORDER BY
+                    zscore DESC, word;
+
+            DROP TABLE IF EXISTS significant_address_unigrams;
+
+            CREATE TABLE significant_address_unigrams AS
+                SELECT
+                    word,
+                    address_frequency,
+                    zscore
+                FROM
+                    unigram_comparison
+                WHERE
+                    zscore < -1
+                ORDER BY
+                    zscore,word;
+            COMMIT;`,
+        (err) => {
+            if (err) {
+                pool.end();
+                return callback(err);
+            }
+            done();
+        }
+        );
+    });
+
+    /**
+     * Copy the significant ngrams for some type and order to a CSV file
+     *
+     * @param {string} type - The type of data to be analyzed. Must be either "network" or "address"
+     * @param {string} order - The order of the analysis. Must be one of "bigram" or "unigram"
+     * @param {function} cb - callback
+     */
+    function copyOutput(type, order, cb) {
+        const outputPath = `${outputPrefix}-${type}-${order}.csv`;
+        pool.connect((err, client, release) => {
+            const queryString = `COPY significant_${type}_${order}s TO STDOUT CSV HEADER`;
+            const copyStream = client.query(copyTo(queryString));
+            const writeStream = fs.createWriteStream(outputPath, { encoding: 'utf8' });
+            writeStream.on('error', cb);
+            copyStream.on('error', (err) => {
+                release();
+                return cb(err);
+            });
+            copyStream.on('end', (err) => {
+                if (err) cb(err);
+            });
+            writeStream.on('finish', (err) => {
+                if (err) cb(err);
+                release();
+                return cb(null);
+            });
+            copyStream.pipe(writeStream);
+        });
+    }
+
+    popQ.defer(copyOutput, 'address', 'bigram');
+    popQ.defer(copyOutput, 'address', 'unigram');
+    popQ.defer(copyOutput, 'network', 'bigram');
+    popQ.defer(copyOutput, 'network', 'unigram');
+
+    popQ.await((err) => {
+        if (err) callback(err);
+        return callback(null);
+    });
+
+}
+
+module.exports = analyze;
+module.exports.frequencyDistributionMunger = frequencyDistributionMunger;
+module.exports.extractTextField = extractTextField;
+module.exports.formatData = formatData;

--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -28,9 +28,10 @@ let totalTokens = 0;
  * Generally speaking, this command should be run three times per country. Once
  * for network, once for address, and then once for the comparison. eg:
  *
- *     pt2itp analyze --cc us_ia --type address --output=/tmp/us_ia.text-analysis/address
- *     pt2itp analyze --cc us_ia --type network --output=/tmp/us_ia.text-analysis/network
- *     pt2itp analyze --cc us_ia --compare true --output=/tmp/us_ia.text-analysis/comparison
+ *     ./index.js analyze --cc fr --source /path/to/file.geojson --output /tmp/fr.text-analysis/address
+ *     ./index.js analyze --cc us_ia --type address --output=/tmp/us_ia.text-analysis/address
+ *     ./index.js analyze --cc us_ia --type network --output=/tmp/us_ia.text-analysis/network
+ *     ./index.js analyze --cc us_ia --compare true --output=/tmp/us_ia.text-analysis/comparison
  *
  * For each run with compare mode off, a markdown based summary will be generated to
  * summarize the results.

--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -1,20 +1,26 @@
 'use strict';
 
 const fs = require('fs');
+const readline = require('readline');
 const pg = require('pg');
 const path = require('path');
 const Queue = require('d3-queue').queue;
 const csv = require('fast-csv');
 const collocation = require('./analyze/collocation.js');
-const tokenize = require('./util/tokenize.js');
 const copyFrom = require('pg-copy-streams').from;
+const { tokenize_name } = require('../native/index.node');
+const Context = require('./util/context');
 const copyTo = require('pg-copy-streams').to;
 const BiGramCollocationTable = collocation.BiGramCollocationTable;
 
+let matchedTokens = 0;
+let totalTokens = 0;
+
 /**
  * This module analyzes the 'name' fields of address and network data. It
- * assumes they have been loaded into the database already. The output is a CSV
- * file with statistics on the frequency distribution of each token in that
+ * can load data from either the database, or a geojson file.
+ *
+ * The output is a CSV file with statistics on the frequency distribution of each token in that
  * data. Those statistics will be useful for surfacing important patterns in
  * street names and spotting potential near-misses when matching address and
  * network entries.
@@ -26,10 +32,14 @@ const BiGramCollocationTable = collocation.BiGramCollocationTable;
  *     pt2itp analyze --cc us_ia --type network --output=/tmp/us_ia.text-analysis/network
  *     pt2itp analyze --cc us_ia --compare true --output=/tmp/us_ia.text-analysis/comparison
  *
+ * For each run with compare mode off, a markdown based summary will be generated to
+ * summarize the results.
+ *
  * @param {Object} argv - command line arguments passed when calling `pt2itp analyze`
  * @param {string} argv.cc - country code with optional region code (eg. `es` or `us ny`)
  * @param {string} argv.type - one of "network" or "address"
- * @param {boolean} argv.compare - when true, run a comparison analysis.
+ * @param {string} argv.source - path to geojson file to load names from
+ * @param {boolean} argv.compare - when true, run a comparison analysis
  * @param {number} argv.limit - limit analysis to just this many text values
  * @param {string} argv.output - the file path prefix to be used when writing CSV outputs
  * @param {function} callback - callback function to surface any thrown errors
@@ -40,6 +50,7 @@ function analyze(argv, callback) {
             string: [
                 'cc',
                 'type',
+                'source',
                 'limit',
                 'output'
             ],
@@ -93,11 +104,11 @@ function analyze(argv, callback) {
             if (err) callback(err);
             pool.end((err) => {
                 if (err) callback(err);
+                generateMarkdownSummary(cc, argv.output);
                 callback(null);
             });
         });
     }
-
 }
 
 
@@ -109,20 +120,15 @@ function analyze(argv, callback) {
  * @param {function} cb - done
  */
 function buildCollocationTables(argv, pool, cb) {
-    if (!argv.type) {
-        console.error('--type=<type> argument required');
-        process.exit(1);
-    } else if (!argv.output) {
+    const { type, limit, source, cc } = argv;
+    if (!argv.output) {
         console.error('--output=<output file location> argument required');
         process.exit(1);
     }
 
-    const type = argv.type;
-    const limit = argv.limit;
-
-    extractTextField(type, limit, pool, (err, text) => {
+    extractTextField(type, limit, source, pool, (err, text) => {
         if (err) cb(err);
-        frequencyDistributionMunger(text, (err, bigrams) => {
+        frequencyDistributionMunger(text, cc, (err, bigrams) => {
             if (err) cb(err);
 
             const popQ = new Queue(1);
@@ -208,7 +214,8 @@ function writeUnigram(argv, pool, bigrams, cb) {
 
     const unigramN = bigrams.unigram_fd.n();
 
-    for (const [word, frequency] of bigrams.unigram_fd.entries()) {
+    const unigrams = [...bigrams.unigram_fd.entries()].sort((a, b) => b[1] - a[1]);
+    for (const [word, frequency] of unigrams) {
         const relativeFrequency = frequency / unigramN;
         unigramCSVStream.write(
             { 'word': word,'frequency': frequency, 'relative_frequency': relativeFrequency },
@@ -251,8 +258,14 @@ function writeBigram(argv, pool, bigrams, cb) {
     const bigramWriteStream = fs.createWriteStream(bigramOutput, { encoding: 'utf8' });
     bigramCSVStream.pipe(bigramWriteStream);
 
+    const bigramsSorted = [];
     for (const score of bigrams.score_ngrams('likelihoodRatio')) {
-        bigramCSVStream.write(score, { headers: true });
+        bigramsSorted.push(score);
+    }
+    bigramsSorted.sort((a, b) => b.frequency - a.frequency);
+
+    for (const bigram of bigramsSorted) {
+        bigramCSVStream.write(bigram, { headers: true });
     }
 
     bigramCSVStream.end(null, 'utf8', () => {
@@ -277,16 +290,39 @@ function writeBigram(argv, pool, bigrams, cb) {
 }
 
 /**
+ * Delegates the retrieval of the list of names fields from either the
+ * database, or a flat file.
+ *
+ * @param {String} type - one of "network" or "address"
+ * @param {Number} limit - for dev/testing purposes, limit to this many rows
+ * @param {String} source - path to geojson file
+ * @param {Pool} pool - postgres pool object, connected to the database
+ * @param {Function} callback - callback function
+ * @returns {void}
+ */
+function extractTextField(type, limit, source, pool, callback) {
+    if (source) {
+        return extractNameFromFile(source, limit, callback);
+    } else {
+        return extractNameFromDb(type, limit, pool, callback);
+    }
+}
+
+/**
  * This method queries the appropriate table in the postgres database, returns
  * the name field for each row, passes each value through {@link formatData},
  * and calls callback on an array of the results.
  *
- * @param {string} type - one of "network" or "address"
- * @param {numeric} limit - for dev/testing purposes, limit to this many rows
+ * @param {String} type - one of "network" or "address"
+ * @param {Number} limit - for dev/testing purposes, limit to this many rows
  * @param {Pool} pool - postgres pool object, connected to the database
- * @param {function} callback - callback function
+ * @param {Function} callback - callback function
  */
-function extractTextField(type, limit, pool, callback) {
+function extractNameFromDb(type, limit, pool, callback) {
+    if (!type) {
+        console.error('--type=<type> argument required');
+        process.exit(1);
+    }
     const table = (type === 'address') ? 'address_cluster' : 'network_cluster';
     const limitClause = limit ? ' LIMIT ' + limit : '';
 
@@ -298,6 +334,33 @@ function extractTextField(type, limit, pool, callback) {
         const textFields = formatData(data.rows);
         return callback(null, textFields);
     });
+}
+
+/**
+ * Reads in a line-delimited geojson file and populates an array with the contents
+ * of all street name values.
+ *
+ * @param {String} source - path to geojson file
+ * @param {Number} limit - for dev/testing purposes, limit to this many rows
+ * @param {Function} cb - callback function
+ */
+function extractNameFromFile(source, limit, cb) {
+    const stream = fs.createReadStream(path.resolve(__dirname, source));
+    const rl = readline.createInterface({
+        input: stream
+    });
+
+    const textFields = [];
+    rl.on('line', (line) => {
+        if (!line) return;
+        if (textFields.length >= limit) rl.close();
+        const feat = JSON.parse(line);
+        if (feat && feat.properties.street) {
+            feat.properties.street.forEach((street) => textFields.push(street.display));
+        }
+    });
+    rl.on('close', () => cb(null, textFields));
+    rl.on('error', (err) => cb(err));
 }
 
 /**
@@ -328,12 +391,17 @@ function formatData(data) {
  * @param {Array<string>} textfields - An array of _text values
  * @param {function} callback - callback function
  */
-function frequencyDistributionMunger(textfields, callback) {
+function frequencyDistributionMunger(textfields, cc, callback) {
     const bigrams = new BiGramCollocationTable();
+    const context = new Context({ country: cc });
 
     for (const textField in textfields) {
-        const tokens = tokenize.main(textfields[textField]);
-        bigrams.update(tokens);
+        const tokenized = tokenize_name(textfields[textField], context);
+        tokenized.forEach((t) => {
+            if (t.token_type) matchedTokens++;
+            totalTokens++;
+        });
+        bigrams.update(tokenized.map((t) => t.token));
     }
     return callback(null, bigrams);
 }
@@ -611,7 +679,30 @@ function compareAddressAndNetwork(argv, pool, callback) {
         if (err) callback(err);
         return callback(null);
     });
+}
 
+function generateMarkdownSummary(cc, output) {
+    const bigrams = fs.readFileSync(path.resolve(output) + '-bigram.csv').toString();
+    const unigrams = fs.readFileSync(path.resolve(output) + '-unigram.csv').toString();
+
+    const markdown = `## ${cc} token matching\nmatched tokens: ${matchedTokens}\ntotal tokens: ${totalTokens}\n## ${cc} top unigrams\n${generateTable(unigrams)}\n## ${cc} top bigrams\n${generateTable(bigrams)}`;
+
+    fs.writeFileSync(path.resolve(output) + '-summary.md', markdown);
+}
+
+function generateTable(csvStr) {
+    let tableStr = '';
+    csvStr.split('\n').slice(0, 26).forEach((line) => {
+        if (tableStr === '') {
+            const split = line.split(',');
+            tableStr += split.join('|') + '\n';
+            split.forEach(() => tableStr += '---|');
+            tableStr += '\n';
+        } else {
+            tableStr = tableStr.concat(line.split(',').join('|') + '\n');
+        }
+    });
+    return tableStr;
 }
 
 module.exports = analyze;

--- a/lib/analyze/collocation.js
+++ b/lib/analyze/collocation.js
@@ -1,0 +1,771 @@
+'use strict';
+
+const ngrams = require('talisman/tokenizers/ngrams');
+
+const SMALL = 1e-20;
+
+/**
+ * FrequencyDistribution
+ */
+class FrequencyDistribution {
+
+    /**
+     * constructor
+     *
+     * @param {(Array|Map)} initial_data - used to populate frequencies on initialization
+     */
+    constructor(initial_data) {
+        this.frequencies = new Map();
+        if (initial_data) {
+            this.update(initial_data);
+        }
+        this._N = null;
+    }
+
+    /**
+     * Utility function for reliably making string hashes of non-string keys.
+     * Necessary because this.frequencies is a Map, and requires strict
+     * equality for matches. The easiest way to do this is to use strings for
+     * keys. Currently only hashes arrays.
+     *
+     * @param {(string|number|Object|Array)} k - intuitive key. objects will be stringified using JSON.stringify
+     * @returns {string} hash of the intuitive key, suitable for querying this.frequencies (which is a Map)
+     */
+    makeKey(k) {
+        let key = k;
+        if (Array.isArray(k)) {
+            key = k.join('|');
+        }
+
+        if (typeof(key) == 'string') {
+            return key;
+        } else {
+            return JSON.stringify(key);
+        }
+    }
+
+    /**
+     * Inverse of {@link FrequencyDistribution#makeKey}. Converts Map-suitable
+     * string hashes to back to intuitive keys.
+     *
+     * @param {string} key - hash of the intuitive key, suitable for querying this.frequencies (which is a Map)
+     * @returns {(string|number|Object|Array<string>)} intuitive key
+     */
+    unmakeKey(key) {
+        try {
+            // stringified objects, numbers should parse fine
+            return JSON.parse(key);
+        } catch (e) {
+            if (e instanceof SyntaxError) {
+                // if key didn't parse, it probably came in as a string
+                if (key.indexOf('|') >= 0) {
+                    // if it has a pipe, assume it should be an array
+                    return key.split('|');
+                } else {
+                    // otherwise just return
+                    return key;
+                }
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Interface to this.frequencies.entries which unhashes Map keys
+     * using {@link FrequencyDistribution#unmakeKey}
+     *
+     * @returns {Array<Array>} an array of [key, value] pairs
+     */
+    *entries() {
+        for (const [key, frequency] of this.frequencies.entries()) {
+            yield([this.unmakeKey(key), frequency]);
+        }
+    }
+
+    /**
+     * Interface to this.frequencies.keys which unhashes Map keys
+     * using {@link FrequencyDistribution#unmakeKey}
+     *
+     * @returns {Array<string>} array of keys
+     */
+    *keys() {
+        for (const [key] of this.frequencies.entries()) {
+            yield this.unmakeKey(key);
+        }
+    }
+
+    /**
+     * Utility to aggregate an array of samples into a Map of sample counts.
+     * Converts samples to Map-friendly keys with {@link FrequencyDistribution#makeKey}
+     *
+     * @param {Array<string>|Array<Array<string>>} sample_array - An array of samples to be counted
+     * @returns {Map<string, number>} aggregated counts of samples
+     */
+    arrayToCounts(sample_array) {
+        const counts = new Map();
+        for (let i = 0; i < sample_array.length; i++) {
+            const sample = sample_array[i];
+            if (!counts.has(this.makeKey(sample))) {
+                counts.set(this.makeKey(sample), 0);
+            }
+            const current_count = counts.get(this.makeKey(sample));
+            counts.set(this.makeKey(sample), current_count + 1);
+        }
+        return counts;
+    }
+
+    /**
+     * Interface to this.frequencies.has which hashes intuitive keys
+     * to Map-friendly strings using {@link FrequencyDistribution#makeKey}
+     *
+     * @param {string|Array<string>} k - Intuitive key
+     * @returns {boolean} true iff the frequency distribution contains this key
+     */
+    has(k) {
+        return this.frequencies.has(this.makeKey(k));
+    }
+
+    /**
+     * Interface to this.frequencies.get which hashes intuitive keys to strings
+     * using {@link FrequencyDistribution#makeKey}. Should not be used directly.
+     * Use {@link FrequencyDistribution#absoluteFrequency} instead.
+     *
+     * @param {string|Array<string>} k - Intuitive key
+     * @returns {number} the absolute frequency for this key
+     */
+    get(k) {
+        return this.frequencies.get(this.makeKey(k));
+    }
+
+    /**
+     * Interface to this.frequencies.set which hashes intuitive keys to
+     * Map-friendly strings using {@link FrequencyDistribution#makeKey}. Should
+     * not be used directly. Use {@link FrequencyDistribution#update} instead.
+     *
+     * @param {(string|Array<string>)} k - Intuitive key
+     * @param {number} value Frequency of k
+     */
+    set(k, value) {
+        return this.frequencies.set(this.makeKey(k), value);
+    }
+
+    /**
+     * Increment the frequency of a key by some value. Should not be used
+     * directly. Use {@link FrequencyDistribution#update} instead.
+     *
+     * @param {(string|Array<string>)} k Intuitive key
+     * @param {number} value Amount to increment frequency by
+     */
+    increment(k, value) {
+        if (!this.has(k)) {
+            this.set(k, 0);
+        }
+        const newCount = this.get(k) + value;
+        this.set(k, newCount);
+    }
+
+    /**
+     * Update the frequency distribution using either an array of samples or a
+     * frequency Map. This should be used instead of using this.set or
+     * this.increment directly. It also sets this._N to null, meaning this.N
+     * will need to be recomputed when this.N is next called.
+     *
+     * @param {(Array<string>|Array<Array<string>>|Map<string|number>)} data - An array of samples or a map from sample keys to frequencies.
+     */
+    update(data) {
+        this._N = null;
+
+        let counts;
+
+        if (Array.isArray(data)) {
+            counts = this.arrayToCounts(data);
+        }
+        else {
+            counts = data;
+        }
+
+        for (const [k, value] of counts.entries()) {
+            this.increment(k, value);
+        }
+    }
+
+    /**
+     * Gives the absolute frequency of an (intuitive) key. If the key is not
+     * in this.frequencies, returns 0
+     *
+     * @param {(string|Array<string>)} k - An intuitive key
+     * @returns {number} The absolute frequency of k, or 0 if k is not in the distribution.
+     */
+    absoluteFrequency(k) {
+        if (!this.has(k)) {
+            return 0;
+        }
+        else {
+            return this.get(k);
+        }
+    }
+
+    /**
+     * Gives the relative frequency of an (intuitive) key. Relative frequency
+     * of k is calculated as:
+     *
+     *      frequency_of_k / sum(all_frequencies)
+     *
+     * If the key is not in this.frequencies, returns 0.
+     *
+     * @param {(string|Array<string>)} k - An intuitive key
+     * @returns {number} The absolute frequency of k, or 0 if k is not in the distribution.
+     */
+    relativeFrequency(k) {
+        return this.absoluteFrequency(k) / this.n();
+    }
+
+    /**
+     * Gives N, which is the sum of all frequencies in the distribution. The
+     * property this._N is used to cache this number so that the sum need not
+     * be computed each time. Whenever update is called, this._N is set to null
+     * (and the sum must be recomputed)
+     *
+     * @returns {number} the sum of all frequency counts in the distribution
+     */
+    n() {
+        if (!this._N) {
+            let accumulator = 0;
+            for (const value of this.frequencies.values()) {
+                accumulator += value;
+            }
+            this._N = accumulator;
+        }
+        return this._N;
+    }
+
+    /**
+     * Gives the bin count (sometimes called B) of the distribution. The bin
+     * count is just the number of things that were counted, and corresponds to
+     * the number of keys in this.frequencies. Can also be thought of as the
+     * count of unique samples recorded.
+     *
+     * @returns {number} the number of bins in the distribution
+     */
+    binCount() {
+        return this.frequencies.size;
+    }
+
+}
+
+/**
+ * Base class for collocation tables. Not to be used directly. Use one of the
+ * extensions below.
+ *
+ * @see BiGramCollocationTable
+ * @see TriGramCollocationTable
+ */
+class NGramCollocationTable {
+
+    /**
+     * constructor
+     *
+     */
+    constructor() {
+        this.unigram_fd = new FrequencyDistribution();
+        this.order = 1;
+    }
+
+    /**
+     * Update collocation tables using an array of words. The array is broken
+     * into n-grams and the counts of those n-grams are added to each frequency
+     * distribution.
+     *
+     * @param {Array<string>} words - An array of words.
+     */
+    update(words) {
+        this.unigram_fd.update(ngrams(1, words));
+    }
+
+    /**
+     * Merge another NGramCollocationTable into this one. Both must have the same value for `order`.
+     *
+     * @param {NGramCollocationTable} collocationTable - another NGramCollocation table of the same order as this
+     */
+    merge(collocationTable) {
+        const orderCompatible = (this.order === collocationTable.order);
+        if (!orderCompatible) {
+            throw 'NGramCollocation tables may only merge with others of the same order';
+        }
+        this.unigram_fd.update(collocationTable.unigram_fd.frequencies);
+    }
+
+    /**
+     * Gives the {@link http://www.statisticshowto.com/expected-frequency/|Expected Frequency}
+     * values for a contingency table. Necessary for some associativity metrics.
+     *
+     * @param {Array<number>} contingency - An array whose values correspond to the values of a {@link http://www.statisticshowto.com/what-is-a-contingency-table/|Contingency Table}, read from left-to-right, top-to-bottom.
+     * @returns {Array<number>} The expected frequencies associated with the contingency table.
+     */
+    getExpectedFrequencies(contingency) {
+        /* left-shift 1 (binary 0001) by the integers 0 to this.order. For
+         * example, in a trigram case (order 3):
+         *
+         *     int   left-shifted
+         *       0           0001
+         *       1           0010
+         *       2           0100
+         */
+        const bits = [];
+        for (let x = 0; x < this.order; x++) {
+            bits.push(1 << x);
+        }
+
+        /* The contingency variable is an array that goes from top-left to
+         * bottom-right of a contingency square (or cube). For bigrams (w1,w2),
+         * it is a two-by-two table:
+         *
+         *      w1               ~w1
+         *      ---------------  ----------------
+         *  w2 | contingency[0] | contingency[1] |
+         *      ---------------  ----------------
+         * ~w2 | contingency[2] | contingency[3] |
+         *      ---------------  ----------------
+         *                                        TOTAL = n_all
+         *
+         * We want the expected frequency of each cell in that table, so we
+         * need to make 4 calculations. Informally, when you want the expected
+         * frequency of cell (x,y), you do:
+         *
+         *   expected[0] = (sum(row_x) * sum(column_y)) / (n_all)
+         *
+         * This is easy enough for a 2x2 square, but higher-order contingencies
+         * get complicated and unintuitive pretty quickly. Trigram contingency
+         * tables, for instance, are really 3x3x3 cubes, which I am not even
+         * going to try to do in ASCII art.
+         *
+         * There's a (very unintuitive) way of doing this so that it
+         * generalizes to bigger contingencies. It involves bitmasking, which
+         * takes advantage of bitwise AND (& in javascript). When you AND two
+         * equal-length binary representations, you get a 1 in the places where
+         * both have a 1, and a zero everywhere else. For example, if you
+         * calculate 5 & 3, you get 1.
+         *
+         *       decimal   bit
+         *       -------   ------
+         *       5         0101
+         *       3         0011
+         *  AND  ----------------
+         *       1         0001
+         *
+         * Bitmasking helps us iterate over the contingency, summing and
+         * multiplying using the appropriate cells for each expected frequency.
+         * (FYI: See how bits is calculated above).
+         *
+         *   expected = []
+         *   For each i in 0 ... length(contingency):
+         *     For each j in 0 ... length(bits):
+         *       For each k in (Math.pow(2, order):
+         *         if (i & bit) == (k & bit):
+         *            select k
+         *     Sum selected cells
+         *   Multiply all sums, then divide by Math.pow(n_all, order-1)
+         *   Result is added to expected[i]
+         *
+         * For example, the first iteration (i=0) for a * bigram, where
+         * bits=[1,2] and k ranges over [0,1,2,3].
+         *
+         *   i=0    bits[0]=1      k       i&bits[j]      k&bits[j]    select k?
+         *   ---    ---------      ---     ---------      ---------    ------
+         *   0000   0001           0000    0000           0000         yes
+         *   0000   0001           0001    0000           0001         no
+         *   0000   0001           0010    0000           0000         yes
+         *   0000   0001           0011    0001           0000         no
+         *
+         * So the first sum is (contingency[0] + contingency[2]). Next bit:
+         *
+         *   i=0    bits[1]=2      k       i&bits[j]      k&bits[j]    select k?
+         *   ---    ---------      ---     ---------      ---------    ------
+         *   0000   0010           0000    0000           0000         yes
+         *   0000   0010           0001    0000           0000         yes
+         *   0000   0010           0010    0000           0010         no
+         *   0000   0010           0011    0000           0010         no
+         *
+         * So the second sum is (contingency[0] + contingency[1]).
+         *
+         * Then these two sums are reduced by multiplication and divided by the
+         * sum of all cells raised to the power (this.order - 1).  That is the
+         * expected frequency for cell 0.
+         *
+         *  expected[0] = ((cont[0] + cont[2]) * (cont[0] * cont[1])) / Math.pow(n_all, (2 - 1))
+         *
+         * Repeat those same steps for the other 4 cells of the contingency table.
+         *
+         *  expected[1] = ((cont[1] + cont[3]) * (cont[0] + cont[1])) / Math.pow(n_all, (2 - 1))
+         *  expected[2] = ((cont[0] + cont[2]) * (cont[2] + cont[3])) / Math.pow(n_all, (2 - 1))
+         *  expected[3] = ((cont[1] + cont[3]) * (cont[2] + cont[3])) / Math.pow(n_all, (2 - 1))
+         *
+         */
+
+        const n_all = contingency.reduce((a,b) => { return a + b; }, 0);
+        const expectedFrequencies = [];
+        let productOfSums;
+
+        for (let i = 0; i < contingency.length; i++) {
+            const sums = [];
+            for (let j = 0; j < bits.length; j++) {
+                const bit = bits[j];
+                const selected_cells = [];
+                for (let k = 0; k < Math.pow(2, this.order); k++) {
+                    if ((k & bit) === (i & bit)) {
+                        selected_cells.push(contingency[k]);
+                    }
+                }
+                const sum = selected_cells.reduce((a,b) => {
+                    return a + b;
+                }, 0);
+                sums.push(sum);
+            }
+            productOfSums = sums.reduce((a, b) => {
+                return a * b;
+            }, 1);
+
+            const denom = Math.pow(n_all, (this.order - 1));
+            const expectedFrequency = productOfSums / denom;
+            expectedFrequencies.push(expectedFrequency);
+        }
+
+        return expectedFrequencies;
+    }
+
+    /**
+     * Return the score of a single ngram, given by a specified metric.
+     *
+     * @param {string} metric_name - the name of an associativity metric.
+     * @param {Array<string>} ngram - An array representing an ngram.
+     * @returns {number} the score as predicted by the function this[score_name]
+     */
+    score_ngram(metric_name, ngram) {
+        return this[metric_name](ngram);
+    }
+
+    /**
+     * Scores ngrams using likelihood ratios as in Manning and Schutze's
+     * "Foundations of Statistical Natural Language Processing" (sec 5.3.4).
+     * This explanation uses bigrams because it's easier to understand, but the
+     * metric generalizes to any order.
+     *
+     * Theoretically, it uses two probabilities:
+     *
+     *     P(w2|w1): the probability that word 2 will follow word 1
+     *     P(w2|¬w1): the probability that word 2 will follow any other word (not word 1)
+     *
+     * And it compares two hypotheses:
+     *
+     *     H1: P(w2|w1) == P(w2|¬w1)
+     *     H2: P(w2|w1) != P(w2|¬w1)
+     *
+     * Then, assuming a binomial distribution, it finds the likelihood of each
+     * hypothesis. The log of the ratio between these likelihoods is the score
+     *
+     *     likelihoodRatio = log(likelihood(H1) / likelihood(H2))
+     *
+     * Practically, this function goes cell by cell in the contingency table,
+     * finding the likelihood of its value given the value of the corresponding
+     * cell in the expectedFrequencies table. It then sums these likelihoods
+     * and multiplies them by the order of the collocation table itself.
+     *
+     * @param {Array<string>} ngram - An array representing a single ngram
+     * @returns {number} The likelihood ratio for a single ngram
+     */
+    likelihoodRatio(ngram) {
+        const contingency = this.getContingency(ngram);
+        const expectedFrequencies = this.getExpectedFrequencies(contingency);
+
+        const likelihoods = [];
+        for (let i = 0; i < contingency.length; i++) {
+            const observed = contingency[i];
+            const expected = expectedFrequencies[i];
+            const likelihood = observed * Math.log((observed / (expected + SMALL)) + SMALL);
+            likelihoods.push(likelihood);
+        }
+        const sumLikelihoods = likelihoods.reduce((a,b) => {
+            return a + b;
+        }, 0);
+        return this.order * sumLikelihoods;
+    }
+
+}
+
+/**
+ * Collocation table for bigram (2-word) samples.
+ *
+ * @extends {NGramCollocationTable}
+ */
+class BiGramCollocationTable extends NGramCollocationTable {
+
+    /**
+     * constructor
+     *
+     */
+    constructor() {
+        super();
+        this.bigram_fd = new FrequencyDistribution();
+        this.order = 2;
+    }
+
+    /**
+     * Update collocation tables using an array of words. The array is broken
+     * into 1-grams, and the counts are added to the unigram frequency
+     * distribution. Then the array is broken into 2-grams and the counts of
+     * those are added to the bigram frequency distribution.
+     *
+     * @param {Array<string>} words - An array of words.
+     */
+    update(words) {
+        super.update(words);
+        this.bigram_fd.update(ngrams(2, words));
+    }
+
+    /**
+     * Merge another BiGramCollocationTable into this one.
+     *
+     * @param {BiGramCollocationTable} collocationTable - another BiGramCollocation table.
+     */
+    merge(collocationTable) {
+        super.merge(collocationTable);
+        this.bigram_fd.update(collocationTable.bigram_fd.frequencies);
+    }
+
+    /**
+     * Build a 2x2 contingency table for a given bigram. There are some
+     * strange-looking variables here, but they follow a pattern.  The first
+     * part, "n_" means "frequency of". The second part is made up of two
+     * characters, visually depicting the positions in the bigram.
+     *
+     *   i: "word at this position"
+     *   x: "anything at this position"
+     *   o: "not(word) at this position"
+     *
+     * For example, n_ix means "frequency of word in first position followed by
+     * anything" (which is the same as the frequency of that word overall.
+     * Compare that with n_io: "frequency of word in first position followed by
+     * any word other than the word in second position". Concretely, for "big
+     * kahuna":
+     *
+     *     n_ii:  frequency of ["big", "kahuna"]
+     *     n_ix:  frequency of ["big", *],  or frequency of "big"
+     *     n_io:  frequency of ["big", not("kahuna")]
+     *
+     * The table produced can be shown visually as:
+     *
+     *        w1     ¬w1
+     *        ------ ------
+     *    w2 | n_ii | n_oi |
+     *        ------ ------
+     *   ¬w2 | n_io | n_oo |
+     *        ------ ------
+     *
+     * It is returned as a single flat array, going from top-left to bottom-right:
+     *
+     *        w1              ¬w1
+     *        ---------------- ----------------
+     *    w2 | contingency[0] | contingency[1] |
+     *        ---------------- ----------------
+     *   ¬w2 | contingency[2] | contingency[3] |
+     *        ---------------- ----------------
+     *
+     * @param {Array<string>} ngram - A length-2 array of words.
+     * @returns {Array<number>} A length-4 array of contingency counts
+     */
+    getContingency(ngram) {
+        // Get the total of all unigram freqencies.
+        const n_all = this.unigram_fd.n();
+
+        // Step 1: Get component frequencies
+        const n_ii = this.bigram_fd.absoluteFrequency(ngram); // freq of (w1, w2)
+        const n_ix = this.unigram_fd.absoluteFrequency(ngram[0]); // freq of w1
+        const n_xi = this.unigram_fd.absoluteFrequency(ngram[1]); // freq of w2
+
+        // Step 2: derive contingencies
+        const n_io = n_ix - n_ii; // freq of (w1, ¬w2)
+        const n_oi = n_xi - n_ii; // freq of (¬w1, w2)
+        const n_oo = n_all - n_ii - n_oi - n_io; // freq of (¬w1, ¬w2)
+
+        // Step 3: build contingency table
+        const contingency = [n_ii, n_oi, n_io, n_oo];
+        return contingency;
+    }
+
+    /**
+     * Returns an array of scored ngrams according to a specified metric. The
+     * objects in the array look like:
+     *
+     *   {
+     *     w1: string
+     *     w2: string
+     *     frequency: number
+     *     <metric_name>: number
+     *   }
+     *
+     * @param {string} metric_name - The name of the metric to be used
+     * @returns {Array<Object>} An array of objects representing frequencies and scores
+     **/
+    *score_ngrams(metric_name) {
+        for (const [bigram, frequency] of this.bigram_fd.entries()) {
+            const score = {};
+            score.w1 = bigram[0];
+            score.w2 = bigram[1];
+            score.frequency = frequency;
+            score[metric_name] = this.score_ngram(metric_name, bigram);
+            yield score;
+        }
+    }
+
+}
+
+/**
+ * Collocation table for trigram (3-word) samples.
+ *
+ * @extends {BiGramCollocationTable}
+ */
+class TriGramCollocationTable extends BiGramCollocationTable {
+
+    /**
+     * constructor
+     *
+     */
+    constructor() {
+        super();
+        this.trigram_fd = new FrequencyDistribution();
+        this.wildcard_fd = new FrequencyDistribution();
+        this.order = 3;
+    }
+
+    /**
+     * Update collocation tables using an array of words. The array is broken
+     * into 1-grams, and the counts are added to the unigram frequency
+     * distribution. Then the array is broken into 2-grams and the counts of
+     * those are added to the bigram frequency distribution. Then the array is
+     * broken into 3-grams and the counts of those are added to the trigram
+     * frequency distribution.
+     *
+     * In addition, each trigram's first and third members are added to the
+     * wildcard frequency distribution, which represents counts of (w1, *, w3).
+     *
+     * @param {Array<string>} words - An array of words.
+     */
+    update(words) {
+        super.update(words);
+        const trigrams = ngrams(3,words);
+        this.trigram_fd.update(trigrams);
+
+        const wildcards = [];
+
+        for (let i = 0; i < trigrams.length; i++) {
+            wildcards.push([trigrams[i][0], trigrams[i][2]]);
+        }
+        this.wildcard_fd.update(wildcards);
+    }
+
+    /**
+     * Merge another TriGramCollocationTable into this one.
+     *
+     * @param {TriGramCollocationTable} collocationTable - another trigram collocation table
+     */
+    merge(collocationTable) {
+        super.merge(collocationTable);
+        this.trigram_fd.update(collocationTable.trigram_fd.frequencies);
+        this.wildcard_fd.update(collocationTable.wildcard_fd.frequencies);
+    }
+
+    /**
+     * Build a 2x2x2 contingency "cube" for a given trigram. This is analogous
+     * to the {@link BiGramCollocationTable#getContingency} method, but for 3
+     * variables. More detail about the intuitions can be found there.
+     *
+     * The cube is more difficult to visualize but can be thought of as two
+     * tables:
+     *
+     *    | w3                     |  ¬w3
+     *    | --------------------   |  --------------------
+     *    |      w1      ¬w1       |       w1      ¬w1
+     *    |      ------- -------   |       ------- -------
+     *    |  w2 | n_iii | n_oii |  |   w2 | n_iio | n_oio |
+     *    |      ------- -------   |       ------- -------
+     *    | ¬w2 | n_ioi | n_ooi |  |  ¬w2 | n_ioo | n_ooo |
+     *    |      ------- -------   |       ------- -------
+     *
+     * It is returned as a single flat array, going from left-top-left to
+     * right-bottom-right:
+     *
+     *    | w3                          | ¬w3
+     *    | -------------------------   | --------------------------
+     *    |      w1      ¬w1            |       w1        ¬w1
+     *    |      --------- ---------    |       --------- ---------
+     *    |  w2 | cont[0] | cont[1] |   |   w2 | cont[4] | cont[5] |
+     *    |      --------- ---------    |       --------- ---------
+     *    | ¬w2 | cont[2] | cont[3] |   |  ¬w2 | cont[6] | cont[7] |
+     *    |      --------- ---------    |       --------- ---------
+     *
+     * @param {Array<string>} ngram - array of length 3 that represents a trigram
+     * @returns {Array<number>} A length-8 array of contingency counts
+     */
+    getContingency(ngram) {
+        const n_xxx = this.unigram_fd.n();
+
+        // Step 1: Get component frequencies
+        const n_iii = this.trigram_fd.absoluteFrequency(ngram); // freq of (w1, w2, w3)
+
+        const n_iix = this.bigram_fd.absoluteFrequency([ngram[0], ngram[1]]); // freq of (w1, w2,  *)
+        const n_ixi = this.wildcard_fd.absoluteFrequency([ngram[0], ngram[2]]); // freq of (w1,  *, w3)
+        const n_xii = this.bigram_fd.absoluteFrequency([ngram[1], ngram[2]]); // freq of (*,  w2, w3)
+
+        const n_ixx = this.unigram_fd.absoluteFrequency(ngram[0]); // freq of w1
+        const n_xix = this.unigram_fd.absoluteFrequency(ngram[1]); // freq of w2
+        const n_xxi = this.unigram_fd.absoluteFrequency(ngram[2]); // freq of w3
+
+        // Step 2: derive contingencies
+        const n_oii = n_xii - n_iii; // freq of (¬w1,  w2,  w3)
+        const n_ioi = n_ixi - n_iii; // freq of ( w1, ¬w2,  w3)
+        const n_iio = n_iix - n_iii; // freq of ( w1,  w2, ¬w3)
+        const n_ooi = n_xxi - n_iii - n_oii - n_ioi; // freq of (¬w1, ¬w2,  w3)
+        const n_oio = n_xix - n_iii - n_oii - n_iio; // freq of (¬w1,  w2, ¬w3)
+        const n_ioo = n_ixx - n_iii - n_ioi - n_iio; // freq of ( w1, ¬w2, ¬w3)
+        const n_ooo = n_xxx - n_iii - n_oii - n_ioi - n_iio - n_ooi - n_oio - n_ioo; // freq of (¬w1, ¬w2, ¬w3)
+
+        const contingency = [n_iii, n_oii, n_ioi, n_ooi,
+            n_iio, n_oio, n_ioo, n_ooo];
+        return contingency;
+    }
+
+    /**
+     * Returns an array of scored ngrams according to a specified metric. The
+     * objects in the array look like:
+     *
+     *   {
+     *     w1: string
+     *     w2: string
+     *     w3: string
+     *     frequency: number
+     *     <metric_name>: number
+     *   }
+     *
+     * @param {string} metric_name - The name of the metric to be used
+     * @returns {Array<Object>} An array of objects representing frequencies and scores
+     **/
+    *score_ngrams(metric_name) {
+        for (const [trigram, frequency] of this.trigram_fd.entries()) {
+            const score = {};
+            score.w1 = trigram[0];
+            score.w2 = trigram[1];
+            score.w3 = trigram[2];
+            score.frequency = frequency;
+            score[metric_name] = this.score_ngram(metric_name, trigram);
+            yield score;
+        }
+    }
+
+}
+
+module.exports = {
+    FrequencyDistribution: FrequencyDistribution,
+    BiGramCollocationTable: BiGramCollocationTable,
+    TriGramCollocationTable: TriGramCollocationTable
+};

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -59,6 +59,8 @@ register_module!(mut m, {
 
     m.export_function("dedupe_syn", map::dedupe_syn)?;
 
+    m.export_function("tokenize_name", text::tokenize_name)?;
+
     m.export_function("classify", classify::classify)?;
     m.export_function("conflate", conflate::conflate)?;
     m.export_function("convert", convert::convert)?;

--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -12,7 +12,7 @@ mod titlecase;
 
 pub use self::diacritics::diacritics;
 pub use self::titlecase::titlecase;
-pub use self::tokens::{Tokens, Tokenized, ParsedToken};
+pub use self::tokens::{Tokens, Tokenized, ParsedToken, tokenize_name};
 
 use std::collections::HashMap;
 use regex::{Regex, RegexSet};

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -2,6 +2,7 @@ use regex::Regex;
 use super::diacritics;
 use std::collections::HashMap;
 use geocoder_abbreviations::{Token, TokenType};
+use neon::prelude::*;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Tokens {
@@ -169,6 +170,17 @@ pub fn type_us_st(tokens: &Vec<String>, mut tokenized: Vec<Tokenized>) -> Vec<To
         }
     }
     tokenized
+}
+
+pub fn tokenize_name(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let name = cx.argument::<JsString>(0)?.value();
+    let context = cx.argument::<JsValue>(1)?;
+    let context: crate::types::InputContext = neon_serde::from_value(&mut cx, context)?;
+    let context = crate::Context::from(context);
+    
+    let tokenized = context.tokens.process(&name, &context.country);
+
+    Ok(neon_serde::to_value(&mut cx, &tokenized)?)
 }
 
 #[cfg(test)]

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/tilebelt": "^1.0.1",
     "@turf/turf": "^5.1.0",
-    "csv-stringify": "^5.0.0",
     "d3-queue": "^3.0.7",
     "diacritics": "^1.3.0",
     "eslint-plugin-node": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2227,13 +2227,6 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-csv-stringify@^5.0.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-5.3.0.tgz#ff2dfafa6fcccd455ff5039be9c202475aa3bbe0"
-  integrity sha512-VMYPbE8zWz475smwqb9VbX9cj0y4J0PBl59UdcqzLkzXHZZ8dh4Rmbb0ZywsWEtUml4A96Hn7Q5MW9ppVghYzg==
-  dependencies:
-    lodash.get "~4.4.2"
-
 cuid@^2.1.1:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/cuid/-/cuid-2.1.6.tgz#dc3a20b5a7497d36d32c0bf8a2997524c9c796c4"
@@ -3692,11 +3685,6 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
-
-lodash.get@~4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.includes@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
This PR brings back the old `analyze` mode meant to run stats on common names within a set of address/network data.

#### Next steps

- [x] Extend module to accept raw geojsonld sources.
- [x] Create visual output report.
- [x] Migrate to rust-based tokenize module

cc @ilissablech @mapbox-danny 