### PR TITLE
German regex parsing

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
 [[package]]
 name = "geocoder-abbreviations"
 version = "0.1.0"
-source = "git+https://github.com/mapbox/geocoder-abbreviations?rev=master#26442ab0ce9f3f6e4b09b1f1cb795478420d2d73"
+source = "git+https://github.com/mapbox/geocoder-abbreviations?rev=26f7329a0d92f721b1090a373796d6d08970707f#26f7329a0d92f721b1090a373796d6d08970707f"
 dependencies = [
  "alphanumeric-sort 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fancy-regex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -575,7 +575,7 @@ dependencies = [
  "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fancy-regex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=master)",
+ "geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=26f7329a0d92f721b1090a373796d6d08970707f)",
  "geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -981,7 +981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum geo 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "89ce8faa25a6f5ce8ea98faa95247d66377a843408eb4418332ec37de96850b0"
 "checksum geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "866e8f6dbd2218b05ea8a25daa1bfac32b0515fe7e0a37cb6a7b9ed0ed82a07e"
-"checksum geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=master)" = "<none>"
+"checksum geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=26f7329a0d92f721b1090a373796d6d08970707f)" = "<none>"
 "checksum geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22b37e57c7f498be81360116a489ebad0b133557e87d8b4f82d51bebd1c3ef9e"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -311,11 +311,11 @@ dependencies = [
 [[package]]
 name = "geocoder-abbreviations"
 version = "0.1.0"
-source = "git+https://github.com/mapbox/geocoder-abbreviations?rev=26f7329a0d92f721b1090a373796d6d08970707f#26f7329a0d92f721b1090a373796d6d08970707f"
+source = "git+https://github.com/mapbox/geocoder-abbreviations?rev=master#8b9ea0dbd5a57d8d986236cf0ed9d474162c39e3"
 dependencies = [
  "alphanumeric-sort 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fancy-regex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-embed 5.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -591,7 +591,7 @@ dependencies = [
  "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fancy-regex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=26f7329a0d92f721b1090a373796d6d08970707f)",
+ "geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=master)",
  "geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kodama 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -730,6 +730,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "5.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rust-embed-impl 5.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-embed-utils 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "5.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-embed-utils 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +780,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "safemem"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "scopeguard"
@@ -933,6 +970,16 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +997,14 @@ dependencies = [
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -998,7 +1053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum geo 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "89ce8faa25a6f5ce8ea98faa95247d66377a843408eb4418332ec37de96850b0"
 "checksum geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "866e8f6dbd2218b05ea8a25daa1bfac32b0515fe7e0a37cb6a7b9ed0ed82a07e"
-"checksum geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=26f7329a0d92f721b1090a373796d6d08970707f)" = "<none>"
+"checksum geocoder-abbreviations 0.1.0 (git+https://github.com/mapbox/geocoder-abbreviations?rev=master)" = "<none>"
 "checksum geojson 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22b37e57c7f498be81360116a489ebad0b133557e87d8b4f82d51bebd1c3ef9e"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
@@ -1046,10 +1101,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum rstar 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "120bfe4837befb82c5a637a5a8c490a27d25524ac19fffec5b4e555ca6e36ee8"
 "checksum rstar 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd08ae4f9661517777346592956ea6cdbba2895a28037af7daa600382f4b4001"
+"checksum rust-embed 5.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a17890cbd0fae97c2006fa1ecec9554946443c319f4dd8cd8d3b92031725161"
+"checksum rust-embed-impl 5.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "60cacc306d294556771c6e92737ba7e6be0264144bc46dd713a14ef384b0d6b8"
+"checksum rust-embed-utils 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97655158074ccb2d2cfb1ccb4c956ef0f4054e43a2c1e71146d4991e6961e105"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
+"checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
@@ -1074,7 +1133,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum utf8-ranges 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
+"checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1.0"
 serde = "1.0"
 fancy-regex = "0.1.0"
 memchr = "2.0.2"
-geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "ec19b7920571c5e0acc776924073f343238e9b85" }
+geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "master" }
 unicode-segmentation = "1.3.0"
 kodama = "0.1"
 

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1.0"
 serde = "1.0"
 fancy-regex = "0.1.0"
 memchr = "2.0.2"
-geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "26f7329a0d92f721b1090a373796d6d08970707f" }
+geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "ebe5488963e1b94174eb812fcd7db893090a039c" }
 unicode-segmentation = "1.3.0"
 kodama = "0.1"
 

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1.0"
 serde = "1.0"
 fancy-regex = "0.1.0"
 memchr = "2.0.2"
-geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "92527eb169a6f2fea52c24ba5806b4959b84b8ae" }
+geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "b518011c0a42070dc36f2a61356bec6e074930fc" }
 unicode-segmentation = "1.3.0"
 
 [dependencies.geojson]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1.0"
 serde = "1.0"
 fancy-regex = "0.1.0"
 memchr = "2.0.2"
-geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "ebe5488963e1b94174eb812fcd7db893090a039c" }
+geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "ec19b7920571c5e0acc776924073f343238e9b85" }
 unicode-segmentation = "1.3.0"
 kodama = "0.1"
 

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1.0"
 serde = "1.0"
 fancy-regex = "0.1.0"
 memchr = "2.0.2"
-geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "b518011c0a42070dc36f2a61356bec6e074930fc" }
+geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "26f7329a0d92f721b1090a373796d6d08970707f" }
 unicode-segmentation = "1.3.0"
 
 [dependencies.geojson]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1.0"
 serde = "1.0"
 fancy-regex = "0.1.0"
 memchr = "2.0.2"
-geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "master" }
+geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "92527eb169a6f2fea52c24ba5806b4959b84b8ae" }
 unicode-segmentation = "1.3.0"
 
 [dependencies.geojson]

--- a/native/src/conflate/mod.rs
+++ b/native/src/conflate/mod.rs
@@ -1,23 +1,22 @@
-use std::convert::From;
+use geojson::GeoJson;
 use postgres::{Connection, TlsMode};
 use std::collections::HashMap;
+use std::convert::From;
 use std::fs::File;
 use std::io::{BufWriter, Write};
-use geojson::GeoJson;
 
 use neon::prelude::*;
 
 use crate::{
-    Names,
-    Address,
     hecate,
-    util::linker,
+    stream::{AddrStream, GeoStream},
     types::name::InputName,
-    stream::{GeoStream, AddrStream}
+    util::linker,
+    Address, Names,
 };
 
 use super::pg;
-use super::pg::{Table, InputTable};
+use super::pg::{InputTable, Table};
 
 #[derive(Serialize, Deserialize, Debug)]
 struct ConflateArgs {
@@ -27,7 +26,7 @@ struct ConflateArgs {
     in_persistent: Option<String>,
     error_address: Option<String>,
     error_persistent: Option<String>,
-    output: Option<String>
+    output: Option<String>,
 }
 
 impl ConflateArgs {
@@ -39,7 +38,7 @@ impl ConflateArgs {
             in_persistent: None,
             error_address: None,
             error_persistent: None,
-            output: None
+            output: None,
         }
     }
 }
@@ -74,17 +73,26 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         None => panic!("Output file required"),
         Some(output) => match File::create(output) {
             Ok(outfile) => BufWriter::new(outfile),
-            Err(err) => panic!("Unable to write to output file: {}", err)
-        }
+            Err(err) => panic!("Unable to write to output file: {}", err),
+        },
     };
 
-    let conn = Connection::connect(format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(), TlsMode::None).unwrap();
+    let conn = Connection::connect(
+        format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(),
+        TlsMode::None,
+    )
+    .unwrap();
 
-    conn.execute("
+    conn.execute(
+        "
         DROP TABLE IF EXISTS modified;
-    ", &[]).unwrap();
+    ",
+        &[],
+    )
+    .unwrap();
 
-    conn.execute("
+    conn.execute(
+        "
         CREATE UNLOGGED TABLE modified (
             id BIGINT,
             version BIGINT,
@@ -96,23 +104,43 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
             props JSONB,
             geom GEOMETRY(POINT, 4326)
         );
-    ", &[]).unwrap();
+    ",
+        &[],
+    )
+    .unwrap();
 
     let context = match args.context {
         Some(context) => crate::Context::from(context),
-        None => crate::Context::new(String::from(""), None, crate::Tokens::new(HashMap::new()))
+        None => crate::Context::new(
+            String::from(""),
+            None,
+            crate::Tokens::new(HashMap::new(), HashMap::new()),
+        ),
     };
 
     let pgaddress = pg::Address::new();
     pgaddress.create(&conn);
-    pgaddress.input(&conn, AddrStream::new(GeoStream::new(args.in_persistent), context.clone(), args.error_persistent));
+    pgaddress.input(
+        &conn,
+        AddrStream::new(
+            GeoStream::new(args.in_persistent),
+            context.clone(),
+            args.error_persistent,
+        ),
+    );
     pgaddress.index(&conn);
     pg::address::pre_conflate(&conn);
 
-    for addr in AddrStream::new(GeoStream::new(args.in_address), context.clone(), args.error_address) {
+    for addr in AddrStream::new(
+        GeoStream::new(args.in_address),
+        context.clone(),
+        args.error_address,
+    ) {
         // find all persistent addresses with the same address number
         // within 0.01 decimal degrees (~ 1 km) of the new address
-        let rows = conn.query("
+        let rows = conn
+            .query(
+                "
             SELECT
                 ST_Distance(ST_SetSRID(ST_Point($2, $3), 4326), p.geom),
                 json_build_object(
@@ -130,7 +158,10 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
             WHERE
                 p.number = $1
                 AND ST_DWithin(ST_SetSRID(ST_Point($2, $3), 4326), p.geom, 0.01);
-        ", &[ &addr.number, &addr.geom[0], &addr.geom[1] ]).unwrap();
+        ",
+                &[&addr.number, &addr.geom[0], &addr.geom[1]],
+            )
+            .unwrap();
 
         let mut persistents: Vec<Address> = Vec::with_capacity(rows.len());
 
@@ -143,10 +174,13 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         match compare(&addr, &mut persistents) {
             // persistent address matches new address, consider modifying persistent address
             Some(link_id) => {
-                let mut pmatches: Vec<&mut Address> = persistents.iter_mut().filter(|persistent| {
-                    // addresses with output set to false should not be modified
-                    link_id == persistent.id.unwrap() && persistent.output
-                }).collect();
+                let mut pmatches: Vec<&mut Address> = persistents
+                    .iter_mut()
+                    .filter(|persistent| {
+                        // addresses with output set to false should not be modified
+                        link_id == persistent.id.unwrap() && persistent.output
+                    })
+                    .collect();
 
                 match pmatches.len() {
                     // if all matches have output set to false, don't modify
@@ -162,7 +196,8 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
                             combined_names.sort();
                             combined_names.dedupe();
 
-                            let mut new_names: Vec<InputName> = Vec::with_capacity(combined_names.names.len());
+                            let mut new_names: Vec<InputName> =
+                                Vec::with_capacity(combined_names.names.len());
                             for name in combined_names.names {
                                 new_names.push(InputName::from(name));
                             }
@@ -173,18 +208,30 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
                             paddr.props.insert(String::from("street"), new_names);
                             paddr.to_db(&conn, "modified").unwrap();
                         }
-                    },
-                    _ => panic!("Duplicate IDs are not allowed in input data")
+                    }
+                    _ => panic!("Duplicate IDs are not allowed in input data"),
                 }
-            },
+            }
             // no match in persistent addresses, write new address to output
             None => {
-                output.write(format!("{}\n", GeoJson::Feature(addr.to_geojson(hecate::Action::Create, false)).to_string()).as_bytes()).unwrap();
+                output
+                    .write(
+                        format!(
+                            "{}\n",
+                            GeoJson::Feature(addr.to_geojson(hecate::Action::Create, false))
+                                .to_string()
+                        )
+                        .as_bytes(),
+                    )
+                    .unwrap();
             }
         };
     }
 
-    let modifieds = pg::Cursor::new(conn, format!("
+    let modifieds = pg::Cursor::new(
+        conn,
+        format!(
+            "
         SELECT
             json_build_object(
                 'id', id,
@@ -200,7 +247,10 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
             id,
             version,
             geom
-    ")).unwrap();
+    "
+        ),
+    )
+    .unwrap();
 
     for mut modified in modifieds {
         let modified_obj = modified.as_object_mut().unwrap();
@@ -218,13 +268,17 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
             // other properties
             let mut props_base = props_arr.pop().unwrap();
             let props_base_obj = props_base.as_object_mut().unwrap();
-            let names_base: Vec<InputName> = serde_json::from_value(props_base_obj.remove(&String::from("street")).unwrap()).unwrap();
+            let names_base: Vec<InputName> =
+                serde_json::from_value(props_base_obj.remove(&String::from("street")).unwrap())
+                    .unwrap();
 
             let mut names_base = Names::from_input(names_base, &context);
             for prop in props_arr {
                 let prop_obj = prop.as_object_mut().unwrap();
 
-                let names_new: Vec<InputName> = serde_json::from_value(prop_obj.remove(&String::from("street")).unwrap()).unwrap();
+                let names_new: Vec<InputName> =
+                    serde_json::from_value(prop_obj.remove(&String::from("street")).unwrap())
+                        .unwrap();
                 let names_new = Names::from_input(names_new, &context);
 
                 names_base.concat(names_new);
@@ -237,21 +291,26 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
                 names_final.push(InputName::from(name));
             }
 
-            props_base_obj.insert(String::from("street"), serde_json::to_value(names_final).unwrap());
+            props_base_obj.insert(
+                String::from("street"),
+                serde_json::to_value(names_final).unwrap(),
+            );
             modified_obj.insert(String::from("properties"), props_base);
         }
 
         let modified = match modified {
             serde_json::Value::Object(modified) => modified,
-            _ => panic!("Modified should always be an object")
+            _ => panic!("Modified should always be an object"),
         };
 
         let modified: geojson::Feature = match geojson::Feature::from_json_object(modified) {
             Ok(m) => m,
-            Err(e) => panic!(e)
+            Err(e) => panic!(e),
         };
 
-        output.write(format!("{}\n", modified.to_string()).as_bytes()).unwrap();
+        output
+            .write(format!("{}\n", modified.to_string()).as_bytes())
+            .unwrap();
     }
 
     Ok(cx.boolean(true))
@@ -271,12 +330,13 @@ pub fn compare(potential: &Address, persistents: &mut Vec<Address>) -> Option<i6
         return None;
     }
     let potential_link = linker::Link::new(0, &potential.names);
-    let persistent_links: Vec<linker::Link> = persistents.iter().map(|persistent| {
-        linker::Link::new(persistent.id.unwrap(), &persistent.names)
-    }).collect();
+    let persistent_links: Vec<linker::Link> = persistents
+        .iter()
+        .map(|persistent| linker::Link::new(persistent.id.unwrap(), &persistent.names))
+        .collect();
 
     match linker::linker(potential_link, persistent_links, true) {
         Some(link) => Some(link.id),
-        None => None
+        None => None,
     }
 }

--- a/native/src/consensus/mod.rs
+++ b/native/src/consensus/mod.rs
@@ -79,7 +79,7 @@ pub fn consensus(mut cx: FunctionContext) -> JsResult<JsValue> {
 
     let context = match args.context {
         Some(context) => crate::Context::from(context),
-        None => crate::Context::new(String::from(""), None, crate::Tokens::new(HashMap::new()))
+        None => crate::Context::new(String::from(""), None, crate::Tokens::new(HashMap::new(), HashMap::new()))
     };
 
     let pgaddress = pg::Address::new();

--- a/native/src/map/mod.rs
+++ b/native/src/map/mod.rs
@@ -126,7 +126,7 @@ pub fn import_addr(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
     let context = match args.context {
         Some(context) => CrateContext::from(context),
-        None => CrateContext::new(String::from(""), None, Tokens::new(HashMap::new()))
+        None => CrateContext::new(String::from(""), None, Tokens::new(HashMap::new(), HashMap::new()))
     };
 
     let address = pg::Address::new();
@@ -163,7 +163,7 @@ pub fn import_net(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
     let context = match args.context {
         Some(context) => CrateContext::from(context),
-        None => CrateContext::new(String::from(""), None, Tokens::new(HashMap::new()))
+        None => CrateContext::new(String::from(""), None, Tokens::new(HashMap::new(), HashMap::new()))
     };
 
     let network = pg::Network::new();

--- a/native/src/text/diacritics.rs
+++ b/native/src/text/diacritics.rs
@@ -898,6 +898,8 @@ mod tests {
 
         assert_eq!(diacritics(&String::from("Fußball")), String::from("Fussball"));
 
+        assert_eq!(diacritics(&String::from("hauptstraße")), String::from("hauptstrasse"));
+
         assert_eq!(diacritics(&String::from("ABCDEFGHIJKLMNOPQRSTUVWXYZé")), String::from("ABCDEFGHIJKLMNOPQRSTUVWXYZe"));
     }
 }

--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -179,6 +179,18 @@ pub fn str_remove_octo(text: &String) -> String {
 }
 
 ///
+/// Replace German street names that end in straße & str with strasse
+/// for better token matching
+///
+pub fn str_replace_strasse(text: &String) -> String {
+    lazy_static! {
+        static ref STRASSE: Regex = Regex::new(r"(straße|str)$").unwrap();
+    }
+
+    return STRASSE.replace_all(&text, "strasse").to_string();
+}
+
+///
 /// Detect Strings like `5 Avenue` and return a synonym like `5th Avenue` where possible
 ///
 pub fn syn_number_suffix(name: &Name, context: &Context) -> Vec<Name> {

--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -1,7 +1,7 @@
 mod diacritics;
-mod tokens;
 mod replace;
 mod titlecase;
+mod tokens;
 
 //
 // A note on fn names:
@@ -12,17 +12,18 @@ mod titlecase;
 
 pub use self::diacritics::diacritics;
 pub use self::titlecase::titlecase;
-pub use self::tokens::{Tokens, Tokenized, ParsedToken, tokenize_name};
+pub use self::tokens::{tokenize_name, ParsedToken, Tokenized, Tokens};
 
-use std::collections::HashMap;
+use crate::{Context, Name, Source};
 use regex::{Regex, RegexSet};
-use crate::{Name, Source, Context};
+use std::collections::HashMap;
 
 ///
 /// Return the Levenshtein distance between two strings
 ///
 pub fn distance<T>(a: &T, b: &T) -> usize
-    where T: ToString
+where
+    T: ToString,
 {
     let v1: Vec<char> = a.to_string().chars().collect();
     let v2: Vec<char> = b.to_string().chars().collect();
@@ -30,25 +31,37 @@ pub fn distance<T>(a: &T, b: &T) -> usize
     let v2len = v2.len();
 
     // Early exit if one of the strings is empty
-    if v1len == 0 { return v2len; }
-    if v2len == 0 { return v1len; }
+    if v1len == 0 {
+        return v2len;
+    }
+    if v2len == 0 {
+        return v1len;
+    }
 
-    fn min3<T: Ord>(v1: T, v2: T, v3: T) -> T{
+    fn min3<T: Ord>(v1: T, v2: T, v3: T) -> T {
         std::cmp::min(v1, std::cmp::min(v2, v3))
     }
 
     fn delta(x: char, y: char) -> usize {
-        if x == y { 0 } else { 1 }
+        if x == y {
+            0
+        } else {
+            1
+        }
     }
 
-    let mut column: Vec<usize> = (0..v1len+1).collect();
+    let mut column: Vec<usize> = (0..v1len + 1).collect();
 
-    for x in 1..v2len+1 {
+    for x in 1..v2len + 1 {
         column[0] = x;
-        let mut lastdiag = x-1;
-        for y in 1..v1len+1 {
+        let mut lastdiag = x - 1;
+        for y in 1..v1len + 1 {
             let olddiag = column[y];
-            column[y] = min3(column[y] + 1, column[y-1] + 1, lastdiag + delta(v1[y-1], v2[x-1]));
+            column[y] = min3(
+                column[y] + 1,
+                column[y - 1] + 1,
+                lastdiag + delta(v1[y - 1], v2[x - 1]),
+            );
             lastdiag = olddiag;
         }
     }
@@ -56,18 +69,15 @@ pub fn distance<T>(a: &T, b: &T) -> usize
     column[v1len]
 }
 
-
 ///
 /// Is the street a numbered street: ie 1st, 2nd, 3rd etc
 ///
 pub fn is_numbered(name: &Name) -> Option<String> {
-    let tokens: Vec<String> = name.tokenized
-        .iter()
-        .map(|x| x.token.to_owned())
-        .collect();
+    let tokens: Vec<String> = name.tokenized.iter().map(|x| x.token.to_owned()).collect();
 
     lazy_static! {
-        static ref NUMBERED: Regex = Regex::new(r"^(?P<num>([0-9]+)?(1st|2nd|3rd|[0-9]th))$").unwrap();
+        static ref NUMBERED: Regex =
+            Regex::new(r"^(?P<num>([0-9]+)?(1st|2nd|3rd|[0-9]th))$").unwrap();
     }
 
     for token in tokens {
@@ -75,7 +85,7 @@ pub fn is_numbered(name: &Name) -> Option<String> {
             Some(capture) => {
                 return Some(capture["num"].to_string());
             }
-            None => ()
+            None => (),
         };
     }
 
@@ -87,10 +97,7 @@ pub fn is_numbered(name: &Name) -> Option<String> {
 /// ie: US Route 4
 ///
 pub fn is_routish(name: &Name) -> Option<String> {
-    let tokens: Vec<String> = name.tokenized
-        .iter()
-        .map(|x| x.token.to_owned())
-        .collect();
+    let tokens: Vec<String> = name.tokenized.iter().map(|x| x.token.to_owned()).collect();
 
     lazy_static! {
         static ref ROUTISH: Regex = Regex::new(r"^(?P<num>\d+)$").unwrap();
@@ -101,7 +108,7 @@ pub fn is_routish(name: &Name) -> Option<String> {
             Some(capture) => {
                 return Some(capture["num"].to_string());
             }
-            None => ()
+            None => (),
         };
     }
 
@@ -117,20 +124,18 @@ pub fn is_drivethrough(text: &String, context: &Context) -> bool {
         static ref EN: Regex = Regex::new(r"(?i)drive.?(in|through|thru)$").unwrap();
     }
 
-    if (
-        context.country == String::from("US")
+    if (context.country == String::from("US")
         || context.country == String::from("CA")
         || context.country == String::from("GB")
         || context.country == String::from("DE")
         || context.country == String::from("CH")
-        || context.country == String::from("AT")
-    ) && EN.is_match(text.as_str()) {
+        || context.country == String::from("AT"))
+        && EN.is_match(text.as_str())
+    {
         return true;
     }
 
-    if (
-        context.country == String::from("DE")
-    ) && DE.is_match(text.as_str()) {
+    if (context.country == String::from("DE")) && DE.is_match(text.as_str()) {
         return true;
     }
 
@@ -142,20 +147,17 @@ pub fn is_drivethrough(text: &String, context: &Context) -> bool {
 /// e.g. US Hwy 125 Ext 1
 ///
 pub fn is_undesireable(tokenized: &Vec<Tokenized>) -> bool {
-    let tokens: Vec<String> = tokenized
-        .iter()
-        .map(|x| x.token.to_owned())
-        .collect();
+    let tokens: Vec<String> = tokenized.iter().map(|x| x.token.to_owned()).collect();
 
     let subs = vec![
-            String::from("ext"),
-            String::from("connector"),
-            String::from("unit"),
-            String::from("apt"),
-            String::from("apts"),
-            String::from("suite"),
-            String::from("lot")
-        ];
+        String::from("ext"),
+        String::from("connector"),
+        String::from("unit"),
+        String::from("apt"),
+        String::from("apts"),
+        String::from("suite"),
+        String::from("lot"),
+    ];
     for token in tokens {
         if subs.contains(&token) {
             return true;
@@ -169,12 +171,14 @@ pub fn is_undesireable(tokenized: &Vec<Tokenized>) -> bool {
 ///
 pub fn str_remove_octo(text: &String) -> String {
     lazy_static! {
-        static ref OCTO: Regex = Regex::new(r"(?i)^(?P<type>HWY |HIGHWAY |RTE |ROUTE |US )(#)(?P<post>\d+\s?.*)$").unwrap();
+        static ref OCTO: Regex =
+            Regex::new(r"(?i)^(?P<type>HWY |HIGHWAY |RTE |ROUTE |US )(#)(?P<post>\d+\s?.*)$")
+                .unwrap();
     }
 
     match OCTO.captures(text.as_str()) {
         Some(capture) => format!("{}{}", &capture["type"], &capture["post"]),
-        _ => text.clone()
+        _ => text.clone(),
     }
 }
 
@@ -183,14 +187,17 @@ pub fn str_remove_octo(text: &String) -> String {
 ///
 pub fn syn_number_suffix(name: &Name, context: &Context) -> Vec<Name> {
     lazy_static! {
-        static ref NUMSUFFIX: Regex = Regex::new(r"(?i)^(?P<number>\d+)\s+(?P<name>\w.*)$").unwrap();
+        static ref NUMSUFFIX: Regex =
+            Regex::new(r"(?i)^(?P<number>\d+)\s+(?P<name>\w.*)$").unwrap();
     }
 
     match NUMSUFFIX.captures(name.display.as_str()) {
         Some(capture) => {
             let num: i64 = match capture["number"].parse() {
                 Ok(num) => num,
-                _ => { return Vec::new(); }
+                _ => {
+                    return Vec::new();
+                }
             };
 
             let suffix: String;
@@ -206,9 +213,14 @@ pub fn syn_number_suffix(name: &Name, context: &Context) -> Vec<Name> {
                 suffix = String::from("th");
             }
 
-            vec![Name::new(format!("{}{} {}", num, suffix, &capture["name"]), -1, Some(Source::Generated), &context)]
-        },
-        None => Vec::new()
+            vec![Name::new(
+                format!("{}{} {}", num, suffix, &capture["name"]),
+                -1,
+                Some(Source::Generated),
+                &context,
+            )]
+        }
+        None => Vec::new(),
     }
 }
 
@@ -218,13 +230,17 @@ pub fn syn_number_suffix(name: &Name, context: &Context) -> Vec<Name> {
 ///
 pub fn syn_ca_french(name: &Name, context: &Context) -> Vec<Name> {
     let mut syns = Vec::new();
-    let standalone = vec![String::from("r"), String::from("ch"), String::from("av"), String::from("bd")];
+    let standalone = vec![
+        String::from("r"),
+        String::from("ch"),
+        String::from("av"),
+        String::from("bd"),
+    ];
     let eliminator = vec![String::from("du"), String::from("des"), String::from("de")];
 
     if name.tokenized.len() <= 1 {
         return syns;
-    } else if
-        standalone.contains(&name.tokenized[0].token)
+    } else if standalone.contains(&name.tokenized[0].token)
         && !eliminator.contains(&name.tokenized[1].token)
     {
         let tokens: Vec<String> = name.tokenized[1..name.tokenized.len()]
@@ -254,7 +270,11 @@ pub fn syn_ny_beach(name: &Name, context: &Context) -> Vec<Name> {
 
     // if the original feature has a priority of < 0, ensure the display form synonym priority isn't
     // > the address and primary network names. Otherwise ensure it's always > the original name
-    let display_priority = if name.priority >= 0 { name.priority + 1 } else { -1 };
+    let display_priority = if name.priority >= 0 {
+        name.priority + 1
+    } else {
+        -1
+    };
     // Ensure non display form synonyms always have a priority of < 0 and < the original name
     let priority_offset = std::cmp::min(0, name.priority);
 
@@ -262,24 +282,33 @@ pub fn syn_ny_beach(name: &Name, context: &Context) -> Vec<Name> {
         let strnumber: String = match BEACH.captures(name.display.as_str()) {
             Some(capture) => match capture.name("number") {
                 Some(name) => name.as_str().to_string(),
-                None => String::from("")
+                None => String::from(""),
             },
-            None => String::from("")
+            None => String::from(""),
         };
 
         let strpost: String = match BEACH.captures(name.display.as_str()) {
             Some(capture) => match capture.name("post") {
                 Some(name) => name.as_str().to_string(),
-                None => String::from("")
+                None => String::from(""),
             },
-            None => String::from("")
+            None => String::from(""),
         };
 
         // Display Form 'Beach 31st St'
-        syns.push(Name::new(format!("Beach{}{}", &strnumber, &strpost), display_priority, Some(Source::Generated), &context));
+        syns.push(Name::new(
+            format!("Beach{}{}", &strnumber, &strpost),
+            display_priority,
+            Some(Source::Generated),
+            &context,
+        ));
         // Synonym 'B 31st St'
-        syns.push(Name::new(format!("B{}{}", &strnumber, &strpost), priority_offset - 1, Some(Source::Generated), &context));
-
+        syns.push(Name::new(
+            format!("B{}{}", &strnumber, &strpost),
+            priority_offset - 1,
+            Some(Source::Generated),
+            &context,
+        ));
     }
 
     syns
@@ -291,12 +320,12 @@ pub fn syn_ny_beach(name: &Name, context: &Context) -> Vec<Name> {
 pub fn syn_ca_hwy(name: &Name, context: &Context) -> Vec<Name> {
     let region = match context.region {
         Some(ref region) => region,
-        None => { return Vec::new() }
+        None => return Vec::new(),
     };
 
     let region_name = match context.region_name() {
         Some(region) => region,
-        None => { return Vec::new() }
+        None => return Vec::new(),
     };
 
     lazy_static! {
@@ -319,8 +348,7 @@ pub fn syn_ca_hwy(name: &Name, context: &Context) -> Vec<Name> {
             Some(capture) => {
                 let num = capture["num"].to_string();
                 let hwy_type: String;
-                if
-                    region == &String::from("NB")
+                if region == &String::from("NB")
                     || region == &String::from("NL")
                     || region == &String::from("PE")
                     || region == &String::from("QC")
@@ -334,30 +362,53 @@ pub fn syn_ca_hwy(name: &Name, context: &Context) -> Vec<Name> {
 
                 // if the original feature has a priority of < 0, ensure the display form synonym priority isn't
                 // > the address and primary network names. Otherwise ensure it's always > the original name
-                let display_priority = if name.priority >= 0 { name.priority + 1 } else { -1 };
+                let display_priority = if name.priority >= 0 {
+                    name.priority + 1
+                } else {
+                    -1
+                };
                 // New Brunswick Route 123 (Display Form)
-                syns.push(Name::new(format!("{} {} {}", &region_name, &hwy_type, &num), display_priority, Some(Source::Generated), &context));
+                syns.push(Name::new(
+                    format!("{} {} {}", &region_name, &hwy_type, &num),
+                    display_priority,
+                    Some(Source::Generated),
+                    &context,
+                ));
 
                 // Ensure non display form synonyms always have a priority of < 0 and < the original name
                 let priority_offset = std::cmp::min(0, name.priority);
 
                 // Highway 123
-                syns.push(Name::new(format!("Highway {}", &num), priority_offset - 1, Some(Source::Generated), &context));
+                syns.push(Name::new(
+                    format!("Highway {}", &num),
+                    priority_offset - 1,
+                    Some(Source::Generated),
+                    &context,
+                ));
 
                 // Route 123
-                syns.push(Name::new(format!("Route {}", &num), priority_offset - 1, Some(Source::Generated), &context));
+                syns.push(Name::new(
+                    format!("Route {}", &num),
+                    priority_offset - 1,
+                    Some(Source::Generated),
+                    &context,
+                ));
 
                 // NB 123
-                syns.push(Name::new(format!("{} {}", &region, &num), priority_offset - 2, Some(Source::Generated), &context));
+                syns.push(Name::new(
+                    format!("{} {}", &region, &num),
+                    priority_offset - 2,
+                    Some(Source::Generated),
+                    &context,
+                ));
 
                 syns
-            },
-            None => Vec::new()
+            }
+            None => Vec::new(),
         }
     } else {
         Vec::new()
     }
-
 }
 
 ///
@@ -398,18 +449,27 @@ pub fn syn_written_numeric(name: &Name, context: &Context) -> Vec<Name> {
     match NUMERIC.captures(name.display.as_str()) {
         Some(capture) => {
             let tenth = match NUMERIC_MAP.get(&capture["tenth"].to_lowercase()) {
-                None => { return Vec::new(); },
-                Some(tenth) => tenth
+                None => {
+                    return Vec::new();
+                }
+                Some(tenth) => tenth,
             };
 
             let nth = match NUMERIC_MAP.get(&capture["nth"].to_lowercase()) {
-                None => { return Vec::new(); },
-                Some(nth) => nth
+                None => {
+                    return Vec::new();
+                }
+                Some(nth) => nth,
             };
 
-            vec![Name::new(format!("{}{}{}{}", &capture["pre"], tenth, nth, &capture["post"]), -1, Some(Source::Generated), &context)]
-        },
-        _ => Vec::new()
+            vec![Name::new(
+                format!("{}{}{}{}", &capture["pre"], tenth, nth, &capture["post"]),
+                -1,
+                Some(Source::Generated),
+                &context,
+            )]
+        }
+        _ => Vec::new(),
     }
 }
 
@@ -423,20 +483,36 @@ pub fn syn_us_cr(name: &Name, context: &Context) -> Vec<Name> {
 
     let cr: String = match US_CR.captures(name.display.as_str()) {
         Some(capture) => capture["num"].to_string(),
-        None => { return Vec::new(); }
+        None => {
+            return Vec::new();
+        }
     };
 
     // Note ensure capacity is increased if additional permuations are added below
     let mut syns: Vec<Name> = Vec::with_capacity(2);
     // if the original feature has a priority of < 0, ensure the display form synonym priority isn't
     // > the address and primary network names. Otherwise ensure it's always > the original name
-    let display_priority = if name.priority >= 0 { name.priority + 1 } else { -1 };
+    let display_priority = if name.priority >= 0 {
+        name.priority + 1
+    } else {
+        -1
+    };
     // County Road 123 (Display Form)
-    syns.push(Name::new(format!("County Road {}", &cr), display_priority, Some(Source::Generated), &context));
+    syns.push(Name::new(
+        format!("County Road {}", &cr),
+        display_priority,
+        Some(Source::Generated),
+        &context,
+    ));
 
     // CR 123
     // Ensure non display form synonyms always have a priority of < 0 and < the original name
-    syns.push(Name::new(format!("CR {}", &cr), std::cmp::min(0, name.priority) - 1, Some(Source::Generated), &context));
+    syns.push(Name::new(
+        format!("CR {}", &cr),
+        std::cmp::min(0, name.priority) - 1,
+        Some(Source::Generated),
+        &context,
+    ));
 
     syns
 }
@@ -453,7 +529,11 @@ pub fn syn_us_famous(name: &Name, context: &Context) -> Vec<Name> {
     }
     // if the original feature has a priority of < 0, ensure the display form synonym priority isn't
     // > the address and primary network names. Otherwise ensure it's always > the original name
-    let display_priority = if name.priority >= 0 { name.priority + 1 } else { -1 };
+    let display_priority = if name.priority >= 0 {
+        name.priority + 1
+    } else {
+        -1
+    };
     // Ensure non display form synonyms always have a priority of < 0 and < the original name
     let priority_offset = std::cmp::min(0, name.priority);
 
@@ -461,48 +541,87 @@ pub fn syn_us_famous(name: &Name, context: &Context) -> Vec<Name> {
         let strpost: String = match JFK.captures(name.display.as_str()) {
             Some(capture) => match capture.name("post") {
                 Some(name) => name.as_str().to_string(),
-                None => String::from("")
+                None => String::from(""),
             },
-            None => String::from("")
+            None => String::from(""),
         };
 
         let strpre: String = match JFK.captures(name.display.as_str()) {
             Some(capture) => match capture.name("pre") {
                 Some(name) => name.as_str().to_string(),
-                None => String::from("")
+                None => String::from(""),
             },
-            None => String::from("")
+            None => String::from(""),
         };
         // Display Form
-        syns.push(Name::new(format!("{}John F Kennedy{}", &strpre, &strpost), display_priority, Some(Source::Generated), &context));
+        syns.push(Name::new(
+            format!("{}John F Kennedy{}", &strpre, &strpost),
+            display_priority,
+            Some(Source::Generated),
+            &context,
+        ));
 
-        syns.push(Name::new(format!("{}JFK{}", &strpre, &strpost), priority_offset - 1, Some(Source::Generated), &context));
-
+        syns.push(Name::new(
+            format!("{}JFK{}", &strpre, &strpost),
+            priority_offset - 1,
+            Some(Source::Generated),
+            &context,
+        ));
     } else if MLKJR.is_match(name.display.as_str()) {
         let strpost: String = match MLKJR.captures(name.display.as_str()) {
             Some(capture) => match capture.name("post") {
                 Some(name) => name.as_str().to_string(),
-                None => String::from("")
+                None => String::from(""),
             },
-            None => String::from("")
+            None => String::from(""),
         };
 
         let strpre: String = match MLKJR.captures(name.display.as_str()) {
             Some(capture) => match capture.name("pre") {
                 Some(name) => name.as_str().to_string(),
-                None => String::from("")
+                None => String::from(""),
             },
-            None => String::from("")
+            None => String::from(""),
         };
 
         // Display Form
-        syns.push(Name::new(format!("{}Martin Luther King Jr{}", &strpre, &strpost), display_priority, Some(Source::Generated), &context));
+        syns.push(Name::new(
+            format!("{}Martin Luther King Jr{}", &strpre, &strpost),
+            display_priority,
+            Some(Source::Generated),
+            &context,
+        ));
 
-        syns.push(Name::new(format!("{}MLK{}", &strpre, &strpost), priority_offset - 1, Some(Source::Generated), &context));
-        syns.push(Name::new(format!("{}M L K{}", &strpre, &strpost), priority_offset - 1, Some(Source::Generated), &context));
-        syns.push(Name::new(format!("{}Martin Luther King{}", &strpre, &strpost), priority_offset - 1, Some(Source::Generated), &context));
-        syns.push(Name::new(format!("{}MLK Jr{}", &strpre, &strpost), priority_offset - 1, Some(Source::Generated), &context));
-        syns.push(Name::new(format!("{}M L K Jr{}", &strpre, &strpost), priority_offset - 1, Some(Source::Generated), &context));
+        syns.push(Name::new(
+            format!("{}MLK{}", &strpre, &strpost),
+            priority_offset - 1,
+            Some(Source::Generated),
+            &context,
+        ));
+        syns.push(Name::new(
+            format!("{}M L K{}", &strpre, &strpost),
+            priority_offset - 1,
+            Some(Source::Generated),
+            &context,
+        ));
+        syns.push(Name::new(
+            format!("{}Martin Luther King{}", &strpre, &strpost),
+            priority_offset - 1,
+            Some(Source::Generated),
+            &context,
+        ));
+        syns.push(Name::new(
+            format!("{}MLK Jr{}", &strpre, &strpost),
+            priority_offset - 1,
+            Some(Source::Generated),
+            &context,
+        ));
+        syns.push(Name::new(
+            format!("{}M L K Jr{}", &strpre, &strpost),
+            priority_offset - 1,
+            Some(Source::Generated),
+            &context,
+        ));
     }
 
     syns
@@ -513,36 +632,70 @@ pub fn syn_us_famous(name: &Name, context: &Context) -> Vec<Name> {
 ///
 pub fn syn_us_hwy(name: &Name, context: &Context) -> Vec<Name> {
     lazy_static! {
-        static ref US_HWY: Regex = Regex::new(r"(?i)^(U\.?S\.?|United States)(\s|-)(Rte |Route |Hwy |Highway )?(?P<num>[0-9]+)$").unwrap();
+        static ref US_HWY: Regex = Regex::new(
+            r"(?i)^(U\.?S\.?|United States)(\s|-)(Rte |Route |Hwy |Highway )?(?P<num>[0-9]+)$"
+        )
+        .unwrap();
     }
 
     let highway: String = match US_HWY.captures(name.display.as_str()) {
         Some(capture) => capture["num"].to_string(),
-        None => { return Vec::new(); }
+        None => {
+            return Vec::new();
+        }
     };
 
     // Note ensure capacity is increased if additional permuations are added below
     let mut syns: Vec<Name> = Vec::with_capacity(5);
     // if the original feature has a priority of < 0, ensure the display form synonym priority isn't
     // > the address and primary network names. Otherwise ensure it's always > the original name
-    let display_priority = if name.priority >= 0 { name.priority + 1 } else { -1 };
+    let display_priority = if name.priority >= 0 {
+        name.priority + 1
+    } else {
+        -1
+    };
     // US Route 81 (Display Form)
-    syns.push(Name::new(format!("US Route {}", &highway), display_priority, Some(Source::Generated), &context));
+    syns.push(Name::new(
+        format!("US Route {}", &highway),
+        display_priority,
+        Some(Source::Generated),
+        &context,
+    ));
 
     // Ensure non display form synonyms always have a priority of < 0 and < the original name
     let priority_offset = std::cmp::min(0, name.priority);
 
     // US 81
-    syns.push(Name::new(format!("US {}", &highway), priority_offset - 1, Some(Source::Generated), &context));
+    syns.push(Name::new(
+        format!("US {}", &highway),
+        priority_offset - 1,
+        Some(Source::Generated),
+        &context,
+    ));
 
     // US Highway 81
-    syns.push(Name::new(format!("US Highway {}", &highway), priority_offset - 1, Some(Source::Generated), &context));
+    syns.push(Name::new(
+        format!("US Highway {}", &highway),
+        priority_offset - 1,
+        Some(Source::Generated),
+        &context,
+    ));
 
     // United States Route 81
-    syns.push(Name::new(format!("United States Route {}", &highway), priority_offset - 1, Some(Source::Generated), &context));
+    syns.push(Name::new(
+        format!("United States Route {}", &highway),
+        priority_offset - 1,
+        Some(Source::Generated),
+        &context,
+    ));
 
     // United States Highway 81
-    syns.push(Name::new(format!("United States Highway {}", &highway), priority_offset - 1, Some(Source::Generated), &context));
+    syns.push(Name::new(
+        format!("United States Highway {}", &highway),
+        priority_offset - 1,
+        Some(Source::Generated),
+        &context,
+    ));
 
     syns
 }
@@ -552,15 +705,14 @@ pub fn syn_us_hwy(name: &Name, context: &Context) -> Vec<Name> {
 /// Replace names like "State Highway 1 => NC 1, North Carolina Highway 1
 ///
 pub fn syn_state_hwy(name: &Name, context: &Context) -> Vec<Name> {
-
     let region = match context.region {
         Some(ref region) => region,
-        None => { return Vec::new() }
+        None => return Vec::new(),
     };
 
     let region_name = match context.region_name() {
         Some(region) => region,
-        None => { return Vec::new() }
+        None => return Vec::new(),
     };
 
     // the goal is to get all the input highways to <state> #### and then format the matrix
@@ -601,37 +753,78 @@ pub fn syn_state_hwy(name: &Name, context: &Context) -> Vec<Name> {
         Some(capture) => capture["num"].to_string(),
         None => match POST_HWY.captures(name.display.as_str()) {
             Some(capture) => capture["num"].to_string(),
-            None => { return Vec::new(); }
-        }
+            None => {
+                return Vec::new();
+            }
+        },
     };
 
     let mut syns: Vec<Name> = Vec::with_capacity(7);
     // if the original feature has a priority of < 0, ensure the display form synonym priority isn't
     // > the address and primary network names. Otherwise ensure it's always > the original name
-    let display_priority = if name.priority >= 0 { name.priority + 1 } else { -1 };
+    let display_priority = if name.priority >= 0 {
+        name.priority + 1
+    } else {
+        -1
+    };
     // <State> Highway 123 (Display Form)
-    syns.push(Name::new(format!("{} Highway {}", &region_name, &highway), display_priority, Some(Source::Generated), &context));
+    syns.push(Name::new(
+        format!("{} Highway {}", &region_name, &highway),
+        display_priority,
+        Some(Source::Generated),
+        &context,
+    ));
 
     // Ensure non display form synonyms always have a priority of < 0 and < the original name
     let priority_offset = std::cmp::min(0, name.priority);
 
     // NC 123 Highway
-    syns.push(Name::new(format!("{} {} Highway", region.to_uppercase(), &highway), priority_offset - 2, Some(Source::Generated), &context));
+    syns.push(Name::new(
+        format!("{} {} Highway", region.to_uppercase(), &highway),
+        priority_offset - 2,
+        Some(Source::Generated),
+        &context,
+    ));
 
     // NC 123
-    syns.push(Name::new(format!("{} {}", region.to_uppercase(), &highway), priority_offset - 1, Some(Source::Generated), &context));
+    syns.push(Name::new(
+        format!("{} {}", region.to_uppercase(), &highway),
+        priority_offset - 1,
+        Some(Source::Generated),
+        &context,
+    ));
 
     // Highway 123
-    syns.push(Name::new(format!("Highway {}", &highway), priority_offset - 2, Some(Source::Generated), &context));
+    syns.push(Name::new(
+        format!("Highway {}", &highway),
+        priority_offset - 2,
+        Some(Source::Generated),
+        &context,
+    ));
 
     // SR 123 (State Route)
-    syns.push(Name::new(format!("SR {}", &highway), priority_offset - 1, Some(Source::Generated), &context));
+    syns.push(Name::new(
+        format!("SR {}", &highway),
+        priority_offset - 1,
+        Some(Source::Generated),
+        &context,
+    ));
 
     //State Highway 123
-    syns.push(Name::new(format!("State Highway {}", &highway), priority_offset - 1, Some(Source::Generated), &context));
+    syns.push(Name::new(
+        format!("State Highway {}", &highway),
+        priority_offset - 1,
+        Some(Source::Generated),
+        &context,
+    ));
 
     //State Route 123
-    syns.push(Name::new(format!("State Route {}", &highway), priority_offset - 1, Some(Source::Generated), &context));
+    syns.push(Name::new(
+        format!("State Route {}", &highway),
+        priority_offset - 1,
+        Some(Source::Generated),
+        &context,
+    ));
 
     syns
 }
@@ -639,7 +832,7 @@ pub fn syn_state_hwy(name: &Name, context: &Context) -> Vec<Name> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Name, Context, Tokens};
+    use crate::{Context, Name, Tokens};
 
     #[test]
     fn test_distance() {
@@ -647,19 +840,58 @@ mod tests {
         assert_eq!(distance(&String::from("ab"), &String::from("ac")), 1);
         assert_eq!(distance(&String::from("ac"), &String::from("bc")), 1);
         assert_eq!(distance(&String::from("abc"), &String::from("axc")), 1);
-        assert_eq!(distance(&String::from("xabxcdxxefxgx"), &String::from("1ab2cd34ef5g6")), 6);
+        assert_eq!(
+            distance(
+                &String::from("xabxcdxxefxgx"),
+                &String::from("1ab2cd34ef5g6")
+            ),
+            6
+        );
 
-        assert_eq!(distance(&String::from("xabxcdxxefxgx"), &String::from("abcdefg")), 6);
-        assert_eq!(distance(&String::from("javawasneat"), &String::from("scalaisgreat")), 7);
-        assert_eq!(distance(&String::from("example"), &String::from("samples")), 3);
-        assert_eq!(distance(&String::from("forward"), &String::from("drawrof")), 6);
-        assert_eq!(distance(&String::from("sturgeon"), &String::from("urgently")), 6 );
-        assert_eq!(distance(&String::from("levenshtein"), &String::from("frankenstein")), 6 );
-        assert_eq!(distance(&String::from("distance"), &String::from("difference")), 5 );
-        assert_eq!(distance(&String::from("distance"), &String::from("eistancd")), 2 );
+        assert_eq!(
+            distance(&String::from("xabxcdxxefxgx"), &String::from("abcdefg")),
+            6
+        );
+        assert_eq!(
+            distance(&String::from("javawasneat"), &String::from("scalaisgreat")),
+            7
+        );
+        assert_eq!(
+            distance(&String::from("example"), &String::from("samples")),
+            3
+        );
+        assert_eq!(
+            distance(&String::from("forward"), &String::from("drawrof")),
+            6
+        );
+        assert_eq!(
+            distance(&String::from("sturgeon"), &String::from("urgently")),
+            6
+        );
+        assert_eq!(
+            distance(&String::from("levenshtein"), &String::from("frankenstein")),
+            6
+        );
+        assert_eq!(
+            distance(&String::from("distance"), &String::from("difference")),
+            5
+        );
+        assert_eq!(
+            distance(&String::from("distance"), &String::from("eistancd")),
+            2
+        );
 
-        assert_eq!(distance(&String::from("你好世界"), &String::from("你好")), 2);
-        assert_eq!(distance(&String::from("因為我是中國人所以我會說中文"), &String::from("因為我是英國人所以我會說英文")), 2);
+        assert_eq!(
+            distance(&String::from("你好世界"), &String::from("你好")),
+            2
+        );
+        assert_eq!(
+            distance(
+                &String::from("因為我是中國人所以我會說中文"),
+                &String::from("因為我是英國人所以我會說英文")
+            ),
+            2
+        );
 
         assert_eq!(distance(
             &String::from("Morbi interdum ultricies neque varius condimentum. Donec volutpat turpis interdum metus ultricies vulputate. Duis ultricies rhoncus sapien, sit amet fermentum risus imperdiet vitae. Ut et lectus"),
@@ -669,566 +901,1871 @@ mod tests {
 
     #[test]
     fn test_is_drivethrough() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
-        assert_eq!(is_drivethrough(
-            &String::from("Main St NE"),
-            &context
-        ), false);
+        assert_eq!(
+            is_drivethrough(&String::from("Main St NE"), &context),
+            false
+        );
 
-        assert_eq!(is_drivethrough(
-            &String::from("McDonalds einfahrt"),
-            &context
-        ), false);
+        assert_eq!(
+            is_drivethrough(&String::from("McDonalds einfahrt"), &context),
+            false
+        );
 
-        let context = Context::new(String::from("de"), None, Tokens::new(HashMap::new()));
-        assert_eq!(is_drivethrough(
-            &String::from("McDonalds einfahrt"),
-            &context
-        ), true);
+        let context = Context::new(
+            String::from("de"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
+        assert_eq!(
+            is_drivethrough(&String::from("McDonalds einfahrt"), &context),
+            true
+        );
 
-        assert_eq!(is_drivethrough(
-            &String::from("Burger King Drive-through"),
-            &context
-        ), true);
+        assert_eq!(
+            is_drivethrough(&String::from("Burger King Drive-through"), &context),
+            true
+        );
 
-        assert_eq!(is_drivethrough(
-            &String::from("McDonalds Drivethrough"),
-            &context
-        ), true);
+        assert_eq!(
+            is_drivethrough(&String::from("McDonalds Drivethrough"), &context),
+            true
+        );
 
-        assert_eq!(is_drivethrough(
-            &String::from("McDonalds Drive through"),
-            &context
-        ), true);
+        assert_eq!(
+            is_drivethrough(&String::from("McDonalds Drive through"), &context),
+            true
+        );
 
-        assert_eq!(is_drivethrough(
-            &String::from("McDonalds Drivethru"),
-            &context
-        ), true);
+        assert_eq!(
+            is_drivethrough(&String::from("McDonalds Drivethru"), &context),
+            true
+        );
     }
 
     #[test]
     fn test_is_undesireable() {
         let tokens = Tokens::generate(vec![String::from("en")]);
 
-        assert_eq!(is_undesireable(&tokens.process(&String::from("Main St NE"), &String::from(""))), false);
-        assert_eq!(is_undesireable(&tokens.process(&String::from("Main St NE Ext 25"), &String::from(""))), true);
-        assert_eq!(is_undesireable(&tokens.process(&String::from("Main St NE Connector 25"), &String::from(""))), true);
-        assert_eq!(is_undesireable(&tokens.process(&String::from("Main St NE Unit 25"), &String::from(""))), true);
-        assert_eq!(is_undesireable(&tokens.process(&String::from("Main St NE Apartment 25"), &String::from(""))), true);
-        assert_eq!(is_undesireable(&tokens.process(&String::from("Main St NE Shelby Apts"), &String::from(""))), true);
-        assert_eq!(is_undesireable(&tokens.process(&String::from("Main St NE Suite 25"), &String::from(""))), true);
-        assert_eq!(is_undesireable(&tokens.process(&String::from("Main St NE Lot 25"), &String::from(""))), true);
+        assert_eq!(
+            is_undesireable(&tokens.process(&String::from("Main St NE"), &String::from(""))),
+            false
+        );
+        assert_eq!(
+            is_undesireable(&tokens.process(&String::from("Main St NE Ext 25"), &String::from(""))),
+            true
+        );
+        assert_eq!(
+            is_undesireable(
+                &tokens.process(&String::from("Main St NE Connector 25"), &String::from(""))
+            ),
+            true
+        );
+        assert_eq!(
+            is_undesireable(
+                &tokens.process(&String::from("Main St NE Unit 25"), &String::from(""))
+            ),
+            true
+        );
+        assert_eq!(
+            is_undesireable(
+                &tokens.process(&String::from("Main St NE Apartment 25"), &String::from(""))
+            ),
+            true
+        );
+        assert_eq!(
+            is_undesireable(
+                &tokens.process(&String::from("Main St NE Shelby Apts"), &String::from(""))
+            ),
+            true
+        );
+        assert_eq!(
+            is_undesireable(
+                &tokens.process(&String::from("Main St NE Suite 25"), &String::from(""))
+            ),
+            true
+        );
+        assert_eq!(
+            is_undesireable(&tokens.process(&String::from("Main St NE Lot 25"), &String::from(""))),
+            true
+        );
     }
 
     #[test]
     fn test_syn_us_famous() {
-        let mut context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let mut context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
-        assert_eq!(syn_us_famous(&Name::new(String::from(""), 0, None, &context), &context), vec![]);
+        assert_eq!(
+            syn_us_famous(&Name::new(String::from(""), 0, None, &context), &context),
+            vec![]
+        );
 
         // original name priority == 0
         let results = vec![
             Name::new("John F Kennedy", 1, Some(Source::Generated), &context),
-            Name::new("JFK", -1, Some(Source::Generated), &context)
+            Name::new("JFK", -1, Some(Source::Generated), &context),
         ];
-        assert_eq!(syn_us_famous(&Name::new(String::from("JFK"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("J.F.K."), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("J F K"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("J. F. K."), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("John F Kennedy"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("John F. Kennedy"), 0, None, &context), &context), results);
+        assert_eq!(
+            syn_us_famous(&Name::new(String::from("JFK"), 0, None, &context), &context),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("J.F.K."), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("J F K"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("J. F. K."), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("John F Kennedy"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("John F. Kennedy"), 0, None, &context),
+                &context
+            ),
+            results
+        );
 
         let results = vec![
-            Name::new("John F Kennedy Highway", 1, Some(Source::Generated), &context),
-            Name::new("JFK Highway", -1, Some(Source::Generated), &context)
+            Name::new(
+                "John F Kennedy Highway",
+                1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new("JFK Highway", -1, Some(Source::Generated), &context),
         ];
-        assert_eq!(syn_us_famous(&Name::new(String::from("JFK Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("J.F.K Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("J F K Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("J. F. K. Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("John F Kennedy Highway"), 0, None, &context), &context), results);
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("JFK Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("J.F.K Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("J F K Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("J. F. K. Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("John F Kennedy Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
 
         let results = vec![
-            Name::new("NE John F Kennedy Highway", 1, Some(Source::Generated), &context),
-            Name::new("NE JFK Highway", -1, Some(Source::Generated), &context)
+            Name::new(
+                "NE John F Kennedy Highway",
+                1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new("NE JFK Highway", -1, Some(Source::Generated), &context),
         ];
 
-        assert_eq!(syn_us_famous(&Name::new(String::from("NE JFK Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("NE J.F.K Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("NE J F K Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("NE J. F. K. Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("NE John F Kennedy Highway"), 0, None, &context), &context), results);
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("NE JFK Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("NE J.F.K Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("NE J F K Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("NE J. F. K. Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("NE John F Kennedy Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
 
         // original name priority < 0
         let results = vec![
             Name::new("John F Kennedy", -1, Some(Source::Generated), &context),
-            Name::new("JFK", -2, Some(Source::Generated), &context)
+            Name::new("JFK", -2, Some(Source::Generated), &context),
         ];
-        assert_eq!(syn_us_famous(&Name::new(String::from("JFK"), -1, None, &context), &context), results);
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("JFK"), -1, None, &context),
+                &context
+            ),
+            results
+        );
 
         // original name priority > 0
         let results = vec![
             Name::new("John F Kennedy", 2, Some(Source::Generated), &context),
-            Name::new("JFK", -1, Some(Source::Generated), &context)
+            Name::new("JFK", -1, Some(Source::Generated), &context),
         ];
-        assert_eq!(syn_us_famous(&Name::new(String::from("JFK"), 1, None, &context), &context), results);
+        assert_eq!(
+            syn_us_famous(&Name::new(String::from("JFK"), 1, None, &context), &context),
+            results
+        );
 
         // original name priority == 0
         let results = vec![
-            Name::new("Martin Luther King Jr", 1, Some(Source::Generated), &context),
+            Name::new(
+                "Martin Luther King Jr",
+                1,
+                Some(Source::Generated),
+                &context,
+            ),
             Name::new("MLK", -1, Some(Source::Generated), &context),
             Name::new("M L K", -1, Some(Source::Generated), &context),
             Name::new("Martin Luther King", -1, Some(Source::Generated), &context),
             Name::new("MLK Jr", -1, Some(Source::Generated), &context),
-            Name::new("M L K Jr", -1, Some(Source::Generated), &context)
+            Name::new("M L K Jr", -1, Some(Source::Generated), &context),
         ];
-        assert_eq!(syn_us_famous(&Name::new(String::from("mlk"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("m l king"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("m l k"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("mlk jr"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("m l king jr"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("m l k jr"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("m l k junior"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("m. l. k. jr."), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("m. l. k. junior"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King Jr"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King Junior"), 0, None, &context), &context), results);
+        assert_eq!(
+            syn_us_famous(&Name::new(String::from("mlk"), 0, None, &context), &context),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("m l king"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("m l k"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("Martin Luther King"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("mlk jr"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("m l king jr"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("m l k jr"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("m l k junior"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("m. l. k. jr."), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("m. l. k. junior"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("Martin Luther King Jr"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("Martin Luther King Junior"), 0, None, &context),
+                &context
+            ),
+            results
+        );
 
         let results = vec![
-            Name::new("Martin Luther King Jr Highway", 1, Some(Source::Generated), &context),
+            Name::new(
+                "Martin Luther King Jr Highway",
+                1,
+                Some(Source::Generated),
+                &context,
+            ),
             Name::new("MLK Highway", -1, Some(Source::Generated), &context),
             Name::new("M L K Highway", -1, Some(Source::Generated), &context),
-            Name::new("Martin Luther King Highway", -1, Some(Source::Generated), &context),
+            Name::new(
+                "Martin Luther King Highway",
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
             Name::new("MLK Jr Highway", -1, Some(Source::Generated), &context),
-            Name::new("M L K Jr Highway", -1, Some(Source::Generated), &context)
+            Name::new("M L K Jr Highway", -1, Some(Source::Generated), &context),
         ];
-        assert_eq!(syn_us_famous(&Name::new(String::from("mlk Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("m l king Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("m l k Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("mlk jr Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("m l king jr Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("m l k jr Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("m l k junior Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King Jr Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("Martin Luther King Junior Highway"), 0, None, &context), &context), results);
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("mlk Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("m l king Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("m l k Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(
+                    String::from("Martin Luther King Highway"),
+                    0,
+                    None,
+                    &context
+                ),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("mlk jr Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("m l king jr Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("m l k jr Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("m l k junior Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(
+                    String::from("Martin Luther King Jr Highway"),
+                    0,
+                    None,
+                    &context
+                ),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(
+                    String::from("Martin Luther King Junior Highway"),
+                    0,
+                    None,
+                    &context
+                ),
+                &context
+            ),
+            results
+        );
 
         let results = vec![
-            Name::new("West Martin Luther King Jr Highway", 1, Some(Source::Generated), &context),
+            Name::new(
+                "West Martin Luther King Jr Highway",
+                1,
+                Some(Source::Generated),
+                &context,
+            ),
             Name::new("West MLK Highway", -1, Some(Source::Generated), &context),
             Name::new("West M L K Highway", -1, Some(Source::Generated), &context),
-            Name::new("West Martin Luther King Highway", -1, Some(Source::Generated), &context),
+            Name::new(
+                "West Martin Luther King Highway",
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
             Name::new("West MLK Jr Highway", -1, Some(Source::Generated), &context),
-            Name::new("West M L K Jr Highway", -1, Some(Source::Generated), &context)
+            Name::new(
+                "West M L K Jr Highway",
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
-        assert_eq!(syn_us_famous(&Name::new(String::from("West mlk Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("West m l king Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("West m l k Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("West Martin Luther King Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("West mlk jr Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("West m l king jr Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("West m l k jr Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("West m l k junior Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("West Martin Luther King Jr Highway"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_famous(&Name::new(String::from("West Martin Luther King Junior Highway"), 0, None, &context), &context), results);
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("West mlk Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("West m l king Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("West m l k Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(
+                    String::from("West Martin Luther King Highway"),
+                    0,
+                    None,
+                    &context
+                ),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("West mlk jr Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("West m l king jr Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("West m l k jr Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("West m l k junior Highway"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(
+                    String::from("West Martin Luther King Jr Highway"),
+                    0,
+                    None,
+                    &context
+                ),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(
+                    String::from("West Martin Luther King Junior Highway"),
+                    0,
+                    None,
+                    &context
+                ),
+                &context
+            ),
+            results
+        );
 
         // original name priority < 0
         let results = vec![
-            Name::new("Martin Luther King Jr", -1, Some(Source::Generated), &context),
+            Name::new(
+                "Martin Luther King Jr",
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
             Name::new("MLK", -2, Some(Source::Generated), &context),
             Name::new("M L K", -2, Some(Source::Generated), &context),
             Name::new("Martin Luther King", -2, Some(Source::Generated), &context),
             Name::new("MLK Jr", -2, Some(Source::Generated), &context),
-            Name::new("M L K Jr", -2, Some(Source::Generated), &context)
+            Name::new("M L K Jr", -2, Some(Source::Generated), &context),
         ];
-        assert_eq!(syn_us_famous(&Name::new(String::from("mlk"), -1, None, &context), &context), results);
+        assert_eq!(
+            syn_us_famous(
+                &Name::new(String::from("mlk"), -1, None, &context),
+                &context
+            ),
+            results
+        );
 
         // original name priority > 0
         let results = vec![
-            Name::new("Martin Luther King Jr", 2, Some(Source::Generated), &context),
+            Name::new(
+                "Martin Luther King Jr",
+                2,
+                Some(Source::Generated),
+                &context,
+            ),
             Name::new("MLK", -1, Some(Source::Generated), &context),
             Name::new("M L K", -1, Some(Source::Generated), &context),
             Name::new("Martin Luther King", -1, Some(Source::Generated), &context),
             Name::new("MLK Jr", -1, Some(Source::Generated), &context),
-            Name::new("M L K Jr", -1, Some(Source::Generated), &context)
+            Name::new("M L K Jr", -1, Some(Source::Generated), &context),
         ];
-        assert_eq!(syn_us_famous(&Name::new(String::from("mlk"), 1, None, &context), &context), results);
+        assert_eq!(
+            syn_us_famous(&Name::new(String::from("mlk"), 1, None, &context), &context),
+            results
+        );
 
         // @TODO remove, real world test case
-        context = Context::new(String::from("us"), None, Tokens::generate(vec![String::from("en")]));
+        context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::generate(vec![String::from("en")]),
+        );
 
         let input = vec![
             Name::new(String::from("NE M L King Blvd"), 0, None, &context),
-            Name::new(String::from("NE MARTIN LUTHER KING JR BLVD"), 0, None, &context),
+            Name::new(
+                String::from("NE MARTIN LUTHER KING JR BLVD"),
+                0,
+                None,
+                &context,
+            ),
             Name::new(String::from("NE M L KING BLVD"), 0, None, &context),
             Name::new(String::from("SE M L King Blvd"), 0, None, &context),
             Name::new(String::from("N M L King Blvd"), 0, None, &context),
-            Name::new(String::from("SE MARTIN LUTHER KING JR BLVD"), 0, None, &context),
+            Name::new(
+                String::from("SE MARTIN LUTHER KING JR BLVD"),
+                0,
+                None,
+                &context,
+            ),
             Name::new(String::from("NE MLK"), 0, None, &context),
-            Name::new(String::from("Northeast Martin Luther King Junior Boulevard"), 0, None, &context),
+            Name::new(
+                String::from("Northeast Martin Luther King Junior Boulevard"),
+                0,
+                None,
+                &context,
+            ),
             Name::new(String::from("OR 99E"), 0, None, &context),
-            Name::new(String::from("State Highway 99E"), 0, None, &context)
+            Name::new(String::from("State Highway 99E"), 0, None, &context),
         ];
         let mut output = vec![];
 
         for name in input {
-            let synonyms = syn_us_famous(&name,  &context);
+            let synonyms = syn_us_famous(&name, &context);
             for synonym in synonyms {
                 output.push(synonym);
             }
         }
 
-        assert_eq!(vec![
-            Name::new("NE Martin Luther King Jr Blvd", 1, Some(Source::Generated), &context),
-            Name::new("NE MLK Blvd", -1, Some(Source::Generated), &context),
-            Name::new("NE M L K Blvd", -1, Some(Source::Generated), &context),
-            Name::new("NE Martin Luther King Blvd", -1, Some(Source::Generated), &context),
-            Name::new("NE MLK Jr Blvd", -1, Some(Source::Generated), &context),
-            Name::new("NE M L K Jr Blvd", -1, Some(Source::Generated), &context),
-            Name::new("NE Martin Luther King Jr Blvd", 1, Some(Source::Generated), &context),
-            Name::new("NE MLK Blvd", -1, Some(Source::Generated), &context),
-            Name::new("NE M L K Blvd", -1, Some(Source::Generated), &context),
-            Name::new("NE Martin Luther King Blvd", -1, Some(Source::Generated), &context),
-            Name::new("NE MLK Jr Blvd", -1, Some(Source::Generated), &context),
-            Name::new("NE M L K Jr Blvd", -1, Some(Source::Generated), &context),
-            Name::new("NE Martin Luther King Jr Blvd", 1, Some(Source::Generated), &context),
-            Name::new("NE MLK Blvd", -1, Some(Source::Generated), &context),
-            Name::new("NE M L K Blvd", -1, Some(Source::Generated), &context),
-            Name::new("NE Martin Luther King Blvd", -1, Some(Source::Generated), &context),
-            Name::new("NE MLK Jr Blvd", -1, Some(Source::Generated), &context),
-            Name::new("NE M L K Jr Blvd", -1, Some(Source::Generated), &context),
-            Name::new("SE Martin Luther King Jr Blvd", 1, Some(Source::Generated), &context),
-            Name::new("SE MLK Blvd", -1, Some(Source::Generated), &context),
-            Name::new("SE M L K Blvd", -1, Some(Source::Generated), &context),
-            Name::new("SE Martin Luther King Blvd", -1, Some(Source::Generated), &context),
-            Name::new("SE MLK Jr Blvd", -1, Some(Source::Generated), &context),
-            Name::new("SE M L K Jr Blvd", -1, Some(Source::Generated), &context),
-            Name::new("N Martin Luther King Jr Blvd", 1, Some(Source::Generated), &context),
-            Name::new("N MLK Blvd", -1, Some(Source::Generated), &context),
-            Name::new("N M L K Blvd", -1, Some(Source::Generated), &context),
-            Name::new("N Martin Luther King Blvd", -1, Some(Source::Generated), &context),
-            Name::new("N MLK Jr Blvd", -1, Some(Source::Generated), &context),
-            Name::new("N M L K Jr Blvd", -1, Some(Source::Generated), &context),
-            Name::new("SE Martin Luther King Jr Blvd", 1, Some(Source::Generated), &context),
-            Name::new("SE MLK Blvd", -1, Some(Source::Generated), &context),
-            Name::new("SE M L K Blvd", -1, Some(Source::Generated), &context),
-            Name::new("SE Martin Luther King Blvd", -1, Some(Source::Generated), &context),
-            Name::new("SE MLK Jr Blvd", -1, Some(Source::Generated), &context),
-            Name::new("SE M L K Jr Blvd", -1, Some(Source::Generated), &context),
-            Name::new("NE Martin Luther King Jr", 1, Some(Source::Generated), &context),
-            Name::new("NE MLK", -1, Some(Source::Generated), &context),
-            Name::new("NE M L K", -1, Some(Source::Generated), &context),
-            Name::new("NE Martin Luther King", -1, Some(Source::Generated), &context),
-            Name::new("NE MLK Jr", -1, Some(Source::Generated), &context),
-            Name::new("NE M L K Jr", -1, Some(Source::Generated), &context),
-            Name::new("Northeast Martin Luther King Jr Boulevard", 1, Some(Source::Generated), &context),
-            Name::new("Northeast MLK Boulevard", -1, Some(Source::Generated), &context),
-            Name::new("Northeast M L K Boulevard", -1, Some(Source::Generated), &context),
-            Name::new("Northeast Martin Luther King Boulevard", -1, Some(Source::Generated), &context),
-            Name::new("Northeast MLK Jr Boulevard", -1, Some(Source::Generated), &context),
-            Name::new("Northeast M L K Jr Boulevard", -1, Some(Source::Generated), &context),
-        ], output);
+        assert_eq!(
+            vec![
+                Name::new(
+                    "NE Martin Luther King Jr Blvd",
+                    1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new("NE MLK Blvd", -1, Some(Source::Generated), &context),
+                Name::new("NE M L K Blvd", -1, Some(Source::Generated), &context),
+                Name::new(
+                    "NE Martin Luther King Blvd",
+                    -1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new("NE MLK Jr Blvd", -1, Some(Source::Generated), &context),
+                Name::new("NE M L K Jr Blvd", -1, Some(Source::Generated), &context),
+                Name::new(
+                    "NE Martin Luther King Jr Blvd",
+                    1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new("NE MLK Blvd", -1, Some(Source::Generated), &context),
+                Name::new("NE M L K Blvd", -1, Some(Source::Generated), &context),
+                Name::new(
+                    "NE Martin Luther King Blvd",
+                    -1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new("NE MLK Jr Blvd", -1, Some(Source::Generated), &context),
+                Name::new("NE M L K Jr Blvd", -1, Some(Source::Generated), &context),
+                Name::new(
+                    "NE Martin Luther King Jr Blvd",
+                    1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new("NE MLK Blvd", -1, Some(Source::Generated), &context),
+                Name::new("NE M L K Blvd", -1, Some(Source::Generated), &context),
+                Name::new(
+                    "NE Martin Luther King Blvd",
+                    -1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new("NE MLK Jr Blvd", -1, Some(Source::Generated), &context),
+                Name::new("NE M L K Jr Blvd", -1, Some(Source::Generated), &context),
+                Name::new(
+                    "SE Martin Luther King Jr Blvd",
+                    1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new("SE MLK Blvd", -1, Some(Source::Generated), &context),
+                Name::new("SE M L K Blvd", -1, Some(Source::Generated), &context),
+                Name::new(
+                    "SE Martin Luther King Blvd",
+                    -1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new("SE MLK Jr Blvd", -1, Some(Source::Generated), &context),
+                Name::new("SE M L K Jr Blvd", -1, Some(Source::Generated), &context),
+                Name::new(
+                    "N Martin Luther King Jr Blvd",
+                    1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new("N MLK Blvd", -1, Some(Source::Generated), &context),
+                Name::new("N M L K Blvd", -1, Some(Source::Generated), &context),
+                Name::new(
+                    "N Martin Luther King Blvd",
+                    -1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new("N MLK Jr Blvd", -1, Some(Source::Generated), &context),
+                Name::new("N M L K Jr Blvd", -1, Some(Source::Generated), &context),
+                Name::new(
+                    "SE Martin Luther King Jr Blvd",
+                    1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new("SE MLK Blvd", -1, Some(Source::Generated), &context),
+                Name::new("SE M L K Blvd", -1, Some(Source::Generated), &context),
+                Name::new(
+                    "SE Martin Luther King Blvd",
+                    -1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new("SE MLK Jr Blvd", -1, Some(Source::Generated), &context),
+                Name::new("SE M L K Jr Blvd", -1, Some(Source::Generated), &context),
+                Name::new(
+                    "NE Martin Luther King Jr",
+                    1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new("NE MLK", -1, Some(Source::Generated), &context),
+                Name::new("NE M L K", -1, Some(Source::Generated), &context),
+                Name::new(
+                    "NE Martin Luther King",
+                    -1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new("NE MLK Jr", -1, Some(Source::Generated), &context),
+                Name::new("NE M L K Jr", -1, Some(Source::Generated), &context),
+                Name::new(
+                    "Northeast Martin Luther King Jr Boulevard",
+                    1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new(
+                    "Northeast MLK Boulevard",
+                    -1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new(
+                    "Northeast M L K Boulevard",
+                    -1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new(
+                    "Northeast Martin Luther King Boulevard",
+                    -1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new(
+                    "Northeast MLK Jr Boulevard",
+                    -1,
+                    Some(Source::Generated),
+                    &context
+                ),
+                Name::new(
+                    "Northeast M L K Jr Boulevard",
+                    -1,
+                    Some(Source::Generated),
+                    &context
+                ),
+            ],
+            output
+        );
     }
 
     #[test]
     fn test_syn_us_cr() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
-        assert_eq!(syn_us_cr(&Name::new(String::from(""), 0, None, &context), &context), vec![]);
+        assert_eq!(
+            syn_us_cr(&Name::new(String::from(""), 0, None, &context), &context),
+            vec![]
+        );
 
         // original name priority == 0
         let results = vec![
-            Name::new(String::from("County Road 123"), 1, Some(Source::Generated), &context),
-            Name::new(String::from("CR 123"), -1, Some(Source::Generated), &context),
+            Name::new(
+                String::from("County Road 123"),
+                1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("CR 123"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
-        assert_eq!(syn_us_cr(&Name::new(String::from("County Road 123"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_cr(&Name::new(String::from("CR 123"), 0, None, &context), &context), results);
+        assert_eq!(
+            syn_us_cr(
+                &Name::new(String::from("County Road 123"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_cr(
+                &Name::new(String::from("CR 123"), 0, None, &context),
+                &context
+            ),
+            results
+        );
 
         // original name priority < 0
         let results = vec![
-            Name::new(String::from("County Road 123"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("CR 123"), -2, Some(Source::Generated), &context),
+            Name::new(
+                String::from("County Road 123"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("CR 123"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
-        assert_eq!(syn_us_cr(&Name::new(String::from("County Road 123"), -1, None, &context), &context), results);
+        assert_eq!(
+            syn_us_cr(
+                &Name::new(String::from("County Road 123"), -1, None, &context),
+                &context
+            ),
+            results
+        );
 
         // original name priority > 0
         let results = vec![
-            Name::new(String::from("County Road 123"), 2, Some(Source::Generated), &context),
-            Name::new(String::from("CR 123"), -1, Some(Source::Generated), &context),
+            Name::new(
+                String::from("County Road 123"),
+                2,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("CR 123"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
-        assert_eq!(syn_us_cr(&Name::new(String::from("County Road 123"), 1, None, &context), &context), results);
+        assert_eq!(
+            syn_us_cr(
+                &Name::new(String::from("County Road 123"), 1, None, &context),
+                &context
+            ),
+            results
+        );
     }
 
     #[test]
     fn test_syn_ca_french() {
-        let context = Context::new(String::from("ca"), Some(String::from("qc")), Tokens::new(HashMap::new()));
+        let context = Context::new(
+            String::from("ca"),
+            Some(String::from("qc")),
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
-        assert_eq!(syn_ca_french(&Name::new(String::from(""), 0, None, &context), &context), vec![]);
+        assert_eq!(
+            syn_ca_french(&Name::new(String::from(""), 0, None, &context), &context),
+            vec![]
+        );
 
         // Successful Replacements
-        assert_eq!(syn_ca_french(&Name::new(String::from("r principale"), 0, None, &context), &context), vec![
-            Name::new(String::from("principale"), -1, Some(Source::Generated), &context)
-        ]);
+        assert_eq!(
+            syn_ca_french(
+                &Name::new(String::from("r principale"), 0, None, &context),
+                &context
+            ),
+            vec![Name::new(
+                String::from("principale"),
+                -1,
+                Some(Source::Generated),
+                &context
+            )]
+        );
 
         // Ignored Replacements
-        assert_eq!(syn_ca_french(&Name::new(String::from("r des peupliers"), 0, None, &context), &context), vec![ ]);
-        assert_eq!(syn_ca_french(&Name::new(String::from("ch des hauteurs"), 0, None, &context), &context), vec![ ]);
-        assert_eq!(syn_ca_french(&Name::new(String::from("r du blizzard"), 0, None, &context), &context), vec![ ]);
-        assert_eq!(syn_ca_french(&Name::new(String::from("bd de lhotel de vl"), 0, None, &context), &context), vec![ ]);
+        assert_eq!(
+            syn_ca_french(
+                &Name::new(String::from("r des peupliers"), 0, None, &context),
+                &context
+            ),
+            vec![]
+        );
+        assert_eq!(
+            syn_ca_french(
+                &Name::new(String::from("ch des hauteurs"), 0, None, &context),
+                &context
+            ),
+            vec![]
+        );
+        assert_eq!(
+            syn_ca_french(
+                &Name::new(String::from("r du blizzard"), 0, None, &context),
+                &context
+            ),
+            vec![]
+        );
+        assert_eq!(
+            syn_ca_french(
+                &Name::new(String::from("bd de lhotel de vl"), 0, None, &context),
+                &context
+            ),
+            vec![]
+        );
     }
 
     #[test]
     fn test_syn_ny_beach() {
-        let context = Context::new(String::from("us"), Some(String::from("ny")), Tokens::new(HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            Some(String::from("ny")),
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
-        assert_eq!(syn_ny_beach(&Name::new(String::from(""), 0, None, &context), &context), vec![]);
+        assert_eq!(
+            syn_ny_beach(&Name::new(String::from(""), 0, None, &context), &context),
+            vec![]
+        );
 
         // original name priority == 0
         let results = vec![
-            Name::new(String::from("Beach 31st St"), 1, Some(Source::Generated), &context),
-            Name::new(String::from("B 31st St"), -1, Some(Source::Generated), &context)
+            Name::new(
+                String::from("Beach 31st St"),
+                1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("B 31st St"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
-        assert_eq!(syn_ny_beach(&Name::new(String::from("Beach 31st St"), 0, None, &context), &context), results);
-        assert_eq!(syn_ny_beach(&Name::new(String::from("Bch 31st St"), 0, None, &context), &context), results);
-        assert_eq!(syn_ny_beach(&Name::new(String::from("B 31st St"), 0, None, &context), &context), vec![]);
-        assert_eq!(syn_ny_beach(&Name::new(String::from("9B 31st St"), 0, None, &context), &context), vec![]);
+        assert_eq!(
+            syn_ny_beach(
+                &Name::new(String::from("Beach 31st St"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_ny_beach(
+                &Name::new(String::from("Bch 31st St"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_ny_beach(
+                &Name::new(String::from("B 31st St"), 0, None, &context),
+                &context
+            ),
+            vec![]
+        );
+        assert_eq!(
+            syn_ny_beach(
+                &Name::new(String::from("9B 31st St"), 0, None, &context),
+                &context
+            ),
+            vec![]
+        );
 
         // original name priority < 0
         let results = vec![
-            Name::new(String::from("Beach 31st St"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("B 31st St"), -2, Some(Source::Generated), &context)
+            Name::new(
+                String::from("Beach 31st St"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("B 31st St"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
-        assert_eq!(syn_ny_beach(&Name::new(String::from("Beach 31st St"), -1, None, &context), &context), results);
+        assert_eq!(
+            syn_ny_beach(
+                &Name::new(String::from("Beach 31st St"), -1, None, &context),
+                &context
+            ),
+            results
+        );
 
         // original name priority > 0
         let results = vec![
-            Name::new(String::from("Beach 31st St"), 2, Some(Source::Generated), &context),
-            Name::new(String::from("B 31st St"), -1, Some(Source::Generated), &context)
+            Name::new(
+                String::from("Beach 31st St"),
+                2,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("B 31st St"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
-        assert_eq!(syn_ny_beach(&Name::new(String::from("Beach 31st St"), 1, None, &context), &context), results);
+        assert_eq!(
+            syn_ny_beach(
+                &Name::new(String::from("Beach 31st St"), 1, None, &context),
+                &context
+            ),
+            results
+        );
     }
 
     #[test]
     fn test_syn_ca_hwy() {
         // Route preferencing proveninces
-        let context = Context::new(String::from("ca"), Some(String::from("on")), Tokens::new(HashMap::new()));
+        let context = Context::new(
+            String::from("ca"),
+            Some(String::from("on")),
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
-        assert_eq!(syn_ca_hwy(&Name::new(String::from(""), 0, None, &context), &context), vec![]);
+        assert_eq!(
+            syn_ca_hwy(&Name::new(String::from(""), 0, None, &context), &context),
+            vec![]
+        );
         // handle Trans Canada highways
-        assert_eq!(syn_ca_hwy(&Name::new(String::from("1"), 0, None, &context), &context), vec![]);
+        assert_eq!(
+            syn_ca_hwy(&Name::new(String::from("1"), 0, None, &context), &context),
+            vec![]
+        );
 
         // original name priority == 0
         let results = vec![
-            Name::new(String::from("Ontario Route 101"), 1, Some(Source::Generated), &context),
-            Name::new(String::from("Highway 101"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("Route 101"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("ON 101"), -2, Some(Source::Generated), &context)
+            Name::new(
+                String::from("Ontario Route 101"),
+                1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("Highway 101"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("Route 101"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("ON 101"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
-        assert_eq!(syn_ca_hwy(&Name::new(String::from("101"), 0, None, &context), &context), results);
-        assert_eq!(syn_ca_hwy(&Name::new(String::from("ON-101"), 0, None, &context), &context), results);
-        assert_eq!(syn_ca_hwy(&Name::new(String::from("Kings's Highway 101"), 0, None, &context), &context), results);
-        assert_eq!(syn_ca_hwy(&Name::new(String::from("Highway 101"), 0, None, &context), &context), results);
-        assert_eq!(syn_ca_hwy(&Name::new(String::from("Route 101"), 0, None, &context), &context), results);
-        assert_eq!(syn_ca_hwy(&Name::new(String::from("Ontario Highway 101"), 0, None, &context), &context), results);
+        assert_eq!(
+            syn_ca_hwy(&Name::new(String::from("101"), 0, None, &context), &context),
+            results
+        );
+        assert_eq!(
+            syn_ca_hwy(
+                &Name::new(String::from("ON-101"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_ca_hwy(
+                &Name::new(String::from("Kings's Highway 101"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_ca_hwy(
+                &Name::new(String::from("Highway 101"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_ca_hwy(
+                &Name::new(String::from("Route 101"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_ca_hwy(
+                &Name::new(String::from("Ontario Highway 101"), 0, None, &context),
+                &context
+            ),
+            results
+        );
 
         // Highway preferencing proveninces
-        let context = Context::new(String::from("ca"), Some(String::from("nb")), Tokens::new(HashMap::new()));
+        let context = Context::new(
+            String::from("ca"),
+            Some(String::from("nb")),
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
         let results = vec![
-            Name::new(String::from("New Brunswick Highway 101"), 1, Some(Source::Generated), &context),
-            Name::new(String::from("Highway 101"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("Route 101"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("NB 101"), -2, Some(Source::Generated), &context)
+            Name::new(
+                String::from("New Brunswick Highway 101"),
+                1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("Highway 101"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("Route 101"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("NB 101"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
-        assert_eq!(syn_ca_hwy(&Name::new(String::from("101"), 0, None, &context), &context), results);
-        assert_eq!(syn_ca_hwy(&Name::new(String::from("NB-101"), 0, None, &context), &context), results);
-        assert_eq!(syn_ca_hwy(&Name::new(String::from("Kings's Highway 101"), 0, None, &context), &context), results);
-        assert_eq!(syn_ca_hwy(&Name::new(String::from("Highway 101"), 0, None, &context), &context), results);
-        assert_eq!(syn_ca_hwy(&Name::new(String::from("Route 101"), 0, None, &context), &context), results);
-        assert_eq!(syn_ca_hwy(&Name::new(String::from("New Brunswick Highway 101"), 0, None, &context), &context), results);
+        assert_eq!(
+            syn_ca_hwy(&Name::new(String::from("101"), 0, None, &context), &context),
+            results
+        );
+        assert_eq!(
+            syn_ca_hwy(
+                &Name::new(String::from("NB-101"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_ca_hwy(
+                &Name::new(String::from("Kings's Highway 101"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_ca_hwy(
+                &Name::new(String::from("Highway 101"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_ca_hwy(
+                &Name::new(String::from("Route 101"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_ca_hwy(
+                &Name::new(String::from("New Brunswick Highway 101"), 0, None, &context),
+                &context
+            ),
+            results
+        );
 
         // original name priority < 0
         let results = vec![
-            Name::new(String::from("New Brunswick Highway 101"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("Highway 101"), -2, Some(Source::Generated), &context),
-            Name::new(String::from("Route 101"), -2, Some(Source::Generated), &context),
-            Name::new(String::from("NB 101"), -3, Some(Source::Generated), &context)
+            Name::new(
+                String::from("New Brunswick Highway 101"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("Highway 101"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("Route 101"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("NB 101"),
+                -3,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
-        assert_eq!(syn_ca_hwy(&Name::new(String::from("101"), -1, None, &context), &context), results);
+        assert_eq!(
+            syn_ca_hwy(
+                &Name::new(String::from("101"), -1, None, &context),
+                &context
+            ),
+            results
+        );
 
         // original name priority > 0
         let results = vec![
-            Name::new(String::from("New Brunswick Highway 101"), 2, Some(Source::Generated), &context),
-            Name::new(String::from("Highway 101"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("Route 101"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("NB 101"), -2, Some(Source::Generated), &context)
+            Name::new(
+                String::from("New Brunswick Highway 101"),
+                2,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("Highway 101"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("Route 101"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("NB 101"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
-        assert_eq!(syn_ca_hwy(&Name::new(String::from("101"), 1, None, &context), &context), results);
+        assert_eq!(
+            syn_ca_hwy(&Name::new(String::from("101"), 1, None, &context), &context),
+            results
+        );
     }
 
     #[test]
     fn test_syn_us_hwy() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
-        assert_eq!(syn_us_hwy(&Name::new(String::from(""), 0, None, &context), &context), vec![]);
+        assert_eq!(
+            syn_us_hwy(&Name::new(String::from(""), 0, None, &context), &context),
+            vec![]
+        );
 
         // original name priority == 0
         let results = vec![
-            Name::new(String::from("US Route 81"), 1, Some(Source::Generated), &context),
+            Name::new(
+                String::from("US Route 81"),
+                1,
+                Some(Source::Generated),
+                &context,
+            ),
             Name::new(String::from("US 81"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("US Highway 81"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("United States Route 81"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("United States Highway 81"), -1, Some(Source::Generated), &context)
+            Name::new(
+                String::from("US Highway 81"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("United States Route 81"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("United States Highway 81"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
 
-        assert_eq!(syn_us_hwy(&Name::new(String::from("us-81"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_hwy(&Name::new(String::from("US 81"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_hwy(&Name::new(String::from("U.S. Route 81"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_hwy(&Name::new(String::from("US Route 81"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_hwy(&Name::new(String::from("US Rte 81"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_hwy(&Name::new(String::from("US Hwy 81"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_hwy(&Name::new(String::from("US Highway 81"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_hwy(&Name::new(String::from("United States 81"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_hwy(&Name::new(String::from("United States Route 81"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_hwy(&Name::new(String::from("United States Highway 81"), 0, None, &context), &context), results);
-        assert_eq!(syn_us_hwy(&Name::new(String::from("United States Hwy 81"), 0, None, &context), &context), results);
+        assert_eq!(
+            syn_us_hwy(
+                &Name::new(String::from("us-81"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_hwy(
+                &Name::new(String::from("US 81"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_hwy(
+                &Name::new(String::from("U.S. Route 81"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_hwy(
+                &Name::new(String::from("US Route 81"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_hwy(
+                &Name::new(String::from("US Rte 81"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_hwy(
+                &Name::new(String::from("US Hwy 81"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_hwy(
+                &Name::new(String::from("US Highway 81"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_hwy(
+                &Name::new(String::from("United States 81"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_hwy(
+                &Name::new(String::from("United States Route 81"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_hwy(
+                &Name::new(String::from("United States Highway 81"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_us_hwy(
+                &Name::new(String::from("United States Hwy 81"), 0, None, &context),
+                &context
+            ),
+            results
+        );
 
         // original name priority < 0
         let results = vec![
-            Name::new(String::from("US Route 81"), -1, Some(Source::Generated), &context),
+            Name::new(
+                String::from("US Route 81"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
             Name::new(String::from("US 81"), -2, Some(Source::Generated), &context),
-            Name::new(String::from("US Highway 81"), -2, Some(Source::Generated), &context),
-            Name::new(String::from("United States Route 81"), -2, Some(Source::Generated), &context),
-            Name::new(String::from("United States Highway 81"), -2, Some(Source::Generated), &context)
+            Name::new(
+                String::from("US Highway 81"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("United States Route 81"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("United States Highway 81"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
 
-        assert_eq!(syn_us_hwy(&Name::new(String::from("US Route 81"), -1, None, &context), &context), results);
+        assert_eq!(
+            syn_us_hwy(
+                &Name::new(String::from("US Route 81"), -1, None, &context),
+                &context
+            ),
+            results
+        );
 
         // original name priority > 0
         let results = vec![
-            Name::new(String::from("US Route 81"), 2, Some(Source::Generated), &context),
+            Name::new(
+                String::from("US Route 81"),
+                2,
+                Some(Source::Generated),
+                &context,
+            ),
             Name::new(String::from("US 81"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("US Highway 81"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("United States Route 81"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("United States Highway 81"), -1, Some(Source::Generated), &context)
+            Name::new(
+                String::from("US Highway 81"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("United States Route 81"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("United States Highway 81"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
 
-        assert_eq!(syn_us_hwy(&Name::new(String::from("US Route 81"), 1, None, &context), &context), results);
-
+        assert_eq!(
+            syn_us_hwy(
+                &Name::new(String::from("US Route 81"), 1, None, &context),
+                &context
+            ),
+            results
+        );
     }
 
     #[test]
     fn test_syn_state_hwy() {
-        let context = Context::new(String::from("us"), Some(String::from("PA")), Tokens::new(HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            Some(String::from("PA")),
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
-        assert_eq!(syn_state_hwy(&Name::new(String::from(""), 0, None, &context), &context), vec![]);
+        assert_eq!(
+            syn_state_hwy(&Name::new(String::from(""), 0, None, &context), &context),
+            vec![]
+        );
 
         // original name priority == 0
         let results = vec![
-            Name::new(String::from("Pennsylvania Highway 123"), 1, Some(Source::Generated), &context),
-            Name::new(String::from("PA 123 Highway"), -2, Some(Source::Generated), &context),
-            Name::new(String::from("PA 123"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("Highway 123"), -2, Some(Source::Generated), &context),
-            Name::new(String::from("SR 123"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("State Highway 123"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("State Route 123"), -1, Some(Source::Generated), &context)
+            Name::new(
+                String::from("Pennsylvania Highway 123"),
+                1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("PA 123 Highway"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("PA 123"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("Highway 123"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("SR 123"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("State Highway 123"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("State Route 123"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
 
-        assert_eq!(syn_state_hwy(&Name::new(String::from("St Hwy 123"), 0, None, &context), &context), results);
-        assert_eq!(syn_state_hwy(&Name::new(String::from("St Rte 123"), 0, None, &context), &context), results);
-        assert_eq!(syn_state_hwy(&Name::new(String::from("State Highway 123"), 0, None, &context), &context), results);
-        assert_eq!(syn_state_hwy(&Name::new(String::from("Highway 123"), 0, None, &context),&context), results);
-        assert_eq!(syn_state_hwy(&Name::new(String::from("Hwy 123"), 0, None, &context), &context), results);
-        assert_eq!(syn_state_hwy(&Name::new(String::from("Pennsylvania Highway 123"), 0, None, &context), &context), results);
-        assert_eq!(syn_state_hwy(&Name::new(String::from("Pennsylvania Route 123"), 0, None, &context), &context), results);
-        assert_eq!(syn_state_hwy(&Name::new(String::from("PA 123"), 0, None, &context), &context), results);
-        assert_eq!(syn_state_hwy(&Name::new(String::from("PA-123"), 0, None, &context), &context), results);
-        assert_eq!(syn_state_hwy(&Name::new(String::from("US-PA-123"), 0, None, &context), &context), results);
+        assert_eq!(
+            syn_state_hwy(
+                &Name::new(String::from("St Hwy 123"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_state_hwy(
+                &Name::new(String::from("St Rte 123"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_state_hwy(
+                &Name::new(String::from("State Highway 123"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_state_hwy(
+                &Name::new(String::from("Highway 123"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_state_hwy(
+                &Name::new(String::from("Hwy 123"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_state_hwy(
+                &Name::new(String::from("Pennsylvania Highway 123"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_state_hwy(
+                &Name::new(String::from("Pennsylvania Route 123"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_state_hwy(
+                &Name::new(String::from("PA 123"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_state_hwy(
+                &Name::new(String::from("PA-123"), 0, None, &context),
+                &context
+            ),
+            results
+        );
+        assert_eq!(
+            syn_state_hwy(
+                &Name::new(String::from("US-PA-123"), 0, None, &context),
+                &context
+            ),
+            results
+        );
 
         // original name priority < 0
         let results = vec![
-            Name::new(String::from("Pennsylvania Highway 123"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("PA 123 Highway"), -3, Some(Source::Generated), &context),
-            Name::new(String::from("PA 123"), -2, Some(Source::Generated), &context),
-            Name::new(String::from("Highway 123"), -3, Some(Source::Generated), &context),
-            Name::new(String::from("SR 123"), -2, Some(Source::Generated), &context),
-            Name::new(String::from("State Highway 123"), -2, Some(Source::Generated), &context),
-            Name::new(String::from("State Route 123"), -2, Some(Source::Generated), &context)
+            Name::new(
+                String::from("Pennsylvania Highway 123"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("PA 123 Highway"),
+                -3,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("PA 123"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("Highway 123"),
+                -3,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("SR 123"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("State Highway 123"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("State Route 123"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
-        assert_eq!(syn_state_hwy(&Name::new(String::from("Pennsylvania Highway 123"), -1, None, &context), &context), results);
+        assert_eq!(
+            syn_state_hwy(
+                &Name::new(String::from("Pennsylvania Highway 123"), -1, None, &context),
+                &context
+            ),
+            results
+        );
 
         // original name priority > 0
         let results = vec![
-            Name::new(String::from("Pennsylvania Highway 123"), 2, Some(Source::Generated), &context),
-            Name::new(String::from("PA 123 Highway"), -2, Some(Source::Generated), &context),
-            Name::new(String::from("PA 123"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("Highway 123"), -2, Some(Source::Generated), &context),
-            Name::new(String::from("SR 123"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("State Highway 123"), -1, Some(Source::Generated), &context),
-            Name::new(String::from("State Route 123"), -1, Some(Source::Generated), &context)
+            Name::new(
+                String::from("Pennsylvania Highway 123"),
+                2,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("PA 123 Highway"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("PA 123"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("Highway 123"),
+                -2,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("SR 123"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("State Highway 123"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
+            Name::new(
+                String::from("State Route 123"),
+                -1,
+                Some(Source::Generated),
+                &context,
+            ),
         ];
-        assert_eq!(syn_state_hwy(&Name::new(String::from("Pennsylvania Highway 123"), 1, None, &context), &context ), results);
+        assert_eq!(
+            syn_state_hwy(
+                &Name::new(String::from("Pennsylvania Highway 123"), 1, None, &context),
+                &context
+            ),
+            results
+        );
     }
 
     #[test]
     fn test_syn_number_suffix() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
         assert_eq!(
-            syn_number_suffix(&Name::new(String::from("1st Avenue"), 0, None, &context), &context),
+            syn_number_suffix(
+                &Name::new(String::from("1st Avenue"), 0, None, &context),
+                &context
+            ),
             Vec::new()
         );
 
         assert_eq!(
-            syn_number_suffix(&Name::new(String::from("1 Avenue"), 0, None, &context), &context),
-            vec![Name::new(String::from("1st Avenue"), -1, Some(Source::Generated), &context)]
+            syn_number_suffix(
+                &Name::new(String::from("1 Avenue"), 0, None, &context),
+                &context
+            ),
+            vec![Name::new(
+                String::from("1st Avenue"),
+                -1,
+                Some(Source::Generated),
+                &context
+            )]
         );
 
         assert_eq!(
-            syn_number_suffix(&Name::new(String::from("2 Avenue"), 0, None, &context), &context),
-            vec![Name::new(String::from("2nd Avenue"), -1, Some(Source::Generated), &context)]
+            syn_number_suffix(
+                &Name::new(String::from("2 Avenue"), 0, None, &context),
+                &context
+            ),
+            vec![Name::new(
+                String::from("2nd Avenue"),
+                -1,
+                Some(Source::Generated),
+                &context
+            )]
         );
 
         assert_eq!(
-            syn_number_suffix(&Name::new(String::from("3 Street"), 0, None, &context), &context),
-            vec![Name::new(String::from("3rd Street"), -1, Some(Source::Generated), &context)]
+            syn_number_suffix(
+                &Name::new(String::from("3 Street"), 0, None, &context),
+                &context
+            ),
+            vec![Name::new(
+                String::from("3rd Street"),
+                -1,
+                Some(Source::Generated),
+                &context
+            )]
         );
 
         assert_eq!(
-            syn_number_suffix(&Name::new(String::from("4 Street"), 0, None, &context), &context),
-            vec![Name::new(String::from("4th Street"), -1, Some(Source::Generated), &context)]
+            syn_number_suffix(
+                &Name::new(String::from("4 Street"), 0, None, &context),
+                &context
+            ),
+            vec![Name::new(
+                String::from("4th Street"),
+                -1,
+                Some(Source::Generated),
+                &context
+            )]
         );
 
         assert_eq!(
-            syn_number_suffix(&Name::new(String::from("20 Street"), 0, None, &context), &context),
-            vec![Name::new(String::from("20th Street"), -1, Some(Source::Generated), &context)]
+            syn_number_suffix(
+                &Name::new(String::from("20 Street"), 0, None, &context),
+                &context
+            ),
+            vec![Name::new(
+                String::from("20th Street"),
+                -1,
+                Some(Source::Generated),
+                &context
+            )]
         );
 
         assert_eq!(
-            syn_number_suffix(&Name::new(String::from("21 Street"), 0, None, &context), &context),
-            vec![Name::new(String::from("21st Street"), -1, Some(Source::Generated), &context)]
+            syn_number_suffix(
+                &Name::new(String::from("21 Street"), 0, None, &context),
+                &context
+            ),
+            vec![Name::new(
+                String::from("21st Street"),
+                -1,
+                Some(Source::Generated),
+                &context
+            )]
         );
     }
 
     #[test]
     fn test_syn_written_numeric() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
-
-        assert_eq!(
-            syn_written_numeric(&Name::new(String::from("Twenty-third Avenue NW"), 0, None, &context), &context),
-            vec![Name::new(String::from("23rd Avenue NW"), -1, Some(Source::Generated), &context)]
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
         );
 
         assert_eq!(
-            syn_written_numeric(&Name::new(String::from("North twenty-Third Avenue"), 0, None, &context), &context),
-            vec![Name::new(String::from("North 23rd Avenue"), -1, Some(Source::Generated), &context)]
+            syn_written_numeric(
+                &Name::new(String::from("Twenty-third Avenue NW"), 0, None, &context),
+                &context
+            ),
+            vec![Name::new(
+                String::from("23rd Avenue NW"),
+                -1,
+                Some(Source::Generated),
+                &context
+            )]
         );
 
         assert_eq!(
-            syn_written_numeric(&Name::new(String::from("TWENTY-THIRD Avenue"), 0, None, &context), &context),
-            vec![Name::new(String::from("23rd Avenue"), -1, Some(Source::Generated), &context)]
+            syn_written_numeric(
+                &Name::new(String::from("North twenty-Third Avenue"), 0, None, &context),
+                &context
+            ),
+            vec![Name::new(
+                String::from("North 23rd Avenue"),
+                -1,
+                Some(Source::Generated),
+                &context
+            )]
+        );
+
+        assert_eq!(
+            syn_written_numeric(
+                &Name::new(String::from("TWENTY-THIRD Avenue"), 0, None, &context),
+                &context
+            ),
+            vec![Name::new(
+                String::from("23rd Avenue"),
+                -1,
+                Some(Source::Generated),
+                &context
+            )]
         );
     }
 
@@ -1247,7 +2784,11 @@ mod tests {
 
     #[test]
     fn test_is_numbered() {
-        let context = Context::new(String::from("us"), Some(String::from("PA")), Tokens::new(HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            Some(String::from("PA")),
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
         assert_eq!(
             is_numbered(&Name::new(String::from("main st"), 0, None, &context)),
@@ -1312,7 +2853,11 @@ mod tests {
 
     #[test]
     fn test_is_routish() {
-        let context = Context::new(String::from("us"), Some(String::from("PA")), Tokens::new(HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            Some(String::from("PA")),
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
         assert_eq!(
             is_routish(&Name::new(String::from("main st"), 0, None, &context)),
@@ -1335,7 +2880,12 @@ mod tests {
         );
 
         assert_eq!(
-            is_routish(&Name::new(String::from("US Route 50 East"), 0, None, &context)),
+            is_routish(&Name::new(
+                String::from("US Route 50 East"),
+                0,
+                None,
+                &context
+            )),
             Some(String::from("50"))
         );
 

--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -1718,11 +1718,10 @@ mod tests {
 
     #[test]
     fn test_syn_us_cr() {
-        let context = Context::new(
-            String::from("us"),
-            None,
-            Tokens::new(HashMap::new(), HashMap::new()),
-        );
+        let mut map: HashMap<String, ParsedToken> = HashMap::new();
+        let mut regex_map: HashMap<String, ParsedToken> = HashMap::new();
+        let tokens = Tokens::new(map, regex_map);
+        let context = Context::new(String::from("us"), None, tokens);
 
         assert_eq!(
             syn_us_cr(&Name::new(String::from(""), 0, None, &context), &context),

--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -179,18 +179,6 @@ pub fn str_remove_octo(text: &String) -> String {
 }
 
 ///
-/// Replace German street names that end in straße & str with strasse
-/// for better token matching
-///
-pub fn str_replace_strasse(text: &String) -> String {
-    lazy_static! {
-        static ref STRASSE: Regex = Regex::new(r"(straße|str)$").unwrap();
-    }
-
-    return STRASSE.replace_all(&text, "strasse").to_string();
-}
-
-///
 /// Detect Strings like `5 Avenue` and return a synonym like `5th Avenue` where possible
 ///
 pub fn syn_number_suffix(name: &Name, context: &Context) -> Vec<Name> {

--- a/native/src/text/titlecase.rs
+++ b/native/src/text/titlecase.rs
@@ -1,6 +1,6 @@
+use crate::Context;
 use regex::Regex;
 use unicode_segmentation::UnicodeSegmentation;
-use crate::Context;
 
 ///
 /// Titlecase input strings
@@ -8,11 +8,16 @@ use crate::Context;
 
 pub fn titlecase(text: &String, context: &Context) -> String {
     lazy_static! {
-        static ref WORD_BOUNDARY: Regex = Regex::new(r#"[\s\u2000-\u206F\u2E00-\u2E7F\\!#$%&()"*+,\-./:;<=>?@\[\]\^_{\|}~]+"#).unwrap();
+        static ref WORD_BOUNDARY: Regex =
+            Regex::new(r#"[\s\u2000-\u206F\u2E00-\u2E7F\\!#$%&()"*+,\-./:;<=>?@\[\]\^_{\|}~]+"#)
+                .unwrap();
     }
 
     let mut text = text.trim().to_lowercase();
-    text = Regex::new(r"\s+").unwrap().replace_all(&text, " ").to_string();
+    text = Regex::new(r"\s+")
+        .unwrap()
+        .replace_all(&text, " ")
+        .to_string();
     let mut new = String::new();
     let mut word_count = 0;
     let mut last_match = 0;
@@ -32,8 +37,7 @@ pub fn titlecase(text: &String, context: &Context) -> String {
         new.push_str(&capitalize(word, word_count, context));
     }
 
-    if context.country == String::from("US")
-    || context.country == String::from("CA") {
+    if context.country == String::from("US") || context.country == String::from("CA") {
         new = normalize_cardinals(&new)
     }
 
@@ -42,28 +46,28 @@ pub fn titlecase(text: &String, context: &Context) -> String {
 
 pub fn capitalize(word: &str, word_count: usize, context: &Context) -> String {
     const MINOR_EN: [&str; 40] = [
-        "a", "an", "and", "as", "at", "but", "by", "en", "for", "from", "how", "if", "in", "neither", "nor",
-        "of", "on", "only", "onto", "out", "or", "per", "so", "than", "that", "the", "to", "until", "up",
-        "upon", "v", "v.", "versus", "vs", "vs.", "via", "when", "with", "without", "yet"
+        "a", "an", "and", "as", "at", "but", "by", "en", "for", "from", "how", "if", "in",
+        "neither", "nor", "of", "on", "only", "onto", "out", "or", "per", "so", "than", "that",
+        "the", "to", "until", "up", "upon", "v", "v.", "versus", "vs", "vs.", "via", "when",
+        "with", "without", "yet",
     ];
 
     const MAJOR_EN: [&str; 2] = ["us", "dc"];
 
     const MINOR_DE: [&str; 1] = ["du"];
 
-    if (context.country == String::from("US")
-        || context.country == String::from("CA"))
-        && MAJOR_EN.contains(&word) {
+    if (context.country == String::from("US") || context.country == String::from("CA"))
+        && MAJOR_EN.contains(&word)
+    {
         return String::from(word).to_uppercase();
     }
     // don't apply lower casing to the first word in the string
     if word_count > 1 {
-        if (context.country == String::from("US")
-            || context.country == String::from("CA"))
-            && MINOR_EN.contains(&word) {
+        if (context.country == String::from("US") || context.country == String::from("CA"))
+            && MINOR_EN.contains(&word)
+        {
             return String::from(word);
-        } else if context.country == String::from("DE")
-            && MINOR_DE.contains(&word) {
+        } else if context.country == String::from("DE") && MINOR_DE.contains(&word) {
             return String::from(word);
         }
     }
@@ -71,26 +75,26 @@ pub fn capitalize(word: &str, word_count: usize, context: &Context) -> String {
     let mut graphemes = UnicodeSegmentation::graphemes(word, true);
     let first_grapheme = match graphemes.next() {
         Some(g) => g,
-        None => return String::from(word)
+        None => return String::from(word),
     };
     first_grapheme.to_uppercase() + graphemes.as_str()
 }
 
 pub fn normalize_cardinals(text: &str) -> String {
     lazy_static! {
-        static ref CARDINAL: Regex = Regex::new(r"(?i)(^|\s)(?P<cardinal>(n\.w\.|nw|n\.e\.|ne|s\.w\.|sw|s\.e\.|se))(\s|$)").unwrap();
+        static ref CARDINAL: Regex =
+            Regex::new(r"(?i)(^|\s)(?P<cardinal>(n\.w\.|nw|n\.e\.|ne|s\.w\.|sw|s\.e\.|se))(\s|$)")
+                .unwrap();
     }
     let output = match CARDINAL.captures(text) {
-        Some(capture) => {
-            match capture.name("cardinal") {
-                Some(mat) => {
-                    let cardinal = mat.as_str().to_uppercase().replace(".", "");
-                    text[..mat.start()].to_string() + &cardinal + &text[mat.end()..]
-                },
-                None => text.to_string()
+        Some(capture) => match capture.name("cardinal") {
+            Some(mat) => {
+                let cardinal = mat.as_str().to_uppercase().replace(".", "");
+                text[..mat.start()].to_string() + &cardinal + &text[mat.end()..]
             }
+            None => text.to_string(),
         },
-        None => text.to_string()
+        None => text.to_string(),
     };
     output
 }
@@ -98,49 +102,156 @@ pub fn normalize_cardinals(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
     use crate::Tokens;
+    use std::collections::HashMap;
 
     #[test]
     fn test_titlecase() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
-        assert_eq!(titlecase(&String::from("Väike-Sõjamäe"), &context), String::from("Väike-Sõjamäe"));
-        assert_eq!(titlecase(&String::from("Väike-sõjamäe"), &context), String::from("Väike-Sõjamäe"));
-        assert_eq!(titlecase(&String::from("väike-sõjamäe"), &context), String::from("Väike-Sõjamäe"));
-        assert_eq!(titlecase(&String::from("väike sõjamäe"), &context), String::from("Väike Sõjamäe"));
-        assert_eq!(titlecase(&String::from("väike  sõjamäe"), &context), String::from("Väike Sõjamäe"));
-        assert_eq!(titlecase(&String::from("Väike Sõjamäe"), &context), String::from("Väike Sõjamäe"));
-        assert_eq!(titlecase(&String::from("VäikeSõjamäe"), &context), String::from("Väikesõjamäe"));
-        assert_eq!(titlecase(&String::from("ámbar"), &context), String::from("Ámbar"));
-        assert_eq!(titlecase(&String::from("y̆ámbary̆"), &context), String::from("Y̆ámbary̆"));
-        assert_eq!(titlecase(&String::from("y\u{306}ámbary\u{306}"), &context), String::from("Y\u{306}ámbary\u{306}"));
+        assert_eq!(
+            titlecase(&String::from("Väike-Sõjamäe"), &context),
+            String::from("Väike-Sõjamäe")
+        );
+        assert_eq!(
+            titlecase(&String::from("Väike-sõjamäe"), &context),
+            String::from("Väike-Sõjamäe")
+        );
+        assert_eq!(
+            titlecase(&String::from("väike-sõjamäe"), &context),
+            String::from("Väike-Sõjamäe")
+        );
+        assert_eq!(
+            titlecase(&String::from("väike sõjamäe"), &context),
+            String::from("Väike Sõjamäe")
+        );
+        assert_eq!(
+            titlecase(&String::from("väike  sõjamäe"), &context),
+            String::from("Väike Sõjamäe")
+        );
+        assert_eq!(
+            titlecase(&String::from("Väike Sõjamäe"), &context),
+            String::from("Väike Sõjamäe")
+        );
+        assert_eq!(
+            titlecase(&String::from("VäikeSõjamäe"), &context),
+            String::from("Väikesõjamäe")
+        );
+        assert_eq!(
+            titlecase(&String::from("ámbar"), &context),
+            String::from("Ámbar")
+        );
+        assert_eq!(
+            titlecase(&String::from("y̆ámbary̆"), &context),
+            String::from("Y̆ámbary̆")
+        );
+        assert_eq!(
+            titlecase(&String::from("y\u{306}ámbary\u{306}"), &context),
+            String::from("Y\u{306}ámbary\u{306}")
+        );
         assert_eq!(titlecase(&String::from("ç"), &context), String::from("Ç"));
-        assert_eq!(titlecase(&String::from("Здравствуйте"), &context), String::from("Здравствуйте"));
-        assert_eq!(titlecase(&String::from("नमस्त"), &context), String::from("नमस्त"));
-        assert_eq!(titlecase(&String::from("abra CAda -bra"), &context), String::from("Abra Cada -Bra"));
-        assert_eq!(titlecase(&String::from("abra-CAda-bra"), &context), String::from("Abra-Cada-Bra"));
-        assert_eq!(titlecase(&String::from("our lady of whatever"), &context), String::from("Our Lady of Whatever"));
-        assert_eq!(titlecase(&String::from("our lady OF whatever"), &context), String::from("Our Lady of Whatever"));
-        assert_eq!(titlecase(&String::from("St Martin\"s Neck Road"), &context), String::from("St Martin\"S Neck Road"));
-        assert_eq!(titlecase(&String::from("St Martin's Neck Road"), &context), String::from("St Martin's Neck Road"));
-        assert_eq!(titlecase(&String::from("MT. MOOSILAUKE HWY"), &context), String::from("Mt. Moosilauke Hwy"));
-        assert_eq!(titlecase(&String::from("some  miscellaneous rd (what happens to parentheses?)"), &context), String::from("Some Miscellaneous Rd (What Happens to Parentheses?)"));
-        assert_eq!(titlecase(&String::from("main st NE"), &context), String::from("Main St NE"));
-        assert_eq!(titlecase(&String::from("main St NW"), &context), String::from("Main St NW"));
-        assert_eq!(titlecase(&String::from("SW Main St."), &context), String::from("SW Main St."));
-        assert_eq!(titlecase(&String::from("Main S.E. St"), &context), String::from("Main SE St"));
-        assert_eq!(titlecase(&String::from("main st ne"), &context), String::from("Main St NE"));
-        assert_eq!(titlecase(&String::from("nE. Main St"), &context), String::from("Ne. Main St"));
-        assert_eq!(titlecase(&String::from("us hwy 1"), &context), String::from("US Hwy 1"));
-        assert_eq!(titlecase(&String::from(" -a nice road- "), &context), String::from("-A Nice Road-"));
+        assert_eq!(
+            titlecase(&String::from("Здравствуйте"), &context),
+            String::from("Здравствуйте")
+        );
+        assert_eq!(
+            titlecase(&String::from("नमस्त"), &context),
+            String::from("नमस्त")
+        );
+        assert_eq!(
+            titlecase(&String::from("abra CAda -bra"), &context),
+            String::from("Abra Cada -Bra")
+        );
+        assert_eq!(
+            titlecase(&String::from("abra-CAda-bra"), &context),
+            String::from("Abra-Cada-Bra")
+        );
+        assert_eq!(
+            titlecase(&String::from("our lady of whatever"), &context),
+            String::from("Our Lady of Whatever")
+        );
+        assert_eq!(
+            titlecase(&String::from("our lady OF whatever"), &context),
+            String::from("Our Lady of Whatever")
+        );
+        assert_eq!(
+            titlecase(&String::from("St Martin\"s Neck Road"), &context),
+            String::from("St Martin\"S Neck Road")
+        );
+        assert_eq!(
+            titlecase(&String::from("St Martin's Neck Road"), &context),
+            String::from("St Martin's Neck Road")
+        );
+        assert_eq!(
+            titlecase(&String::from("MT. MOOSILAUKE HWY"), &context),
+            String::from("Mt. Moosilauke Hwy")
+        );
+        assert_eq!(
+            titlecase(
+                &String::from("some  miscellaneous rd (what happens to parentheses?)"),
+                &context
+            ),
+            String::from("Some Miscellaneous Rd (What Happens to Parentheses?)")
+        );
+        assert_eq!(
+            titlecase(&String::from("main st NE"), &context),
+            String::from("Main St NE")
+        );
+        assert_eq!(
+            titlecase(&String::from("main St NW"), &context),
+            String::from("Main St NW")
+        );
+        assert_eq!(
+            titlecase(&String::from("SW Main St."), &context),
+            String::from("SW Main St.")
+        );
+        assert_eq!(
+            titlecase(&String::from("Main S.E. St"), &context),
+            String::from("Main SE St")
+        );
+        assert_eq!(
+            titlecase(&String::from("main st ne"), &context),
+            String::from("Main St NE")
+        );
+        assert_eq!(
+            titlecase(&String::from("nE. Main St"), &context),
+            String::from("Ne. Main St")
+        );
+        assert_eq!(
+            titlecase(&String::from("us hwy 1"), &context),
+            String::from("US Hwy 1")
+        );
+        assert_eq!(
+            titlecase(&String::from(" -a nice road- "), &context),
+            String::from("-A Nice Road-")
+        );
         assert_eq!(titlecase(&String::from("-x"), &context), String::from("-X"));
         assert_eq!(titlecase(&String::from("x-"), &context), String::from("X-"));
-        assert_eq!(titlecase(&String::from(" *$&#()__ "), &context), String::from("*$&#()__"));
-        assert_eq!(titlecase(&String::from("BrandywiNE Street Northwest"), &context), String::from("Brandywine Street Northwest"));
+        assert_eq!(
+            titlecase(&String::from(" *$&#()__ "), &context),
+            String::from("*$&#()__")
+        );
+        assert_eq!(
+            titlecase(&String::from("BrandywiNE Street Northwest"), &context),
+            String::from("Brandywine Street Northwest")
+        );
 
-        let context = Context::new(String::from("de"), None, Tokens::new(HashMap::new()));
-        assert_eq!(titlecase(&String::from(" hast Du recht"), &context), String::from("Hast du Recht"));
-        assert_eq!(titlecase(&String::from("a 9, 80939 münchen, germany"), &context), String::from("A 9, 80939 München, Germany"));
+        let context = Context::new(
+            String::from("de"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
+        assert_eq!(
+            titlecase(&String::from(" hast Du recht"), &context),
+            String::from("Hast du Recht")
+        );
+        assert_eq!(
+            titlecase(&String::from("a 9, 80939 münchen, germany"), &context),
+            String::from("A 9, 80939 München, Germany")
+        );
     }
 }

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -30,10 +30,9 @@ impl Tokens {
                         map.insert(
                             diacritics(&tk.to_lowercase()),
                             ParsedToken::new(diacritics(&group.canonical.to_lowercase()), group.token_type.to_owned())
-                            ),
-                        );
+                            )
+                        }
                     }
-                }
                 if group.regex {
                     for tk in &group.tokens {
                         regex_map.insert(
@@ -281,6 +280,7 @@ mod tests {
     #[test]
     fn test_replacement_tokens() {
         let mut map: HashMap<String, ParsedToken> = HashMap::new();
+        let mut regex_map: HashMap<String, ParsedToken> = HashMap::new();
         map.insert(String::from("barter"), ParsedToken::new(String::from("foo"), None));
         map.insert(String::from("saint"), ParsedToken::new(String::from("st"), None));
         map.insert(String::from("street"), ParsedToken::new(String::from("st"), Some(TokenType::Way)));

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -58,21 +58,20 @@ impl Tokens {
 
         let mut tokenized: Vec<Tokenized> = Vec::with_capacity(tokens.len());
         for token in &tokens {
-            // for right now let's only apply regexes to Germany. English has a negative lookahead query that rust doesn't support
+            // for right now let's only apply regexes to Germany. English has a negative lookahead query that rust doesn't support.
             if country == &String::from("DE") {
                 match self.tokens.get(token) {
                     None => {
                         // apply regex before defaulting to tokenized.push(Tokenized::new(token.to_owned(), None))
-                        // loop through regexes to apply any rcanonical value eplacements that match
+                        // loop through regexes to apply any canonical replacements that match
                         let mut no_token_match = Tokenized::new(token.to_owned(), None);
                         for (regex_string, v) in self.regex_tokens.iter() {
                             let re = Regex::new(&format!(r"{}", regex_string));
                             if re.unwrap().is_match(token) {
                                 let re = Regex::new(&format!(r"{}", regex_string)).unwrap();
+                                let canonical: &str = &*v.canonical; // convert from std::string::String -> &str
                                 let regexed_token = re
-                                    .replace_all(&token, |_c: &regex::Captures| {
-                                        v.canonical.to_owned()
-                                    })
+                                    .replace_all(&token, canonical)
                                     .to_string();
                                 no_token_match =
                                     Tokenized::new(regexed_token, v.token_type.to_owned());
@@ -333,7 +332,7 @@ mod tests {
         let tokens = Tokens::generate(vec![String::from("de")]);
         assert_eq!(tokens.process(&String::from("Fresenbergstr"), &String::from("DE")),
         vec![
-            Tokenized::new(String::from("fresenbergstraße"), None),
+            Tokenized::new(String::from("fresenberg str"), None),
         ]);
     }
 

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -30,7 +30,7 @@ impl Tokens {
                         map.insert(
                             diacritics(&tk.to_lowercase()),
                             ParsedToken::new(diacritics(&group.canonical.to_lowercase()), group.token_type.to_owned())
-                            )
+                            );
                         }
                     }
                 if group.regex {

--- a/native/src/types/context.rs
+++ b/native/src/types/context.rs
@@ -1,18 +1,18 @@
-use std::collections::HashMap;
 use crate::text::Tokens;
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct InputContext {
     pub country: Option<String>,
     pub region: Option<String>,
-    pub languages: Option<Vec<String>>
+    pub languages: Option<Vec<String>>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Context {
     pub country: String,
     pub region: Option<String>,
-    pub tokens: Tokens
+    pub tokens: Tokens,
 }
 
 impl From<InputContext> for Context {
@@ -20,14 +20,13 @@ impl From<InputContext> for Context {
         let country = input.country.unwrap_or(String::from(""));
         let region = input.region;
         let tokens = match input.languages {
-            None => Tokens::new(HashMap::new()),
-            Some(languages) => Tokens::generate(languages)
+            None => Tokens::new(HashMap::new(), HashMap::new()),
+            Some(languages) => Tokens::generate(languages),
         };
 
         Context::new(country, region, tokens)
     }
 }
-
 
 impl Context {
     pub fn new(country: String, region: Option<String>, tokens: Tokens) -> Self {
@@ -35,16 +34,16 @@ impl Context {
             country: country.to_uppercase(),
             region: match region {
                 None => None,
-                Some(region) => Some(region.to_uppercase())
+                Some(region) => Some(region.to_uppercase()),
             },
-            tokens: tokens
+            tokens: tokens,
         }
     }
 
     pub fn region_code(&self) -> Option<String> {
         match self.region {
             None => None,
-            Some(ref region) => Some(format!("{}-{}", self.country, region))
+            Some(ref region) => Some(format!("{}-{}", self.country, region)),
         }
     }
 
@@ -108,7 +107,10 @@ impl Context {
                 m.insert(String::from("US-GU"), "Guam");
                 m.insert(String::from("US-MP"), "Northern Mariana Islands");
                 m.insert(String::from("US-PR"), "Puerto Rico");
-                m.insert(String::from("US-UM"), "United States Minor Outlying Islands");
+                m.insert(
+                    String::from("US-UM"),
+                    "United States Minor Outlying Islands",
+                );
                 m.insert(String::from("US-VI"), "Virgin Islands");
 
                 m.insert(String::from("CA-ON"), "Ontario");
@@ -133,8 +135,8 @@ impl Context {
             None => None,
             Some(ref code) => match REGIONS.get(code) {
                 None => None,
-                Some(name) => Some(format!("{}", name))
-            }
+                Some(name) => Some(format!("{}", name)),
+            },
         }
     }
 }
@@ -145,19 +147,37 @@ mod tests {
 
     #[test]
     fn context_test() {
-        assert_eq!(Context::new(String::from("us"), None, Tokens::new(HashMap::new())), Context {
-            country: String::from("US"),
-            region: None,
-            tokens: Tokens::new(HashMap::new())
-        });
+        assert_eq!(
+            Context::new(
+                String::from("us"),
+                None,
+                Tokens::new(HashMap::new(), HashMap::new())
+            ),
+            Context {
+                country: String::from("US"),
+                region: None,
+                tokens: Tokens::new(HashMap::new(), HashMap::new())
+            }
+        );
 
-        assert_eq!(Context::new(String::from("uS"), Some(String::from("wv")), Tokens::new(HashMap::new())), Context {
-            country: String::from("US"),
-            region: Some(String::from("WV")),
-            tokens: Tokens::new(HashMap::new())
-        });
+        assert_eq!(
+            Context::new(
+                String::from("uS"),
+                Some(String::from("wv")),
+                Tokens::new(HashMap::new(), HashMap::new())
+            ),
+            Context {
+                country: String::from("US"),
+                region: Some(String::from("WV")),
+                tokens: Tokens::new(HashMap::new(), HashMap::new())
+            }
+        );
 
-        let cntx = Context::new(String::from("uS"), Some(String::from("wv")), Tokens::new(HashMap::new()));
+        let cntx = Context::new(
+            String::from("uS"),
+            Some(String::from("wv")),
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
         assert_eq!(cntx.region_code(), Some(String::from("US-WV")));
 

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -408,7 +408,7 @@ mod tests {
 
     #[test]
     fn test_name() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(Name::new(String::from("main ST nw"), 0, None, &context), Name {
             display: String::from("Main St NW"),
@@ -514,7 +514,7 @@ mod tests {
 
     #[test]
     fn test_names_concat() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         let mut names = Names {
             names: vec![
@@ -600,7 +600,7 @@ mod tests {
 
     #[test]
     fn test_names_from_value() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         let expected = Names::new(vec![Name::new(String::from("Main St NE"), 0, Some(Source::Network), &context)], &context);
 
@@ -629,7 +629,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "1 network synonym must have greater priority: [InputName { display: \"Main St\", priority: -1 }, InputName { display: \"E Main St\", priority: -1 }]")]
     fn test_names_from_value_invalid_priority() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         let _names = Names::from_value(Some(json!([{
             "display": "Main St",
@@ -643,7 +643,7 @@ mod tests {
 
     #[test]
     fn test_names_has_diff() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         let a_name = Names::new(vec![Name::new("Main St", 0, None, &context)], &context);
         let b_name = Names::new(vec![Name::new("Main St", 0, None, &context)], &context);
@@ -858,7 +858,7 @@ mod tests {
 
     #[test]
     fn test_empty() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         let mut empty_a = Names::new(vec![Name::new(String::from(""), 0, None, &context)], &context);
         empty_a.empty();
@@ -875,7 +875,7 @@ mod tests {
 
     #[test]
     fn test_germany() {
-        let context = Context::new(String::from("de"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("de"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(
             Name::new(String::from("hauptstr"), 0, None, &context),

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -875,7 +875,11 @@ mod tests {
 
     #[test]
     fn test_germany() {
-        let context = Context::new(String::from("de"), None, Tokens::new(HashMap::new(), HashMap::new()));
+        let context = Context::new(
+            String::from("de"),
+            None,
+            Tokens::generate(vec![String::from("de")]),
+        );
 
         assert_eq!(
             Name::new(String::from("hauptstr"), 0, None, &context),
@@ -883,7 +887,7 @@ mod tests {
                 display: String::from("Hauptstr"),
                 priority: 0,
                 source: None,
-                tokenized: vec![Tokenized::new(String::from("hauptstraße"), None)],
+                tokenized: vec![Tokenized::new(String::from("hbf"), None)],
                 freq: 1
             }
         );

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -887,7 +887,7 @@ mod tests {
                 display: String::from("Hauptstr"),
                 priority: 0,
                 source: None,
-                tokenized: vec![Tokenized::new(String::from("hbf"), None)],
+                tokenized: vec![Tokenized::new(String::from("haupt str"), None)],
                 freq: 1
             }
         );
@@ -898,7 +898,7 @@ mod tests {
                 display: String::from("Kuferstr."),
                 priority: 0,
                 source: None,
-                tokenized: vec![Tokenized::new(String::from("kuferstraße"), None)],
+                tokenized: vec![Tokenized::new(String::from("kufer str"), None)],
                 freq: 1
             }
         );
@@ -909,7 +909,7 @@ mod tests {
                 display: String::from("Fresenbergstr"),
                 priority: -1,
                 source: None,
-                tokenized: vec![Tokenized::new(String::from("fresenbergstraße"), None)],
+                tokenized: vec![Tokenized::new(String::from("fresenberg str"), None)],
                 freq: 1
             }
         );

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -292,10 +292,6 @@ impl Name {
         if source != Some(Source::Generated) {
             display = titlecase(&display, &context);
         }
-        // standardize straße & str --> strasse
-        if context.country == String::from("DE") {
-            display = text::str_replace_strasse(&display);
-        }
 
         let tokenized = context.tokens.process(&display, &context.country);
 
@@ -884,21 +880,21 @@ mod tests {
         assert_eq!(
             Name::new(String::from("hauptstr"), 0, None, &context),
             Name {
-                display: String::from("Hauptstrasse"),
+                display: String::from("Hauptstr"),
                 priority: 0,
                 source: None,
-                tokenized: vec![Tokenized::new(String::from("hauptstrasse"), None)],
+                tokenized: vec![Tokenized::new(String::from("hauptstraße"), None)],
                 freq: 1
             }
         );
 
         assert_eq!(
-            Name::new(String::from("kuferstr"), 0, None, &context),
+            Name::new(String::from("kuferstr."), 0, None, &context),
             Name {
-                display: String::from("Kuferstrasse"),
+                display: String::from("Kuferstr."),
                 priority: 0,
                 source: None,
-                tokenized: vec![Tokenized::new(String::from("kuferstrasse"), None)],
+                tokenized: vec![Tokenized::new(String::from("kuferstraße"), None)],
                 freq: 1
             }
         );
@@ -906,10 +902,10 @@ mod tests {
         assert_eq!(
             Name::new(String::from("fresenbergstr"), -1, None, &context),
             Name {
-                display: String::from("Fresenbergstrasse"),
+                display: String::from("Fresenbergstr"),
                 priority: -1,
                 source: None,
-                tokenized: vec![Tokenized::new(String::from("fresenbergstrasse"), None)],
+                tokenized: vec![Tokenized::new(String::from("fresenbergstraße"), None)],
                 freq: 1
             }
         );

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -887,7 +887,7 @@ mod tests {
                 display: String::from("Hauptstr"),
                 priority: 0,
                 source: None,
-                tokenized: vec![Tokenized::new(String::from("haupt str"), None)],
+                tokenized: vec![Tokenized::new(String::from("hbf"), None)],
                 freq: 1
             }
         );

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -292,6 +292,10 @@ impl Name {
         if source != Some(Source::Generated) {
             display = titlecase(&display, &context);
         }
+        // standardize straße & str --> strasse
+        if context.country == String::from("DE") {
+            display = text::str_replace_strasse(&display);
+        }
 
         let tokenized = context.tokens.process(&display, &context.country);
 
@@ -871,5 +875,43 @@ mod tests {
         let mut empty_c = Names::new(vec![Name::new(String::from(""), 0, None, &context), Name::new(String::from("\t  \n"), 0, None, &context)], &context);
         empty_c.empty();
         assert_eq!(empty_c, Names { names: Vec::new() });
+    }
+
+    #[test]
+    fn test_germany() {
+        let context = Context::new(String::from("de"), None, Tokens::new(HashMap::new()));
+
+        assert_eq!(
+            Name::new(String::from("hauptstr"), 0, None, &context),
+            Name {
+                display: String::from("Hauptstrasse"),
+                priority: 0,
+                source: None,
+                tokenized: vec![Tokenized::new(String::from("hauptstrasse"), None)],
+                freq: 1
+            }
+        );
+
+        assert_eq!(
+            Name::new(String::from("kuferstr"), 0, None, &context),
+            Name {
+                display: String::from("Kuferstrasse"),
+                priority: 0,
+                source: None,
+                tokenized: vec![Tokenized::new(String::from("kuferstrasse"), None)],
+                freq: 1
+            }
+        );
+
+        assert_eq!(
+            Name::new(String::from("fresenbergstr"), -1, None, &context),
+            Name {
+                display: String::from("Fresenbergstrasse"),
+                priority: -1,
+                source: None,
+                tokenized: vec![Tokenized::new(String::from("fresenbergstrasse"), None)],
+                freq: 1
+            }
+        );
     }
 }

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -887,7 +887,7 @@ mod tests {
                 display: String::from("Hauptstr"),
                 priority: 0,
                 source: None,
-                tokenized: vec![Tokenized::new(String::from("hbf"), None)],
+                tokenized: vec![Tokenized::new(String::from("haupt str"), None)],
                 freq: 1
             }
         );

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -217,6 +217,34 @@ mod tests {
     use crate::{Context, Tokens, Name, Names};
     use crate::text::ParsedToken;
     use geocoder_abbreviations::TokenType;
+    
+    #[test]
+    fn test_de_linker() {
+        let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
+        let context = Context::new(String::from("de"), None, Tokens::new(tokens));
+
+        {
+            let a_name = Names::new(vec![Name::new("weserstrandstrasse", 0, None, &context)], &context);
+            let b_name = Names::new(vec![Name::new("weserstrandstr", 0, None, &context)], &context);
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));
+        }
+        {
+            let a_name = Names::new(vec![Name::new("kuferstr", 0, None, &context)], &context);
+            let b_name = Names::new(vec![Name::new("kuferstrasse", 0, None, &context)], &context);
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));
+        }
+        {
+            let a_name = Names::new(vec![Name::new("kuferstraße", 0, None, &context)], &context);
+            let b_name = Names::new(vec![Name::new("kuferstrasse", 0, None, &context)], &context);
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));
+        }
+    }
 
     #[test]
     fn test_linker() {

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -222,11 +222,21 @@ mod tests {
     fn test_de_linker() {
         let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
         let mut regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let context = Context::new(String::from("de"), None, Tokens::new(tokens, regex_tokens));
+        let context = Context::new(
+            String::from("de"),
+            None,
+            Tokens::generate(vec![String::from("de")]),
+        );
 
         {
-            let a_name = Names::new(vec![Name::new("weserstrandstrasse", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("weserstrandstr", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("weserstrandstrasse", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("weserstrandstr", 0, None, &context)],
+                &context,
+            );
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -221,7 +221,8 @@ mod tests {
     #[test]
     fn test_de_linker() {
         let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let context = Context::new(String::from("de"), None, Tokens::new(tokens));
+        let mut regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
+        let context = Context::new(String::from("de"), None, Tokens::new(tokens, regex_tokens));
 
         {
             let a_name = Names::new(vec![Name::new("weserstrandstrasse", 0, None, &context)], &context);
@@ -249,6 +250,7 @@ mod tests {
     #[test]
     fn test_linker() {
         let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
+        let mut regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
         tokens.insert(String::from("saint"), ParsedToken::new(String::from("st"), None));
         tokens.insert(String::from("street"), ParsedToken::new(String::from("st"), Some(TokenType::Way)));
         tokens.insert(String::from("st"), ParsedToken::new(String::from("st"), Some(TokenType::Way)));
@@ -269,7 +271,7 @@ mod tests {
         tokens.insert(String::from("w"), ParsedToken::new(String::from("w"), Some(TokenType::Cardinal)));
         tokens.insert(String::from("e"), ParsedToken::new(String::from("e"), Some(TokenType::Cardinal)));
 
-        let context = Context::new(String::from("us"), None, Tokens::new(tokens));
+        let context = Context::new(String::from("us"), None, Tokens::new(tokens, regex_tokens));
 
         // === Intentional Matches ===
         // The following tests should match one of the given potential matches


### PR DESCRIPTION
Add in functionality to apply regex patters to [native/src/text/tokens.rs](https://github.com/mapbox/pt2itp/blob/de_strasse/native/src/text/tokens.rs). 

For Germany only, for streets ending in "strasse", "str, or "straße" we will split these endings off into its own word. And then apply the token matching. For example: "banhofstrasse" => "banhof" => "bhf".

In testing a small cluster of addresses this change brought address_orphans down from 1183 to 212 & network_orphans down from 1764 to 801. 
