### PR TITLE
German "([^ ]+)(strasse|str|straße)" regex parsing

### DIFF
--- a/native/src/classify/mod.rs
+++ b/native/src/classify/mod.rs
@@ -69,7 +69,7 @@ pub fn classify(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         &conn,
         AddrStream::new(
             GeoStream::new(args.input),
-            crate::Context::new(String::from("xx"), None, Tokens::new(HashMap::new())),
+            crate::Context::new(String::from("xx"), None, Tokens::new(HashMap::new(), HashMap::new())),
             None
         )
     );

--- a/native/src/conflate/mod.rs
+++ b/native/src/conflate/mod.rs
@@ -100,7 +100,7 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
     let context = match args.context {
         Some(context) => crate::Context::from(context),
-        None => crate::Context::new(String::from(""), None, crate::Tokens::new(HashMap::new()))
+        None => crate::Context::new(String::from(""), None, crate::Tokens::new(HashMap::new(), HashMap::new()))
     };
 
     let pgaddress = pg::Address::new();

--- a/native/src/consensus/mod.rs
+++ b/native/src/consensus/mod.rs
@@ -79,7 +79,7 @@ pub fn consensus(mut cx: FunctionContext) -> JsResult<JsValue> {
 
     let context = match args.context {
         Some(context) => crate::Context::from(context),
-        None => crate::Context::new(String::from(""), None, crate::Tokens::new(HashMap::new()))
+        None => crate::Context::new(String::from(""), None, crate::Tokens::new(HashMap::new(), HashMap::new()))
     };
 
     let pgaddress = pg::Address::new();

--- a/native/src/dedupe/mod.rs
+++ b/native/src/dedupe/mod.rs
@@ -58,7 +58,7 @@ pub fn dedupe(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
     let context = match args.context {
         Some(context) => crate::Context::from(context),
-        None => crate::Context::new(String::from(""), None, crate::Tokens::new(HashMap::new()))
+        None => crate::Context::new(String::from(""), None, crate::Tokens::new(HashMap::new(), HashMap::new()))
     };
 
     let address = pg::Address::new();

--- a/native/src/map/mod.rs
+++ b/native/src/map/mod.rs
@@ -126,7 +126,7 @@ pub fn import_addr(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
     let context = match args.context {
         Some(context) => CrateContext::from(context),
-        None => CrateContext::new(String::from(""), None, Tokens::new(HashMap::new()))
+        None => CrateContext::new(String::from(""), None, Tokens::new(HashMap::new(), HashMap::new()))
     };
 
     let address = pg::Address::new();
@@ -163,7 +163,7 @@ pub fn import_net(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
     let context = match args.context {
         Some(context) => CrateContext::from(context),
-        None => CrateContext::new(String::from(""), None, Tokens::new(HashMap::new()))
+        None => CrateContext::new(String::from(""), None, Tokens::new(HashMap::new(), HashMap::new()))
     };
 
     let network = pg::Network::new();

--- a/native/src/text/mod.rs
+++ b/native/src/text/mod.rs
@@ -669,7 +669,7 @@ mod tests {
 
     #[test]
     fn test_is_drivethrough() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(is_drivethrough(
             &String::from("Main St NE"),
@@ -681,7 +681,7 @@ mod tests {
             &context
         ), false);
 
-        let context = Context::new(String::from("de"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("de"), None, Tokens::new(HashMap::new(), HashMap::new()));
         assert_eq!(is_drivethrough(
             &String::from("McDonalds einfahrt"),
             &context
@@ -724,7 +724,7 @@ mod tests {
 
     #[test]
     fn test_syn_us_famous() {
-        let mut context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let mut context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(syn_us_famous(&Name::new(String::from(""), 0, None, &context), &context), vec![]);
 
@@ -935,7 +935,7 @@ mod tests {
 
     #[test]
     fn test_syn_us_cr() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(syn_us_cr(&Name::new(String::from(""), 0, None, &context), &context), vec![]);
 
@@ -964,7 +964,7 @@ mod tests {
 
     #[test]
     fn test_syn_ca_french() {
-        let context = Context::new(String::from("ca"), Some(String::from("qc")), Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("ca"), Some(String::from("qc")), Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(syn_ca_french(&Name::new(String::from(""), 0, None, &context), &context), vec![]);
 
@@ -982,7 +982,7 @@ mod tests {
 
     #[test]
     fn test_syn_ny_beach() {
-        let context = Context::new(String::from("us"), Some(String::from("ny")), Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), Some(String::from("ny")), Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(syn_ny_beach(&Name::new(String::from(""), 0, None, &context), &context), vec![]);
 
@@ -1014,7 +1014,7 @@ mod tests {
     #[test]
     fn test_syn_ca_hwy() {
         // Route preferencing proveninces
-        let context = Context::new(String::from("ca"), Some(String::from("on")), Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("ca"), Some(String::from("on")), Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(syn_ca_hwy(&Name::new(String::from(""), 0, None, &context), &context), vec![]);
         // handle Trans Canada highways
@@ -1035,7 +1035,7 @@ mod tests {
         assert_eq!(syn_ca_hwy(&Name::new(String::from("Ontario Highway 101"), 0, None, &context), &context), results);
 
         // Highway preferencing proveninces
-        let context = Context::new(String::from("ca"), Some(String::from("nb")), Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("ca"), Some(String::from("nb")), Tokens::new(HashMap::new(), HashMap::new()));
         let results = vec![
             Name::new(String::from("New Brunswick Highway 101"), 1, Some(Source::Generated), &context),
             Name::new(String::from("Highway 101"), -1, Some(Source::Generated), &context),
@@ -1070,7 +1070,7 @@ mod tests {
 
     #[test]
     fn test_syn_us_hwy() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(syn_us_hwy(&Name::new(String::from(""), 0, None, &context), &context), vec![]);
 
@@ -1121,7 +1121,7 @@ mod tests {
 
     #[test]
     fn test_syn_state_hwy() {
-        let context = Context::new(String::from("us"), Some(String::from("PA")), Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), Some(String::from("PA")), Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(syn_state_hwy(&Name::new(String::from(""), 0, None, &context), &context), vec![]);
 
@@ -1174,7 +1174,7 @@ mod tests {
 
     #[test]
     fn test_syn_number_suffix() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(
             syn_number_suffix(&Name::new(String::from("1st Avenue"), 0, None, &context), &context),
@@ -1214,7 +1214,7 @@ mod tests {
 
     #[test]
     fn test_syn_written_numeric() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(
             syn_written_numeric(&Name::new(String::from("Twenty-third Avenue NW"), 0, None, &context), &context),
@@ -1247,7 +1247,7 @@ mod tests {
 
     #[test]
     fn test_is_numbered() {
-        let context = Context::new(String::from("us"), Some(String::from("PA")), Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), Some(String::from("PA")), Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(
             is_numbered(&Name::new(String::from("main st"), 0, None, &context)),
@@ -1312,7 +1312,7 @@ mod tests {
 
     #[test]
     fn test_is_routish() {
-        let context = Context::new(String::from("us"), Some(String::from("PA")), Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), Some(String::from("PA")), Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(
             is_routish(&Name::new(String::from("main st"), 0, None, &context)),

--- a/native/src/text/titlecase.rs
+++ b/native/src/text/titlecase.rs
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn test_titlecase() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(titlecase(&String::from("Väike-Sõjamäe"), &context), String::from("Väike-Sõjamäe"));
         assert_eq!(titlecase(&String::from("Väike-sõjamäe"), &context), String::from("Väike-Sõjamäe"));
@@ -139,7 +139,7 @@ mod tests {
         assert_eq!(titlecase(&String::from(" *$&#()__ "), &context), String::from("*$&#()__"));
         assert_eq!(titlecase(&String::from("BrandywiNE Street Northwest"), &context), String::from("Brandywine Street Northwest"));
 
-        let context = Context::new(String::from("de"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("de"), None, Tokens::new(HashMap::new(), HashMap::new()));
         assert_eq!(titlecase(&String::from(" hast Du recht"), &context), String::from("Hast du Recht"));
         assert_eq!(titlecase(&String::from("a 9, 80939 münchen, germany"), &context), String::from("A 9, 80939 München, Germany"));
     }

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -1,33 +1,46 @@
-use regex::Regex;
 use super::diacritics;
-use std::collections::HashMap;
 use geocoder_abbreviations::{Token, TokenType};
 use neon::prelude::*;
+use regex::Regex;
+use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Tokens {
-    tokens: HashMap<String, ParsedToken>
+    tokens: HashMap<String, ParsedToken>,
+    regex_tokens: HashMap<String, ParsedToken>,
 }
 
 impl Tokens {
-    pub fn new(tokens: HashMap<String, ParsedToken>) -> Self {
+    pub fn new(tokens: HashMap<String, ParsedToken>, regex_tokens: HashMap<String, ParsedToken>) -> Self {
         Tokens {
-            tokens: tokens
+            tokens: tokens,
+            regex_tokens: regex_tokens,
         }
     }
 
     pub fn generate(languages: Vec<String>) -> Self {
         let import: HashMap<String, Vec<Token>> = geocoder_abbreviations::config(languages).unwrap();
         let mut map: HashMap<String, ParsedToken> = HashMap::new();
+        let mut regex_map: HashMap<String, ParsedToken> = HashMap::new();
 
         for language in import.keys() {
             for group in import.get(language).unwrap() {
-                // if it's a simple, non regex token replacer
                 if !group.regex {
                     for tk in &group.tokens {
                         map.insert(
                             diacritics(&tk.to_lowercase()),
                             ParsedToken::new(diacritics(&group.canonical.to_lowercase()), group.token_type.to_owned())
+                            );
+                        }
+                    }
+                if group.regex {
+                    for tk in &group.tokens {
+                        regex_map.insert(
+                            tk.to_lowercase(),
+                            ParsedToken::new(
+                                group.canonical.to_lowercase(),
+                                group.token_type.to_owned(),
+                            ),
                         );
                     }
                 }
@@ -35,24 +48,57 @@ impl Tokens {
         }
 
         Tokens {
-            tokens: map
+            tokens: map,
+            regex_tokens: regex_map,
         }
     }
 
     pub fn process(&self, text: &String, country: &String) -> Vec<Tokenized> {
-        let tokens = self.tokenize(&text);
+        let tokens = self.tokenize(&text, &country);
 
         let mut tokenized: Vec<Tokenized> = Vec::with_capacity(tokens.len());
-
         for token in &tokens {
-            match self.tokens.get(token) {
-                None => {
-                    tokenized.push(Tokenized::new(token.to_owned(), None));
-                },
-                Some(t) => {
-                    tokenized.push(Tokenized::new(t.canonical.to_owned(), t.token_type.to_owned()));
+            // for right now let's only apply regexes to Germany. English has a negative lookahead query that rust doesn't support.
+            if country == &String::from("DE") {
+                match self.tokens.get(token) {
+                    None => {
+                        // apply regex before defaulting to tokenized.push(Tokenized::new(token.to_owned(), None))
+                        // loop through regexes to apply any canonical replacements that match
+                        let mut no_token_match = Tokenized::new(token.to_owned(), None);
+                        for (regex_string, v) in self.regex_tokens.iter() {
+                            let re = Regex::new(&format!(r"{}", regex_string));
+                            if re.unwrap().is_match(token) {
+                                let re = Regex::new(&format!(r"{}", regex_string)).unwrap();
+                                let canonical: &str = &*v.canonical; // convert from std::string::String -> &str
+                                let regexed_token = re
+                                    .replace_all(&token, canonical)
+                                    .to_string();
+                                no_token_match =
+                                    Tokenized::new(regexed_token, v.token_type.to_owned());
+                            }
+                        }
+                        tokenized.push(no_token_match);
+                    }
+                    Some(t) => {
+                        tokenized.push(Tokenized::new(
+                            t.canonical.to_owned(),
+                            t.token_type.to_owned(),
+                        ));
+                    }
+                };
+            } else {
+                match self.tokens.get(token) {
+                    None => {
+                        tokenized.push(Tokenized::new(token.to_owned(), None));
+                    }
+                    Some(t) => {
+                        tokenized.push(Tokenized::new(
+                            t.canonical.to_owned(),
+                            t.token_type.to_owned(),
+                        ));
+                    }
                 }
-            };
+            }
         }
         if country == &String::from("US") {
             tokenized = type_us_st(&tokens, tokenized);
@@ -65,7 +111,7 @@ impl Tokens {
     /// Remove all diacritics, punctuation non-space whitespace
     /// returning a vector of component tokens
     ///
-    fn tokenize(&self, text: &String) -> Vec<String> {
+    fn tokenize(&self, text: &String, country: &String) -> Vec<String> {
         let text = text.trim();
 
         lazy_static! {
@@ -144,7 +190,6 @@ pub fn type_us_st(tokens: &Vec<String>, mut tokenized: Vec<Tokenized>) -> Vec<To
     // check if original name contained "st"
     // don't modify if "street" or "saint" has already been tokenized
     if tokens.contains(&String::from("st")) {
-
         let mut st_index = Vec::new();
         let mut way_tokens = false;
         for (i, tk) in tokenized.iter().enumerate() {
@@ -177,7 +222,7 @@ pub fn tokenize_name(mut cx: FunctionContext) -> JsResult<JsValue> {
     let context = cx.argument::<JsValue>(1)?;
     let context: crate::types::InputContext = neon_serde::from_value(&mut cx, context)?;
     let context = crate::Context::from(context);
-    
+
     let tokenized = context.tokens.process(&name, &context.country);
 
     Ok(neon_serde::to_value(&mut cx, &tokenized)?)
@@ -198,7 +243,7 @@ mod tests {
 
     #[test]
     fn test_remove_diacritics() {
-        let tokens = Tokens::new(HashMap::new());
+        let tokens = Tokens::new(HashMap::new(), HashMap::new());
 
         // diacritics are removed from latin text
         assert_eq!(tokenized_string(tokens.process(&String::from("Hérê àrë søme wöřdš, including diacritics and puncatuation!"), &String::from(""))), String::from("here are some words including diacritics and puncatuation"));
@@ -218,7 +263,7 @@ mod tests {
 
     #[test]
     fn test_tokenize() {
-        let tokens = Tokens::new(HashMap::new());
+        let tokens = Tokens::new(HashMap::new(), HashMap::new());
 
         assert_eq!(tokenized_string(tokens.process(&String::from(""), &String::from(""))), String::from(""));
 
@@ -253,11 +298,12 @@ mod tests {
     #[test]
     fn test_replacement_tokens() {
         let mut map: HashMap<String, ParsedToken> = HashMap::new();
+        let mut regex_map: HashMap<String, ParsedToken> = HashMap::new();
         map.insert(String::from("barter"), ParsedToken::new(String::from("foo"), None));
         map.insert(String::from("saint"), ParsedToken::new(String::from("st"), None));
         map.insert(String::from("street"), ParsedToken::new(String::from("st"), Some(TokenType::Way)));
 
-        let tokens = Tokens::new(map);
+        let tokens = Tokens::new(map, regex_map);
 
         assert_eq!(tokens.process(&String::from("Main Street"), &String::from("")),
             vec![
@@ -279,6 +325,15 @@ mod tests {
                 Tokenized::new(String::from("foo"), None),
                 Tokenized::new(String::from("foo"), None)
             ]);
+    }
+
+    #[test]
+    fn test_de_replacement() {
+        let tokens = Tokens::generate(vec![String::from("de")]);
+        assert_eq!(tokens.process(&String::from("Fresenbergstr"), &String::from("DE")),
+        vec![
+            Tokenized::new(String::from("fresenberg str"), None),
+        ]);
     }
 
     #[test]

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -68,7 +68,6 @@ impl Tokens {
                         for (regex_string, v) in self.regex_tokens.iter() {
                             let re = Regex::new(&format!(r"{}", regex_string)).unwrap();
                             if re.is_match(token) {
-                                let re = Regex::new(&format!(r"{}", regex_string)).unwrap();
                                 let canonical: &str = &*v.canonical; // convert from std::string::String -> &str
                                 let regexed_token = re
                                     .replace_all(&token, canonical)

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -64,6 +64,8 @@ impl Tokens {
                     None => {
                         // apply regex before defaulting to tokenized.push(Tokenized::new(token.to_owned(), None))
                         // loop through regexes to apply any canonical replacements that match
+                        // TODO #1 add in ability to evaluate multiple regex tokens https://github.com/mapbox/pt2itp/issues/554
+                        // TODO #2 bring in `skipDiacriticStripping` flag from geocoder-abbreviations for if there's any case where we'll want to strip diacritics for a regex pattern https://github.com/mapbox/pt2itp/issues/554
                         let mut no_token_match = Tokenized::new(token.to_owned(), None);
                         for (regex_string, v) in self.regex_tokens.iter() {
                             let re = Regex::new(&format!(r"{}", regex_string)).unwrap();

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -222,7 +222,6 @@ pub fn tokenize_name(mut cx: FunctionContext) -> JsResult<JsValue> {
     let context = cx.argument::<JsValue>(1)?;
     let context: crate::types::InputContext = neon_serde::from_value(&mut cx, context)?;
     let context = crate::Context::from(context);
-
     let tokenized = context.tokens.process(&name, &context.country);
 
     Ok(neon_serde::to_value(&mut cx, &tokenized)?)

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -30,10 +30,10 @@ impl Tokens {
                         map.insert(
                             diacritics(&tk.to_lowercase()),
                             ParsedToken::new(diacritics(&group.canonical.to_lowercase()), group.token_type.to_owned())
-                            );
-                        }
+                        );
                     }
-                if group.regex {
+                }
+                else {
                     for tk in &group.tokens {
                         regex_map.insert(
                             tk.to_lowercase(),
@@ -54,7 +54,7 @@ impl Tokens {
     }
 
     pub fn process(&self, text: &String, country: &String) -> Vec<Tokenized> {
-        let tokens = self.tokenize(&text, &country);
+        let tokens = self.tokenize(&text);
 
         let mut tokenized: Vec<Tokenized> = Vec::with_capacity(tokens.len());
         for token in &tokens {
@@ -66,8 +66,8 @@ impl Tokens {
                         // loop through regexes to apply any canonical replacements that match
                         let mut no_token_match = Tokenized::new(token.to_owned(), None);
                         for (regex_string, v) in self.regex_tokens.iter() {
-                            let re = Regex::new(&format!(r"{}", regex_string));
-                            if re.unwrap().is_match(token) {
+                            let re = Regex::new(&format!(r"{}", regex_string)).unwrap();
+                            if re.is_match(token) {
                                 let re = Regex::new(&format!(r"{}", regex_string)).unwrap();
                                 let canonical: &str = &*v.canonical; // convert from std::string::String -> &str
                                 let regexed_token = re
@@ -111,7 +111,7 @@ impl Tokens {
     /// Remove all diacritics, punctuation non-space whitespace
     /// returning a vector of component tokens
     ///
-    fn tokenize(&self, text: &String, country: &String) -> Vec<String> {
+    fn tokenize(&self, text: &String) -> Vec<String> {
         let text = text.trim();
 
         lazy_static! {

--- a/native/src/types/context.rs
+++ b/native/src/types/context.rs
@@ -20,7 +20,7 @@ impl From<InputContext> for Context {
         let country = input.country.unwrap_or(String::from(""));
         let region = input.region;
         let tokens = match input.languages {
-            None => Tokens::new(HashMap::new()),
+            None => Tokens::new(HashMap::new(), HashMap::new()),
             Some(languages) => Tokens::generate(languages)
         };
 
@@ -145,19 +145,19 @@ mod tests {
 
     #[test]
     fn context_test() {
-        assert_eq!(Context::new(String::from("us"), None, Tokens::new(HashMap::new())), Context {
+        assert_eq!(Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new())), Context {
             country: String::from("US"),
             region: None,
-            tokens: Tokens::new(HashMap::new())
+            tokens: Tokens::new(HashMap::new(), HashMap::new())
         });
 
-        assert_eq!(Context::new(String::from("uS"), Some(String::from("wv")), Tokens::new(HashMap::new())), Context {
+        assert_eq!(Context::new(String::from("uS"), Some(String::from("wv")), Tokens::new(HashMap::new(), HashMap::new())), Context {
             country: String::from("US"),
             region: Some(String::from("WV")),
-            tokens: Tokens::new(HashMap::new())
+            tokens: Tokens::new(HashMap::new(), HashMap::new())
         });
 
-        let cntx = Context::new(String::from("uS"), Some(String::from("wv")), Tokens::new(HashMap::new()));
+        let cntx = Context::new(String::from("uS"), Some(String::from("wv")), Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(cntx.region_code(), Some(String::from("US-WV")));
 

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -408,7 +408,7 @@ mod tests {
 
     #[test]
     fn test_name() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         assert_eq!(Name::new(String::from("main ST nw"), 0, None, &context), Name {
             display: String::from("Main St NW"),
@@ -514,7 +514,7 @@ mod tests {
 
     #[test]
     fn test_names_concat() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         let mut names = Names {
             names: vec![
@@ -600,7 +600,7 @@ mod tests {
 
     #[test]
     fn test_names_from_value() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         let expected = Names::new(vec![Name::new(String::from("Main St NE"), 0, Some(Source::Network), &context)], &context);
 
@@ -629,7 +629,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "1 network synonym must have greater priority: [InputName { display: \"Main St\", priority: -1 }, InputName { display: \"E Main St\", priority: -1 }]")]
     fn test_names_from_value_invalid_priority() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         let _names = Names::from_value(Some(json!([{
             "display": "Main St",
@@ -643,7 +643,7 @@ mod tests {
 
     #[test]
     fn test_names_has_diff() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         let a_name = Names::new(vec![Name::new("Main St", 0, None, &context)], &context);
         let b_name = Names::new(vec![Name::new("Main St", 0, None, &context)], &context);
@@ -858,7 +858,7 @@ mod tests {
 
     #[test]
     fn test_empty() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         let mut empty_a = Names::new(vec![Name::new(String::from(""), 0, None, &context)], &context);
         empty_a.empty();

--- a/native/src/types/network.rs
+++ b/native/src/types/network.rs
@@ -159,7 +159,7 @@ mod tests {
         let context = Context::new(
             String::from("us"),
             Some(String::from("dc")),
-            Tokens::new(HashMap::new())
+            Tokens::new(HashMap::new(), HashMap::new())
         );
 
         let net = Network::new(feat, &context).unwrap();
@@ -170,7 +170,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "1 network synonym must have greater priority: [InputName { display: \"Main St\", priority: -1 }, InputName { display: \"E Main St\", priority: -1 }]")]
     fn test_network_invalid_priority() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new()));
+        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
 
         let feat: geojson::GeoJson = String::from(r#"{
             "type": "Feature",

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -217,10 +217,50 @@ mod tests {
     use crate::{Context, Tokens, Name, Names};
     use crate::text::ParsedToken;
     use geocoder_abbreviations::TokenType;
+    
+    #[test]
+    fn test_de_linker() {
+        let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
+        let mut regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
+        let context = Context::new(
+            String::from("de"),
+            None,
+            Tokens::generate(vec![String::from("de")]),
+        );
+
+        {
+            let a_name = Names::new(
+                vec![Name::new("weserstrandstrasse", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("weserstrandstr", 0, None, &context)],
+                &context,
+            );
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));
+        }
+        {
+            let a_name = Names::new(vec![Name::new("kuferstr", 0, None, &context)], &context);
+            let b_name = Names::new(vec![Name::new("kuferstrasse", 0, None, &context)], &context);
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));
+        }
+        {
+            let a_name = Names::new(vec![Name::new("kuferstraße", 0, None, &context)], &context);
+            let b_name = Names::new(vec![Name::new("kuferstrasse", 0, None, &context)], &context);
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));
+        }
+    }
 
     #[test]
     fn test_linker() {
         let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
+        let mut regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
         tokens.insert(String::from("saint"), ParsedToken::new(String::from("st"), None));
         tokens.insert(String::from("street"), ParsedToken::new(String::from("st"), Some(TokenType::Way)));
         tokens.insert(String::from("st"), ParsedToken::new(String::from("st"), Some(TokenType::Way)));
@@ -241,7 +281,7 @@ mod tests {
         tokens.insert(String::from("w"), ParsedToken::new(String::from("w"), Some(TokenType::Cardinal)));
         tokens.insert(String::from("e"), ParsedToken::new(String::from("e"), Some(TokenType::Cardinal)));
 
-        let context = Context::new(String::from("us"), None, Tokens::new(tokens));
+        let context = Context::new(String::from("us"), None, Tokens::new(tokens, regex_tokens));
 
         // === Intentional Matches ===
         // The following tests should match one of the given potential matches


### PR DESCRIPTION
Add in functionality to apply regex patters to [native/src/text/tokens.rs](https://github.com/mapbox/pt2itp/blob/de_regex/native/src/text/tokens.rs). 

For Germany only, for streets ending in "strasse", "str, or "straße" we will split these endings off into its own word. And then apply the token matching. For example: "banhofstrasse" => "banhof" => "bhf".

In testing a small cluster of addresses this change brought address_orphans down from 1183 to 212 & network_orphans down from 1764 to 801. 
