### PR TITLE
Pass in the country to conflate

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,8 +100,9 @@ if (require.main === module) {
             break;
         }
         case ('conflate'): {
+
             const conflate_arg = require('minimist')(process.argv, Context.args({
-                string: ['in_persistent', 'in_address', 'output', 'languages', 'db'],
+                string: ['in_persistent', 'in_address', 'output', 'languages', 'db', 'country'],
                 boolean: ['hecate'],
                 alias: {
                     database: 'db',
@@ -122,7 +123,8 @@ if (require.main === module) {
                 languages: conflate_arg.languages,
                 hecate: conflate_arg.hecate,
                 context: new Context(conflate_arg).as_json(),
-                db: conflate_arg.db
+                db: conflate_arg.db,
+                country: conflate_arg.country
             });
 
             break;

--- a/lib/map.js
+++ b/lib/map.js
@@ -150,7 +150,7 @@ function main(argv, cb) {
      */
     function matcher() {
         console.time('ok - cross matched data');
-        link_addr(argv.db);
+        link_addr(argv.db, context);
         console.timeEnd('ok - cross matched data');
 
         console.time('ok - clustered addresses');

--- a/native/src/conflate/mod.rs
+++ b/native/src/conflate/mod.rs
@@ -81,7 +81,7 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     };
 
     println!("Country: {}", args.country);
-    let mut is_us =  args.country == "us";
+    let is_us =  args.country == "us";
 
     let conn = Connection::connect(format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(), TlsMode::None).unwrap();
 

--- a/native/src/conflate/mod.rs
+++ b/native/src/conflate/mod.rs
@@ -35,7 +35,7 @@ impl ConflateArgs {
     pub fn new() -> Self {
         ConflateArgs {
             db: String::from("conflate"),
-            country: None,
+            country: String::from("us"),
             context: None,
             in_address: None,
             in_persistent: None,
@@ -81,7 +81,7 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     };
 
     println!("Country: {}", args.country);
-    bool is_us = args.country == "us";
+    let bool is_us =  args.country == "us";
 
     let conn = Connection::connect(format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(), TlsMode::None).unwrap();
 

--- a/native/src/conflate/mod.rs
+++ b/native/src/conflate/mod.rs
@@ -81,7 +81,7 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     };
 
     println!("Country: {}", args.country);
-    let bool is_us =  args.country == "us";
+    let mut is_us =  args.country == "us";
 
     let conn = Connection::connect(format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(), TlsMode::None).unwrap();
 

--- a/native/src/map/mod.rs
+++ b/native/src/map/mod.rs
@@ -361,7 +361,7 @@ pub fn link_process(conn: &impl postgres::GenericConnection, min: i64, max: i64)
                     linker::Link::new(potential.id, &potential.names)
                 }).collect();
 
-                match linker::linker(primary, potentials, false) {
+                match linker::linker(primary, potentials, false, true) {
                     Some(link_match) => {
                         match trans.execute(&*"
                             UPDATE address SET netid = $1 WHERE id = $2;

--- a/native/src/map/mod.rs
+++ b/native/src/map/mod.rs
@@ -366,7 +366,7 @@ pub fn link_process(conn: &impl postgres::GenericConnection, min: i64, max: i64,
                     linker::Link::new(potential.id, &potential.names)
                 }).collect();
 
-                match linker::linker(primary, potentials, false, true) {
+                match linker::linker(primary, potentials, false, context) {
                     Some(link_match) => {
                         match trans.execute(&*"
                             UPDATE address SET netid = $1 WHERE id = $2;

--- a/native/src/map/mod.rs
+++ b/native/src/map/mod.rs
@@ -218,6 +218,11 @@ pub fn link_addr(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         }
     };
 
+    let context = match args.context {
+        Some(context) => CrateContext::from(context),
+        None => CrateContext::new(String::from(""), None, Tokens::new(HashMap::new()))
+    };
+
     let count = pg::Address::new().max(&conn);
 
     let cpus = num_cpus::get() as i64;
@@ -247,7 +252,7 @@ pub fn link_addr(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
             let mut it = min_id;
             while it < max_id {
-                link_process(&conn, it, it + 5000);
+                link_process(&conn, it, it + 5000, context);
                 it += 5001;
             }
         }) {
@@ -290,7 +295,7 @@ pub struct DbType {
     names: Names
 }
 
-pub fn link_process(conn: &impl postgres::GenericConnection, min: i64, max: i64) {
+pub fn link_process(conn: &impl postgres::GenericConnection, min: i64, max: i64, context: Context) {
     match conn.query("
         SELECT
             a.id AS id,

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -616,7 +616,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("Main Street", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));
+            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -624,7 +624,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("St Peter St", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));
+            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -633,7 +633,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 93.75)));
+            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 93.75)));
         }
 
         {
@@ -642,7 +642,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 90.0)));
+            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 90.0)));
         }
 
         {
@@ -651,7 +651,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 86.36)));
+            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 86.36)));
         }
 
         {
@@ -660,7 +660,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 86.36)));
+            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 86.36)));
         }
 
         {
@@ -669,7 +669,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 90.0)));
+            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 90.0)));
         }
 
         {
@@ -678,7 +678,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name1)];
-            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 85.71)));
+            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 85.71)));
         }
 
         {
@@ -687,7 +687,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 80.77)));
+            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 80.77)));
         }
 
         {
@@ -696,7 +696,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 78.57)));
+            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 78.57)));
         }
 
         // === Intentional Strict Non-Matches ===
@@ -706,7 +706,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("US Route 50 West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), None);
+            assert_eq!(linker(a, b, true, true), None);
         }
 
         {
@@ -714,7 +714,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("West Saint Street", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), None);
+            assert_eq!(linker(a, b, true, true), None);
         }
 
         {
@@ -723,7 +723,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), None);
+            assert_eq!(linker(a, b, true, true), None);
         }
 
         {
@@ -732,7 +732,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), None);
+            assert_eq!(linker(a, b, true, true), None);
         }
 
         {
@@ -741,7 +741,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), None);
+            assert_eq!(linker(a, b, true, true), None);
         }
 
         {
@@ -750,7 +750,16 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), None);
+            assert_eq!(linker(a, b, true, true), None);
+        }
+
+        {
+            let a_name = Names::new(vec![Name::new("Street De Prim", 0, None, &context)], &context);
+            let b_name = Names::new(vec![Name::new("Street Prim", 0, None, &context)], &context);
+
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq(linker(a, b, true, false), None);
         }
 
     }

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -113,12 +113,19 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool, is_us: boo
                 // Don't bother considering if the tokenless forms don't share a starting letter
                 // this might require adjustment for countries with addresses that have leading tokens
                 // which aren't properly stripped from the token list
-                if is_us {
-                    if potential_tokenless.len() > 0 && tokenless.len() > 0 && potential_tokenless.get(0..1) != tokenless.get(0..1) {
-                        continue;
-                    }
-                }
 
+                // if is_us {
+                //     if potential_tokenless.len() > 0 && tokenless.len() > 0 && potential_tokenless.get(0..1) != tokenless.get(0..1) {
+                //        continue;
+                //     }
+                // }
+
+                if is_us {
+                    println!("in the us";
+                } else {
+                    println!("not in the us";
+                }
+                
                 // Don't bother considering if both addr and network are a numbered street that
                 // doesn't match (1st != 11th)
                 let name_numbered = is_numbered(name);

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -338,7 +338,7 @@ mod tests {
                 Link::new(42, &b_name41),
                 Link::new(43, &b_name42)
             ];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(14, 100.0)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(14, 100.0)));
         }
 
         /*
@@ -366,7 +366,7 @@ mod tests {
                 Link::new(2, &b_1_name),
                 Link::new(3, &b_2_name)
             ];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 100.0)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -374,7 +374,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("Main Street", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 100.0)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -382,7 +382,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("St Peter St", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 100.0)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -390,7 +390,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("Maim Street", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 85.71)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 85.71)));
         }
 
         {
@@ -398,7 +398,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("US Route 50 West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 98.08)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 98.08)));
         }
 
         {
@@ -406,7 +406,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("11th Avenue West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 92.11)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 92.11)));
         }
 
         {
@@ -424,7 +424,7 @@ mod tests {
                 Link::new(4, &b_name3),
                 Link::new(5, &b_name4)
             ];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 100.0)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -442,7 +442,7 @@ mod tests {
                 Link::new(4, &b_name3),
                 Link::new(5, &b_name4)
             ];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 100.0)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -456,7 +456,7 @@ mod tests {
                 Link::new(2, &b_name1),
                 Link::new(3, &b_name2)
             ];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 80.0)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 80.0)));
         }
 
         {
@@ -470,7 +470,7 @@ mod tests {
                 Link::new(2, &b_name1),
                 Link::new(3, &b_name2)
             ];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 77.78)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 77.78)));
         }
 
         {
@@ -486,7 +486,7 @@ mod tests {
                 Link::new(3, &b_name2),
                 Link::new(4, &b_name3)
             ];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 77.78)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 77.78)));
         }
 
         {
@@ -502,7 +502,7 @@ mod tests {
                 Link::new(3, &b_name2),
                 Link::new(4, &b_name3)
             ];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(4, 100.0)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(4, 100.0)));
         }
 
         {
@@ -511,7 +511,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 85.71)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 85.71)));
         }
 
         {
@@ -527,7 +527,7 @@ mod tests {
                 Link::new(3, &b_name2),
                 Link::new(4, &b_name3)
             ];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 85.71)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 85.71)));
         }
 
         {
@@ -545,7 +545,7 @@ mod tests {
                 Link::new(4, &b_name3),
                 Link::new(5, &b_name4)
             ];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(3, 100.0)));
+            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(3, 100.0)));
         }
 
         // === Intentional Non-Matches ===
@@ -556,7 +556,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("2nd Street West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), None);
+            assert_eq!(linker(a, b, false, true), None);
         }
 
         {
@@ -564,7 +564,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("3rd Street West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), None);
+            assert_eq!(linker(a, b, false, true), None);
         }
 
         {
@@ -572,7 +572,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("4th Street West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), None);
+            assert_eq!(linker(a, b, false, true), None);
         }
 
         {
@@ -580,7 +580,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("21st Street West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), None);
+            assert_eq!(linker(a, b, false, true), None);
         }
 
         {
@@ -588,7 +588,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("US Route 51 West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), None);
+            assert_eq!(linker(a, b, false, true), None);
         }
 
         {
@@ -596,7 +596,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("West Saint Street", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), None);
+            assert_eq!(linker(a, b, false, true), None);
         }
 
         {
@@ -604,7 +604,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("Anne Boulevard", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), None);
+            assert_eq!(linker(a, b, false, true), None);
         }
 
         // === Intentional Strict Matches ===

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -761,7 +761,7 @@ mod tests {
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, true, false), None);
-            println!("context:{}", context);
+            println!("context:{}", context.country);
         }
 
     }

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -757,9 +757,11 @@ mod tests {
             let a_name = Names::new(vec![Name::new("Street De Prim", 0, None, &context)], &context);
             let b_name = Names::new(vec![Name::new("Street Prim", 0, None, &context)], &context);
 
+            
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, true, false), None);
+            println!("context:{}", context);
         }
 
     }

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -63,7 +63,7 @@ impl LinkResult {
 /// being matched with a slightly less desirable match, usually due to data
 /// reasons.
 ///
-pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<LinkResult> {
+pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool, is_us: bool) -> Option<LinkResult> {
     for name in &primary.names.names {
         let tokenized = name.tokenized_string();
         let tokenless = name.tokenless_string();
@@ -113,8 +113,10 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                 // Don't bother considering if the tokenless forms don't share a starting letter
                 // this might require adjustment for countries with addresses that have leading tokens
                 // which aren't properly stripped from the token list
-                if potential_tokenless.len() > 0 && tokenless.len() > 0 && potential_tokenless.get(0..1) != tokenless.get(0..1) {
-                    continue;
+                if is_us {
+                    if potential_tokenless.len() > 0 && tokenless.len() > 0 && potential_tokenless.get(0..1) != tokenless.get(0..1) {
+                        continue;
+                    }
                 }
 
                 // Don't bother considering if both addr and network are a numbered street that

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -759,7 +759,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq(linker(a, b, true, false), None);
+            assert_eq!(linker(a, b, true, false), None);
         }
 
     }

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -5,7 +5,7 @@ use crate::text::{
 };
 
 use crate::types::Names;
-use crate::types::Context;
+use crate::Context;
 use geocoder_abbreviations::TokenType;
 
 #[derive(Debug)]

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -5,6 +5,7 @@ use crate::text::{
 };
 
 use crate::types::Names;
+use crate::types::Context;
 use geocoder_abbreviations::TokenType;
 
 #[derive(Debug)]
@@ -63,7 +64,7 @@ impl LinkResult {
 /// being matched with a slightly less desirable match, usually due to data
 /// reasons.
 ///
-pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool, is_us: bool) -> Option<LinkResult> {
+pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool, context: Context) -> Option<LinkResult> {
     for name in &primary.names.names {
         let tokenized = name.tokenized_string();
         let tokenless = name.tokenless_string();
@@ -120,7 +121,9 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool, is_us: boo
                 //     }
                 // }
 
-                if is_us {
+                println!("{:?}", context);
+
+                if context.country == "US" {
                     println!("in the us";
                 } else {
                     println!("not in the us";
@@ -251,6 +254,7 @@ mod tests {
         tokens.insert(String::from("e"), ParsedToken::new(String::from("e"), Some(TokenType::Cardinal)));
 
         let context = Context::new(String::from("us"), None, Tokens::new(tokens));
+        let context_eu = Context::new(String::from("be"), None, Tokens::new(tokens));
 
         // === Intentional Matches ===
         // The following tests should match one of the given potential matches
@@ -345,7 +349,7 @@ mod tests {
                 Link::new(42, &b_name41),
                 Link::new(43, &b_name42)
             ];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(14, 100.0)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(14, 100.0)));
         }
 
         /*
@@ -373,7 +377,7 @@ mod tests {
                 Link::new(2, &b_1_name),
                 Link::new(3, &b_2_name)
             ];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 100.0)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -381,7 +385,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("Main Street", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 100.0)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -389,7 +393,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("St Peter St", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 100.0)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -397,7 +401,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("Maim Street", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 85.71)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(2, 85.71)));
         }
 
         {
@@ -405,7 +409,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("US Route 50 West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 98.08)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(2, 98.08)));
         }
 
         {
@@ -413,7 +417,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("11th Avenue West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 92.11)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(2, 92.11)));
         }
 
         {
@@ -431,7 +435,7 @@ mod tests {
                 Link::new(4, &b_name3),
                 Link::new(5, &b_name4)
             ];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 100.0)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -449,7 +453,7 @@ mod tests {
                 Link::new(4, &b_name3),
                 Link::new(5, &b_name4)
             ];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 100.0)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -463,7 +467,7 @@ mod tests {
                 Link::new(2, &b_name1),
                 Link::new(3, &b_name2)
             ];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 80.0)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(2, 80.0)));
         }
 
         {
@@ -477,7 +481,7 @@ mod tests {
                 Link::new(2, &b_name1),
                 Link::new(3, &b_name2)
             ];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 77.78)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(2, 77.78)));
         }
 
         {
@@ -493,7 +497,7 @@ mod tests {
                 Link::new(3, &b_name2),
                 Link::new(4, &b_name3)
             ];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 77.78)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(2, 77.78)));
         }
 
         {
@@ -509,7 +513,7 @@ mod tests {
                 Link::new(3, &b_name2),
                 Link::new(4, &b_name3)
             ];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(4, 100.0)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(4, 100.0)));
         }
 
         {
@@ -518,7 +522,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 85.71)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(2, 85.71)));
         }
 
         {
@@ -534,7 +538,7 @@ mod tests {
                 Link::new(3, &b_name2),
                 Link::new(4, &b_name3)
             ];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(2, 85.71)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(2, 85.71)));
         }
 
         {
@@ -552,7 +556,7 @@ mod tests {
                 Link::new(4, &b_name3),
                 Link::new(5, &b_name4)
             ];
-            assert_eq!(linker(a, b, false, true), Some(LinkResult::new(3, 100.0)));
+            assert_eq!(linker(a, b, false, context), Some(LinkResult::new(3, 100.0)));
         }
 
         // === Intentional Non-Matches ===
@@ -563,7 +567,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("2nd Street West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false, true), None);
+            assert_eq!(linker(a, b, false, context), None);
         }
 
         {
@@ -571,7 +575,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("3rd Street West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false, true), None);
+            assert_eq!(linker(a, b, false, context), None);
         }
 
         {
@@ -579,7 +583,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("4th Street West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false, true), None);
+            assert_eq!(linker(a, b, false, context), None);
         }
 
         {
@@ -587,7 +591,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("21st Street West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false, true), None);
+            assert_eq!(linker(a, b, false, context), None);
         }
 
         {
@@ -595,7 +599,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("US Route 51 West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false, true), None);
+            assert_eq!(linker(a, b, false, context), None);
         }
 
         {
@@ -603,7 +607,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("West Saint Street", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false, true), None);
+            assert_eq!(linker(a, b, false, context), None);
         }
 
         {
@@ -611,7 +615,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("Anne Boulevard", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false, true), None);
+            assert_eq!(linker(a, b, false, context), None);
         }
 
         // === Intentional Strict Matches ===
@@ -623,7 +627,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("Main Street", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 100.0)));
+            assert_eq!(linker(a, b, true, context), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -631,7 +635,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("St Peter St", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 100.0)));
+            assert_eq!(linker(a, b, true, context), Some(LinkResult::new(2, 100.0)));
         }
 
         {
@@ -640,7 +644,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 93.75)));
+            assert_eq!(linker(a, b, true, context), Some(LinkResult::new(2, 93.75)));
         }
 
         {
@@ -649,7 +653,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 90.0)));
+            assert_eq!(linker(a, b, true, context), Some(LinkResult::new(2, 90.0)));
         }
 
         {
@@ -658,7 +662,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 86.36)));
+            assert_eq!(linker(a, b, true, context), Some(LinkResult::new(2, 86.36)));
         }
 
         {
@@ -667,7 +671,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 86.36)));
+            assert_eq!(linker(a, b, true, context), Some(LinkResult::new(2, 86.36)));
         }
 
         {
@@ -676,7 +680,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 90.0)));
+            assert_eq!(linker(a, b, true, context), Some(LinkResult::new(2, 90.0)));
         }
 
         {
@@ -685,7 +689,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name1)];
-            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 85.71)));
+            assert_eq!(linker(a, b, true, context), Some(LinkResult::new(2, 85.71)));
         }
 
         {
@@ -694,7 +698,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 80.77)));
+            assert_eq!(linker(a, b, true, context), Some(LinkResult::new(2, 80.77)));
         }
 
         {
@@ -703,7 +707,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, true), Some(LinkResult::new(2, 78.57)));
+            assert_eq!(linker(a, b, true, context), Some(LinkResult::new(2, 78.57)));
         }
 
         // === Intentional Strict Non-Matches ===
@@ -713,7 +717,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("US Route 50 West", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, true), None);
+            assert_eq!(linker(a, b, true, context), None);
         }
 
         {
@@ -721,7 +725,7 @@ mod tests {
             let b_name = Names::new(vec![Name::new("West Saint Street", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, true), None);
+            assert_eq!(linker(a, b, true, context), None);
         }
 
         {
@@ -730,7 +734,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, true), None);
+            assert_eq!(linker(a, b, true, context), None);
         }
 
         {
@@ -739,7 +743,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, true), None);
+            assert_eq!(linker(a, b, true, context), None);
         }
 
         {
@@ -748,7 +752,7 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, true), None);
+            assert_eq!(linker(a, b, true, context), None);
         }
 
         {
@@ -757,7 +761,8 @@ mod tests {
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, true), None);
+            assert_eq!(linker(a, b, true, context), None);
+            println!("context:{}", context.country);
         }
 
         {
@@ -767,8 +772,8 @@ mod tests {
             
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true, false), None);
-            println!("context:{}", context.country);
+            assert_eq!(linker(a, b, true, context_eu), None);
+            println!("context:{}", context_eu.country);
         }
 
     }


### PR DESCRIPTION
Check if the country is United states when requiring tokenless matches to have identical first characters