### PR TITLE
Check properties for the orphan flag before selecting them for inclusion in linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Addresses can have any number of name synonyms of equal or differing priority.
 | `street` | `String` or `Array` The name of the street - preferably non-abbreviated. If it's an array, it must contain an object for each street name synonym with the properties `display` for the street name and `priority` for the numeric ranking. |
 | `source` | `String` The source name of the data so a single input file can have a combination of multiple sources |
 | `output` | `Boolean` A boolean allowing pts to be used to calculate the ITP segment but not output in the final cluster |
+| `interpolate` | `Boolean` A boolean, when set to false, keeps the address as an orphan address by skipping its inclusion in the ITP process |
 
 ##### Example
 

--- a/native/src/conflate/mod.rs
+++ b/native/src/conflate/mod.rs
@@ -93,6 +93,7 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
             number TEXT,
             source TEXT,
             output BOOLEAN,
+            interpolate BOOLEAN,
             props JSONB,
             geom GEOMETRY(POINT, 4326)
         );

--- a/native/src/map/mod.rs
+++ b/native/src/map/mod.rs
@@ -364,7 +364,7 @@ pub fn link_process(conn: &impl postgres::GenericConnection, min: i64, max: i64)
                 match linker::linker(primary, potentials, false) {
                     Some(link_match) => {
                         match trans.execute(&*"
-                            UPDATE address SET netid = $1 WHERE id = $2;
+                            UPDATE address SET netid = $1 WHERE id = $2 AND interpolate = true;
                         ", &[&link_match.id, &id]) {
                             Err(err) => {
                                 println!("Transaction Statement Error: {}", err.to_string());

--- a/native/src/pg/address.rs
+++ b/native/src/pg/address.rs
@@ -41,6 +41,7 @@ impl Table for Address {
                 number TEXT,
                 source TEXT,
                 output BOOLEAN,
+                interpolate BOOLEAN,
                 props JSONB,
                 geom GEOMETRY(POINT, 4326)
             )
@@ -95,6 +96,7 @@ impl InputTable for Address {
                 number,
                 source,
                 output,
+                interpolate,
                 props,
                 geom
             )

--- a/native/src/pg/addresscluster.rs
+++ b/native/src/pg/addresscluster.rs
@@ -47,7 +47,7 @@ impl AddressCluster {
                             address
                         WHERE
                             netid IS NOT NULL AND
-                            (props->'orphan' is NULL OR props->'orphan' <> 'true')
+                            interpolate = true
                         GROUP BY
                             netid,
                             names

--- a/native/src/pg/addresscluster.rs
+++ b/native/src/pg/addresscluster.rs
@@ -46,7 +46,8 @@ impl AddressCluster {
                         FROM
                             address
                         WHERE
-                            netid IS NOT NULL
+                            netid IS NOT NULL AND
+                            (props->'orphan' is NULL OR props->'orphan' <> 'true')
                         GROUP BY
                             netid,
                             names

--- a/native/src/pg/addresscluster.rs
+++ b/native/src/pg/addresscluster.rs
@@ -46,8 +46,7 @@ impl AddressCluster {
                         FROM
                             address
                         WHERE
-                            netid IS NOT NULL AND
-                            interpolate = true
+                            netid IS NOT NULL
                         GROUP BY
                             netid,
                             names

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -287,7 +287,6 @@ impl Address {
                 number,
                 source,
                 output,
-                intrpolate,
                 props,
                 geom
             ) VALUES (
@@ -298,8 +297,7 @@ impl Address {
                 $5,
                 $6,
                 $7,
-                $8,
-                ST_SetSRID(ST_MakePoint($9, $10), 4326)
+                ST_SetSRID(ST_MakePoint($8, $9), 4326)
             )
         ",
                 table = table.to_string()
@@ -312,7 +310,6 @@ impl Address {
                 &self.number,
                 &self.source,
                 &self.output,
-                &self.interpolate,
                 &serde_json::value::Value::from(self.props.clone()),
                 &self.geom[0],
                 &self.geom[1],

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -429,7 +429,7 @@ mod tests {
 
             let addr = Address::new(feat, &context).unwrap();
 
-            assert_eq!(addr.to_tsv(), "80614173\t3\t[{\"display\":\"Rosewynne Ct\",\"priority\":-1,\"source\":\"Address\",\"tokenized\":[{\"token\":\"rosewynne\",\"token_type\":null},{\"token\":\"ct\",\"token_type\":\"Way\"}],\"freq\":1}]\t726\thamilton\ttrue\t{\"accuracy\":\"rooftop\",\"number\":\"726\",\"override:postcode\":\"45002\",\"source\":\"hamilton\",\"street\":[{\"display\":\"Rosewynne Ct\",\"priority\":0}],\"type\":\"residential\"}\t0101000020E6100000BD039722542F55C0437BAB64B6944340\n");
+            assert_eq!(addr.to_tsv(), "80614173\t3\t[{\"display\":\"Rosewynne Ct\",\"priority\":-1,\"source\":\"Address\",\"tokenized\":[{\"token\":\"rosewynne\",\"token_type\":null},{\"token\":\"ct\",\"token_type\":\"Way\"}],\"freq\":1}]\t726\thamilton\ttrue\ttrue\t{\"accuracy\":\"rooftop\",\"number\":\"726\",\"override:postcode\":\"45002\",\"source\":\"hamilton\",\"street\":[{\"display\":\"Rosewynne Ct\",\"priority\":0}],\"type\":\"residential\"}\t0101000020E6100000BD039722542F55C0437BAB64B6944340\n");
         }
 
         // street value is string
@@ -444,7 +444,7 @@ mod tests {
 
             let addr = Address::new(feat, &context).unwrap();
 
-            assert_eq!(addr.to_tsv(), "\t0\t[{\"display\":\"Hickory Hills Dr\",\"priority\":-1,\"source\":\"Address\",\"tokenized\":[{\"token\":\"hickory\",\"token_type\":null},{\"token\":\"hls\",\"token_type\":null},{\"token\":\"dr\",\"token_type\":\"Way\"}],\"freq\":1}]\t1272\tTIGER-2016\tfalse\t{\"number\":1272,\"source\":\"TIGER-2016\",\"street\":\"Hickory Hills Dr\"}\t0101000020E6100000096C0B88B40D55C00BF02796EB9B4340\n");
+            assert_eq!(addr.to_tsv(), "\t0\t[{\"display\":\"Hickory Hills Dr\",\"priority\":-1,\"source\":\"Address\",\"tokenized\":[{\"token\":\"hickory\",\"token_type\":null},{\"token\":\"hls\",\"token_type\":null},{\"token\":\"dr\",\"token_type\":\"Way\"}],\"freq\":1}]\t1272\tTIGER-2016\tfalse\ttrue\n{\"number\":1272,\"source\":\"TIGER-2016\",\"street\":\"Hickory Hills Dr\"}\t0101000020E6100000096C0B88B40D55C00BF02796EB9B4340\n");
         }
     }
 }

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -215,7 +215,7 @@ impl Address {
     pub fn to_tsv(self) -> String {
         let geom = postgis::ewkb::Point::new(self.geom[0], self.geom[1], Some(4326)).as_ewkb().to_hex_ewkb();
 
-        format!("{id}\t{version}\t{names}\t{number}\t{source}\t{output}\t{props}\t{geom}\n",
+        format!("{id}\t{version}\t{names}\t{number}\t{source}\t{output}\t{interpolate}\t{props}\t{geom}\n",
             id = match self.id {
                 None => String::from(""),
                 Some(id) => id.to_string()
@@ -223,6 +223,7 @@ impl Address {
             version = self.version,
             names = serde_json::to_string(&self.names.names).unwrap_or(String::from("")),
             output = self.output,
+            interpolate = self.interpolate,
             number = self.number,
             source = self.source,
             props = serde_json::value::Value::from(self.props),
@@ -246,6 +247,7 @@ impl Address {
                 number,
                 source,
                 output,
+                interpolate,
                 props,
                 geom
             ) VALUES (
@@ -256,6 +258,7 @@ impl Address {
                 $5,
                 $6,
                 $7,
+                $8,
                 ST_SetSRID(ST_MakePoint($8, $9), 4326)
             )
         ",
@@ -267,6 +270,7 @@ impl Address {
             &self.number,
             &self.source,
             &self.output,
+            &self.interpolate,
             &serde_json::value::Value::from(self.props.clone()),
             &self.geom[0],
             &self.geom[1]

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -434,7 +434,7 @@ mod tests {
 
         // street value is string
         {
-            let feat: geojson::GeoJson = String::from(r#"{"type":"Feature","properties":{"street":"Hickory Hills Dr","number":1272,"source":"TIGER-2016","output":false},"geometry":{"type":"Point","coordinates":[-84.21414376368934,39.21812703085023]}}"#).parse().unwrap();
+            let feat: geojson::GeoJson = String::from(r#"{"type":"Feature","properties":{"street":"Hickory Hills Dr","number":1272,"source":"TIGER-2016","output":false},"interpolate":true, "geometry":{"type":"Point","coordinates":[-84.21414376368934,39.21812703085023]}}"#).parse().unwrap();
 
             let context = Context::new(
                 String::from("us"),

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -259,7 +259,7 @@ impl Address {
                 $6,
                 $7,
                 $8,
-                ST_SetSRID(ST_MakePoint($8, $9), 4326)
+                ST_SetSRID(ST_MakePoint($9, $10), 4326)
             )
         ",
             table = table.to_string()

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -247,7 +247,6 @@ impl Address {
                 number,
                 source,
                 output,
-                interpolate,
                 props,
                 geom
             ) VALUES (
@@ -258,8 +257,7 @@ impl Address {
                 $5,
                 $6,
                 $7,
-                $8,
-                ST_SetSRID(ST_MakePoint($9, $10), 4326)
+                ST_SetSRID(ST_MakePoint($8, $9), 4326)
             )
         ",
             table = table.to_string()
@@ -270,7 +268,6 @@ impl Address {
             &self.number,
             &self.source,
             &self.output,
-            &self.interpolate,
             &serde_json::value::Value::from(self.props.clone()),
             &self.geom[0],
             &self.geom[1]

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -287,6 +287,7 @@ impl Address {
                 number,
                 source,
                 output,
+                intrpolate,
                 props,
                 geom
             ) VALUES (
@@ -297,7 +298,8 @@ impl Address {
                 $5,
                 $6,
                 $7,
-                ST_SetSRID(ST_MakePoint($8, $9), 4326)
+                $8,
+                ST_SetSRID(ST_MakePoint($9, $10), 4326)
             )
         ",
                 table = table.to_string()
@@ -310,6 +312,7 @@ impl Address {
                 &self.number,
                 &self.source,
                 &self.output,
+                &self.interpolate,
                 &serde_json::value::Value::from(self.props.clone()),
                 &self.geom[0],
                 &self.geom[1],

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -444,7 +444,7 @@ mod tests {
 
             let addr = Address::new(feat, &context).unwrap();
 
-            assert_eq!(addr.to_tsv(), "\t0\t[{\"display\":\"Hickory Hills Dr\",\"priority\":-1,\"source\":\"Address\",\"tokenized\":[{\"token\":\"hickory\",\"token_type\":null},{\"token\":\"hls\",\"token_type\":null},{\"token\":\"dr\",\"token_type\":\"Way\"}],\"freq\":1}]\t1272\tTIGER-2016\tfalse\ttrue\n{\"number\":1272,\"source\":\"TIGER-2016\",\"street\":\"Hickory Hills Dr\"}\t0101000020E6100000096C0B88B40D55C00BF02796EB9B4340\n");
+            assert_eq!(addr.to_tsv(), "\t0\t[{\"display\":\"Hickory Hills Dr\",\"priority\":-1,\"source\":\"Address\",\"tokenized\":[{\"token\":\"hickory\",\"token_type\":null},{\"token\":\"hls\",\"token_type\":null},{\"token\":\"dr\",\"token_type\":\"Way\"}],\"freq\":1}]\t1272\tTIGER-2016\tfalse\ttrue\t{\"number\":1272,\"source\":\"TIGER-2016\",\"street\":\"Hickory Hills Dr\"}\t0101000020E6100000096C0B88B40D55C00BF02796EB9B4340\n");
         }
     }
 }

--- a/test/match.test.js
+++ b/test/match.test.js
@@ -33,6 +33,7 @@ test('Match', (t) => {
             BEGIN;
             INSERT INTO address (names, number, geom) VALUES ('[{ "tokenized": [{ "token": "main", "token_type": null }, { "token": "st", "token_type": "Way"}], "display": "Main Street", "priority": 0, "freq": 1 }]', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326));
             INSERT INTO address (names, number, geom) VALUES ('[{ "tokenized": [{ "token": "fake", "token_type": null }, { "token": "av", "token_type": "Way"}], "display": "Fake Avenue", "priority": 0, "freq": 1 }]', 12, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326));
+            INSERT INTO address (names, number, geom, interpolate) VALUES ('[{ "tokenized": [{ "token": "main", "token_type": null }, { "token": "st", "token_type": "Way"}], "display": "Main Street", "priority": 0, "freq": 1 }]', 100, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326), false);
             COMMIT;
         `, (err) => {
             t.error(err);
@@ -74,6 +75,19 @@ test('Match', (t) => {
                     display: 'Fake Avenue',
                     tokenized: [{ token: 'fake', token_type: null }, { token: 'av', token_type: 'Way' }]
                 }],
+                netid: null
+            });
+
+            t.deepEquals(res.rows[2], {
+                id: '3',
+                names: [{
+                    priority: 0,
+                    freq: 1,
+                    display: 'Main Street',
+                    tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }]
+                }],
+                number: 100,
+                interpolate: false,
                 netid: null
             });
 

--- a/test/match.test.js
+++ b/test/match.test.js
@@ -89,9 +89,8 @@ test('Match', (t) => {
                     display: 'Main Street',
                     tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }]
                 }],
-                number: 100,
-                interpolate: false,
-                netid: null
+                netid: null,
+                interpolate: false
             });
 
             return done();

--- a/test/match.test.js
+++ b/test/match.test.js
@@ -33,7 +33,7 @@ test('Match', (t) => {
             BEGIN;
             INSERT INTO address (names, number, geom) VALUES ('[{ "tokenized": [{ "token": "main", "token_type": null }, { "token": "st", "token_type": "Way"}], "display": "Main Street", "priority": 0, "freq": 1 }]', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326));
             INSERT INTO address (names, number, geom) VALUES ('[{ "tokenized": [{ "token": "fake", "token_type": null }, { "token": "av", "token_type": "Way"}], "display": "Fake Avenue", "priority": 0, "freq": 1 }]', 12, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326));
-            INSERT INTO address (names, number, geom, interpolate) VALUES ('[{ "tokenized": [{ "token": "main", "token_type": null }, { "token": "st", "token_type": "Way"}], "display": "Main Street", "priority": 0, "freq": 1 }]', 100, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326), false);
+            INSERT INTO address (names, number, geom, interpolate) VALUES ('[{ "tokenized": [{ "token": "main", "token_type": null }, { "token": "st", "token_type": "Way"}], "display": "Main Street", "priority": 0, "freq": 1 }]', 100, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326), 'false');
             COMMIT;
         `, (err) => {
             t.error(err);

--- a/test/match.test.js
+++ b/test/match.test.js
@@ -53,7 +53,7 @@ test('Match', (t) => {
 
     popQ.defer((done) => {
         pool.query(`
-            SELECT id, names, netid FROM address ORDER BY id;
+            SELECT id, names, netid, interpolate FROM address ORDER BY id;
         `, (err, res) => {
             t.error(err);
 
@@ -65,6 +65,7 @@ test('Match', (t) => {
                     display: 'Main Street',
                     tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }]
                 }],
+                interpolate: 'true',
                 netid: '1'
             });
 
@@ -76,6 +77,7 @@ test('Match', (t) => {
                     display: 'Fake Avenue',
                     tokenized: [{ token: 'fake', token_type: null }, { token: 'av', token_type: 'Way' }]
                 }],
+                interpolate: 'true',
                 netid: null
             });
 

--- a/test/match.test.js
+++ b/test/match.test.js
@@ -65,7 +65,7 @@ test('Match', (t) => {
                     display: 'Main Street',
                     tokenized: [{ token: 'main', token_type: null }, { token: 'st', token_type: 'Way' }]
                 }],
-                interpolate: 'true',
+                interpolate: true,
                 netid: '1'
             });
 
@@ -77,7 +77,7 @@ test('Match', (t) => {
                     display: 'Fake Avenue',
                     tokenized: [{ token: 'fake', token_type: null }, { token: 'av', token_type: 'Way' }]
                 }],
-                interpolate: 'true',
+                interpolate: true,
                 netid: null
             });
 

--- a/test/match.test.js
+++ b/test/match.test.js
@@ -31,8 +31,9 @@ test('Match', (t) => {
     popQ.defer((done) => {
         pool.query(`
             BEGIN;
-            INSERT INTO address (names, number, geom) VALUES ('[{ "tokenized": [{ "token": "main", "token_type": null }, { "token": "st", "token_type": "Way"}], "display": "Main Street", "priority": 0, "freq": 1 }]', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326));
-            INSERT INTO address (names, number, geom) VALUES ('[{ "tokenized": [{ "token": "fake", "token_type": null }, { "token": "av", "token_type": "Way"}], "display": "Fake Avenue", "priority": 0, "freq": 1 }]', 12, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326));
+            ALTER TABLE address ADD COLUMN IF NOT EXISTS interpolate boolean;
+            INSERT INTO address (names, number, geom, interpolate) VALUES ('[{ "tokenized": [{ "token": "main", "token_type": null }, { "token": "st", "token_type": "Way"}], "display": "Main Street", "priority": 0, "freq": 1 }]', 10, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326), 'true');
+            INSERT INTO address (names, number, geom, interpolate) VALUES ('[{ "tokenized": [{ "token": "fake", "token_type": null }, { "token": "av", "token_type": "Way"}], "display": "Fake Avenue", "priority": 0, "freq": 1 }]', 12, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326), 'true');
             INSERT INTO address (names, number, geom, interpolate) VALUES ('[{ "tokenized": [{ "token": "main", "token_type": null }, { "token": "st", "token_type": "Way"}], "display": "Main Street", "priority": 0, "freq": 1 }]', 100, ST_SetSRID(ST_GeomFromGeoJSON('{ "type": "Point", "coordinates": [ -66.05154812335967, 45.26861208316249 ] }'), 4326), 'false');
             COMMIT;
         `, (err) => {


### PR DESCRIPTION
**Context:**
Add a property (interpolate) to addresses in Hecate to flag exclusion from consideration in the interpolation process.
This can be used as a technique to avoid poor conflation outcomes for special case addresses.

**How To Use - interpolate=false:**

To mark an address to be skipped for consideration in interpolation and to be assigned as an address orphan, add the 'interpolate' 'false' tag in JOSM

<img width="638" alt="Screen Shot 2020-09-10 at 2 34 12 PM" src="https://user-images.githubusercontent.com/60354371/92786318-232c0780-f376-11ea-9ca0-eae90e3cf6dd.png">

 