### PR TITLE
cargo fmt all the things

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,9 @@ jobs:
                 name: "Cargo Test"
                 command: cd native/ && cargo test --release
             - run:
+                name: "Cargo Format"
+                command: rustup component add rustfmt && cd native/ && cargo fmt -- --check
+            - run:
                 name: "Yarn Lint"
                 command: "yarn run lint"
             - run:

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Apply cargo fmt
+01b581b001ab4f2a0273fb0c8e15604edc13ed71

--- a/native/src/classify/mod.rs
+++ b/native/src/classify/mod.rs
@@ -1,18 +1,18 @@
 use postgres::{Connection, TlsMode};
 use std::{
-    io::{Write, BufWriter},
     collections::HashMap,
+    convert::From,
     fs::File,
-    convert::From
+    io::{BufWriter, Write},
 };
 
 use neon::prelude::*;
 
 use crate::{
     pg,
-    pg::{Table, InputTable},
+    pg::{InputTable, Table},
+    stream::{AddrStream, GeoStream, PolyStream},
     Tokens,
-    stream::{GeoStream, AddrStream, PolyStream}
 };
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -22,7 +22,7 @@ struct ClassifyArgs {
     buildings: Option<String>,
     parcels: Option<String>,
     input: Option<String>,
-    output: Option<String>
+    output: Option<String>,
 }
 
 impl ClassifyArgs {
@@ -33,7 +33,7 @@ impl ClassifyArgs {
             buildings: None,
             parcels: None,
             input: None,
-            output: None
+            output: None,
         }
     }
 }
@@ -57,11 +57,15 @@ pub fn classify(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         None => panic!("Output file required"),
         Some(output) => match File::create(output) {
             Ok(outfile) => BufWriter::new(outfile),
-            Err(err) => panic!("Unable to write to output file: {}", err)
-        }
+            Err(err) => panic!("Unable to write to output file: {}", err),
+        },
     };
 
-    let conn = Connection::connect(format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(), TlsMode::None).unwrap();
+    let conn = Connection::connect(
+        format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(),
+        TlsMode::None,
+    )
+    .unwrap();
 
     let address = pg::Address::new();
     address.create(&conn);
@@ -69,9 +73,13 @@ pub fn classify(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         &conn,
         AddrStream::new(
             GeoStream::new(args.input),
-            crate::Context::new(String::from("xx"), None, Tokens::new(HashMap::new(), HashMap::new())),
-            None
-        )
+            crate::Context::new(
+                String::from("xx"),
+                None,
+                Tokens::new(HashMap::new(), HashMap::new()),
+            ),
+            None,
+        ),
     );
     println!("ok - imported addresses");
 
@@ -88,30 +96,41 @@ pub fn classify(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     buildings.create(&conn);
     match args.buildings {
         Some(buildings_in) => {
-            buildings.input(&conn, PolyStream::new(GeoStream::new(Some(buildings_in)), None));
+            buildings.input(
+                &conn,
+                PolyStream::new(GeoStream::new(Some(buildings_in)), None),
+            );
             buildings.index(&conn);
             println!("ok - imported buildings");
-        },
-        None => ()
+        }
+        None => (),
     };
 
     let parcels = pg::Polygon::new(String::from("parcels"));
     parcels.create(&conn);
     match args.parcels {
         Some(parcels_in) => {
-            parcels.input(&conn, PolyStream::new(GeoStream::new(Some(parcels_in)), None));
+            parcels.input(
+                &conn,
+                PolyStream::new(GeoStream::new(Some(parcels_in)), None),
+            );
             parcels.index(&conn);
             println!("ok - imported parcels");
-        },
-        None => ()
+        }
+        None => (),
     };
 
-    conn.execute("
+    conn.execute(
+        "
         ALTER TABLE address
             ADD COLUMN accuracy TEXT
-    ", &[]).unwrap();
+    ",
+        &[],
+    )
+    .unwrap();
 
-    conn.execute("
+    conn.execute(
+        "
         UPDATE address
             SET
                 accuracy = 'rooftop'
@@ -119,21 +138,33 @@ pub fn classify(mut cx: FunctionContext) -> JsResult<JsBoolean> {
                 buildings
             WHERE
                 ST_Intersects(address.geom, buildings.geom)
-    ", &[]).unwrap();
+    ",
+        &[],
+    )
+    .unwrap();
     println!("ok - calculated accuracy: building");
 
-    conn.execute("
+    conn.execute(
+        "
         ALTER TABLE parcels
             ADD COLUMN centroid GEOMETRY(POINT, 4326)
-    ", &[]).unwrap();
+    ",
+        &[],
+    )
+    .unwrap();
 
-    conn.execute("
+    conn.execute(
+        "
         UPDATE parcels
             SET centroid = ST_PointOnSurface(parcels.geom)
-    ", &[]).unwrap();
+    ",
+        &[],
+    )
+    .unwrap();
     println!("ok - calculated parcel centroids");
 
-    conn.execute("
+    conn.execute(
+        "
         UPDATE address
             SET
                 accuracy = 'parcel'
@@ -142,39 +173,57 @@ pub fn classify(mut cx: FunctionContext) -> JsResult<JsBoolean> {
             WHERE
                 accuracy IS NULL
                 AND ST_DWithin(address.geom, parcels.centroid, 0.0001)
-    ", &[]).unwrap();
+    ",
+        &[],
+    )
+    .unwrap();
     println!("ok - calculated accuracy: parcel");
 
-    conn.execute("
+    conn.execute(
+        "
         UPDATE address
             SET
                 accuracy = 'point'
             WHERE
                 accuracy IS NULL
-    ", &[]).unwrap();
+    ",
+        &[],
+    )
+    .unwrap();
     println!("ok - calculated accuracy: point");
 
     let modified = match is_hecate {
         true => {
-            conn.execute(r#"
+            conn.execute(
+                r#"
                 UPDATE address
                     SET
                         accuracy = NULL
                     WHERE
                         accuracy = props->>'accuracy'
-            "#, &[]).unwrap();
+            "#,
+                &[],
+            )
+            .unwrap();
 
-            conn.execute(r#"
+            conn.execute(
+                r#"
                 UPDATE address
                     SET
                         props = props::JSONB || JSON_Build_Object('accuracy', accuracy)::JSONB
                     WHERE
                         accuracy IS NOT NULL
-            "#, &[]).unwrap();
+            "#,
+                &[],
+            )
+            .unwrap();
 
             println!("ok - outputting hecate addresses");
 
-            pg::Cursor::new(conn, format!(r#"
+            pg::Cursor::new(
+                conn,
+                format!(
+                    r#"
                 SELECT
                     JSON_Build_Object(
                         'id', id,
@@ -188,18 +237,28 @@ pub fn classify(mut cx: FunctionContext) -> JsResult<JsBoolean> {
                     address
                 WHERE
                     accuracy IS NOT NULL
-            "#)).unwrap()
-        },
+            "#
+                ),
+            )
+            .unwrap()
+        }
         false => {
-            conn.execute(r#"
+            conn.execute(
+                r#"
                 UPDATE address
                     SET
                         props = props::JSONB || JSON_Build_Object('accuracy', accuracy)::JSONB
-            "#, &[]).unwrap();
+            "#,
+                &[],
+            )
+            .unwrap();
 
             println!("ok - outputting addresses");
 
-            pg::Cursor::new(conn, format!(r#"
+            pg::Cursor::new(
+                conn,
+                format!(
+                    r#"
                 SELECT
                     JSON_Build_Object(
                         'id', id,
@@ -209,7 +268,10 @@ pub fn classify(mut cx: FunctionContext) -> JsResult<JsBoolean> {
                     )
                 FROM
                     address
-            "#)).unwrap()
+            "#
+                ),
+            )
+            .unwrap()
         }
     };
 

--- a/native/src/conflate/mod.rs
+++ b/native/src/conflate/mod.rs
@@ -1,23 +1,22 @@
-use std::convert::From;
+use geojson::GeoJson;
 use postgres::{Connection, TlsMode};
 use std::collections::HashMap;
+use std::convert::From;
 use std::fs::File;
 use std::io::{BufWriter, Write};
-use geojson::GeoJson;
 
 use neon::prelude::*;
 
 use crate::{
-    Names,
-    Address,
     hecate,
-    util::linker,
+    stream::{AddrStream, GeoStream},
     types::name::InputName,
-    stream::{GeoStream, AddrStream}
+    util::linker,
+    Address, Names,
 };
 
 use super::pg;
-use super::pg::{Table, InputTable};
+use super::pg::{InputTable, Table};
 
 #[derive(Serialize, Deserialize, Debug)]
 struct ConflateArgs {
@@ -27,7 +26,7 @@ struct ConflateArgs {
     in_persistent: Option<String>,
     error_address: Option<String>,
     error_persistent: Option<String>,
-    output: Option<String>
+    output: Option<String>,
 }
 
 impl ConflateArgs {
@@ -39,7 +38,7 @@ impl ConflateArgs {
             in_persistent: None,
             error_address: None,
             error_persistent: None,
-            output: None
+            output: None,
         }
     }
 }
@@ -74,17 +73,26 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         None => panic!("Output file required"),
         Some(output) => match File::create(output) {
             Ok(outfile) => BufWriter::new(outfile),
-            Err(err) => panic!("Unable to write to output file: {}", err)
-        }
+            Err(err) => panic!("Unable to write to output file: {}", err),
+        },
     };
 
-    let conn = Connection::connect(format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(), TlsMode::None).unwrap();
+    let conn = Connection::connect(
+        format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(),
+        TlsMode::None,
+    )
+    .unwrap();
 
-    conn.execute("
+    conn.execute(
+        "
         DROP TABLE IF EXISTS modified;
-    ", &[]).unwrap();
+    ",
+        &[],
+    )
+    .unwrap();
 
-    conn.execute("
+    conn.execute(
+        "
         CREATE UNLOGGED TABLE modified (
             id BIGINT,
             version BIGINT,
@@ -96,23 +104,43 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
             props JSONB,
             geom GEOMETRY(POINT, 4326)
         );
-    ", &[]).unwrap();
+    ",
+        &[],
+    )
+    .unwrap();
 
     let context = match args.context {
         Some(context) => crate::Context::from(context),
-        None => crate::Context::new(String::from(""), None, crate::Tokens::new(HashMap::new(), HashMap::new()))
+        None => crate::Context::new(
+            String::from(""),
+            None,
+            crate::Tokens::new(HashMap::new(), HashMap::new()),
+        ),
     };
 
     let pgaddress = pg::Address::new();
     pgaddress.create(&conn);
-    pgaddress.input(&conn, AddrStream::new(GeoStream::new(args.in_persistent), context.clone(), args.error_persistent));
+    pgaddress.input(
+        &conn,
+        AddrStream::new(
+            GeoStream::new(args.in_persistent),
+            context.clone(),
+            args.error_persistent,
+        ),
+    );
     pgaddress.index(&conn);
     pg::address::pre_conflate(&conn);
 
-    for addr in AddrStream::new(GeoStream::new(args.in_address), context.clone(), args.error_address) {
+    for addr in AddrStream::new(
+        GeoStream::new(args.in_address),
+        context.clone(),
+        args.error_address,
+    ) {
         // find all persistent addresses with the same address number
         // within 0.01 decimal degrees (~ 1 km) of the new address
-        let rows = conn.query("
+        let rows = conn
+            .query(
+                "
             SELECT
                 ST_Distance(ST_SetSRID(ST_Point($2, $3), 4326), p.geom),
                 json_build_object(
@@ -130,7 +158,10 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
             WHERE
                 p.number = $1
                 AND ST_DWithin(ST_SetSRID(ST_Point($2, $3), 4326), p.geom, 0.01);
-        ", &[ &addr.number, &addr.geom[0], &addr.geom[1] ]).unwrap();
+        ",
+                &[&addr.number, &addr.geom[0], &addr.geom[1]],
+            )
+            .unwrap();
 
         let mut persistents: Vec<Address> = Vec::with_capacity(rows.len());
 
@@ -143,10 +174,13 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         match compare(&addr, &mut persistents) {
             // persistent address matches new address, consider modifying persistent address
             Some(link_id) => {
-                let mut pmatches: Vec<&mut Address> = persistents.iter_mut().filter(|persistent| {
-                    // addresses with output set to false should not be modified
-                    link_id == persistent.id.unwrap() && persistent.output
-                }).collect();
+                let mut pmatches: Vec<&mut Address> = persistents
+                    .iter_mut()
+                    .filter(|persistent| {
+                        // addresses with output set to false should not be modified
+                        link_id == persistent.id.unwrap() && persistent.output
+                    })
+                    .collect();
 
                 match pmatches.len() {
                     // if all matches have output set to false, don't modify
@@ -162,7 +196,8 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
                             combined_names.sort();
                             combined_names.dedupe();
 
-                            let mut new_names: Vec<InputName> = Vec::with_capacity(combined_names.names.len());
+                            let mut new_names: Vec<InputName> =
+                                Vec::with_capacity(combined_names.names.len());
                             for name in combined_names.names {
                                 new_names.push(InputName::from(name));
                             }
@@ -173,18 +208,30 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
                             paddr.props.insert(String::from("street"), new_names);
                             paddr.to_db(&conn, "modified").unwrap();
                         }
-                    },
-                    _ => panic!("Duplicate IDs are not allowed in input data")
+                    }
+                    _ => panic!("Duplicate IDs are not allowed in input data"),
                 }
-            },
+            }
             // no match in persistent addresses, write new address to output
             None => {
-                output.write(format!("{}\n", GeoJson::Feature(addr.to_geojson(hecate::Action::Create, false)).to_string()).as_bytes()).unwrap();
+                output
+                    .write(
+                        format!(
+                            "{}\n",
+                            GeoJson::Feature(addr.to_geojson(hecate::Action::Create, false))
+                                .to_string()
+                        )
+                        .as_bytes(),
+                    )
+                    .unwrap();
             }
         };
     }
 
-    let modifieds = pg::Cursor::new(conn, format!("
+    let modifieds = pg::Cursor::new(
+        conn,
+        format!(
+            "
         SELECT
             json_build_object(
                 'id', id,
@@ -200,7 +247,10 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
             id,
             version,
             geom
-    ")).unwrap();
+    "
+        ),
+    )
+    .unwrap();
 
     for mut modified in modifieds {
         let modified_obj = modified.as_object_mut().unwrap();
@@ -218,13 +268,17 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
             // other properties
             let mut props_base = props_arr.pop().unwrap();
             let props_base_obj = props_base.as_object_mut().unwrap();
-            let names_base: Vec<InputName> = serde_json::from_value(props_base_obj.remove(&String::from("street")).unwrap()).unwrap();
+            let names_base: Vec<InputName> =
+                serde_json::from_value(props_base_obj.remove(&String::from("street")).unwrap())
+                    .unwrap();
 
             let mut names_base = Names::from_input(names_base, &context);
             for prop in props_arr {
                 let prop_obj = prop.as_object_mut().unwrap();
 
-                let names_new: Vec<InputName> = serde_json::from_value(prop_obj.remove(&String::from("street")).unwrap()).unwrap();
+                let names_new: Vec<InputName> =
+                    serde_json::from_value(prop_obj.remove(&String::from("street")).unwrap())
+                        .unwrap();
                 let names_new = Names::from_input(names_new, &context);
 
                 names_base.concat(names_new);
@@ -237,21 +291,26 @@ pub fn conflate(mut cx: FunctionContext) -> JsResult<JsBoolean> {
                 names_final.push(InputName::from(name));
             }
 
-            props_base_obj.insert(String::from("street"), serde_json::to_value(names_final).unwrap());
+            props_base_obj.insert(
+                String::from("street"),
+                serde_json::to_value(names_final).unwrap(),
+            );
             modified_obj.insert(String::from("properties"), props_base);
         }
 
         let modified = match modified {
             serde_json::Value::Object(modified) => modified,
-            _ => panic!("Modified should always be an object")
+            _ => panic!("Modified should always be an object"),
         };
 
         let modified: geojson::Feature = match geojson::Feature::from_json_object(modified) {
             Ok(m) => m,
-            Err(e) => panic!(e)
+            Err(e) => panic!(e),
         };
 
-        output.write(format!("{}\n", modified.to_string()).as_bytes()).unwrap();
+        output
+            .write(format!("{}\n", modified.to_string()).as_bytes())
+            .unwrap();
     }
 
     Ok(cx.boolean(true))
@@ -271,12 +330,13 @@ pub fn compare(potential: &Address, persistents: &mut Vec<Address>) -> Option<i6
         return None;
     }
     let potential_link = linker::Link::new(0, &potential.names);
-    let persistent_links: Vec<linker::Link> = persistents.iter().map(|persistent| {
-        linker::Link::new(persistent.id.unwrap(), &persistent.names)
-    }).collect();
+    let persistent_links: Vec<linker::Link> = persistents
+        .iter()
+        .map(|persistent| linker::Link::new(persistent.id.unwrap(), &persistent.names))
+        .collect();
 
     match linker::linker(potential_link, persistent_links, true) {
         Some(link) => Some(link.id),
-        None => None
+        None => None,
     }
 }

--- a/native/src/consensus/agreement.rs
+++ b/native/src/consensus/agreement.rs
@@ -1,17 +1,17 @@
+use kodama::{linkage, Method};
 use std::collections::HashMap;
-use kodama::{Method, linkage};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Results {
     agreement_count: u32,
-    hit_count: u32
+    hit_count: u32,
 }
 
 impl Results {
     pub fn new() -> Self {
         Results {
             agreement_count: 0,
-            hit_count: 0
+            hit_count: 0,
         }
     }
 }
@@ -20,7 +20,7 @@ impl Results {
 pub struct Agreement {
     results: HashMap<String, Results>,
     threshold: u32,
-    sample_count: u32
+    sample_count: u32,
 }
 
 impl Agreement {
@@ -29,7 +29,7 @@ impl Agreement {
         Agreement {
             results,
             threshold,
-            sample_count: 0
+            sample_count: 0,
         }
     }
 
@@ -48,7 +48,10 @@ impl Agreement {
                 source_hit_count += 1;
                 labels.push(source);
                 coordinates.push(point);
-                self.results.entry(String::from(source)).or_insert(Results::new()).hit_count += 1;
+                self.results
+                    .entry(String::from(source))
+                    .or_insert(Results::new())
+                    .hit_count += 1;
             }
         }
 
@@ -65,7 +68,7 @@ impl Agreement {
                 condensed.push(haversine(*coordinates[row], *coordinates[col]));
             }
         }
-    
+
         // Perform hierarchical clustering and return the resulting dendrogram
         let dend = linkage(&mut condensed, coordinates.len(), Method::Single);
 
@@ -79,7 +82,7 @@ impl Agreement {
                 break;
             }
         }
-    
+
         // Re-associate indexes with source values, and update the agreement counts for each
         let modal_cluster: Vec<&String> = modal_cluster
             .into_iter()
@@ -87,7 +90,9 @@ impl Agreement {
             .map(|x| labels[x])
             .collect();
         for source in modal_cluster {
-            self.results.entry(String::from(source)).and_modify(|e| e.agreement_count += 1);
+            self.results
+                .entry(String::from(source))
+                .and_modify(|e| e.agreement_count += 1);
         }
     }
 }
@@ -101,8 +106,7 @@ fn haversine((lon1, lat1): (f64, f64), (lon2, lat2): (f64, f64)) -> f64 {
     let delta_lat = lat2 - lat1;
     let delta_lon = lon2 - lon1;
     let x =
-        (delta_lat / 2.0).sin().powi(2)
-        + lat1.cos() * lat2.cos() * (delta_lon / 2.0).sin().powi(2);
+        (delta_lat / 2.0).sin().powi(2) + lat1.cos() * lat2.cos() * (delta_lon / 2.0).sin().powi(2);
     2.0 * EARTH_RADIUS * x.sqrt().atan() * 1000.0
 }
 
@@ -115,15 +119,21 @@ mod tests {
         let mut agreement = Agreement::new(25);
 
         let mut source_map = HashMap::new();
-        source_map.insert(String::from("source1"), Some((-77.0013365,38.8959637)));
-        source_map.insert(String::from("source2"), Some((-77.0013338,38.8959407)));
-        source_map.insert(String::from("source3"), Some((-77.0013311,38.8955170)));
+        source_map.insert(String::from("source1"), Some((-77.0013365, 38.8959637)));
+        source_map.insert(String::from("source2"), Some((-77.0013338, 38.8959407)));
+        source_map.insert(String::from("source3"), Some((-77.0013311, 38.8955170)));
 
         agreement.process_points(&source_map);
 
-        source_map.entry(String::from("source1")).and_modify(|e| *e = Some((-77.0033025,38.8971410)));
-        source_map.entry(String::from("source2")).and_modify(|e| *e = Some((-77.0032677,38.8971390)));
-        source_map.entry(String::from("source3")).and_modify(|e| *e = Some((-77.0038872,38.8970513)));
+        source_map
+            .entry(String::from("source1"))
+            .and_modify(|e| *e = Some((-77.0033025, 38.8971410)));
+        source_map
+            .entry(String::from("source2"))
+            .and_modify(|e| *e = Some((-77.0032677, 38.8971390)));
+        source_map
+            .entry(String::from("source3"))
+            .and_modify(|e| *e = Some((-77.0038872, 38.8970513)));
 
         agreement.process_points(&source_map);
 
@@ -137,15 +147,21 @@ mod tests {
         let mut agreement = Agreement::new(25);
 
         let mut source_map = HashMap::new();
-        source_map.insert(String::from("source1"), Some((-76.9732081,38.9168672)));
-        source_map.insert(String::from("source2"), Some((-76.9733476,38.9163518)));
-        source_map.insert(String::from("source3"), Some((-76.9731089,38.9175434)));
+        source_map.insert(String::from("source1"), Some((-76.9732081, 38.9168672)));
+        source_map.insert(String::from("source2"), Some((-76.9733476, 38.9163518)));
+        source_map.insert(String::from("source3"), Some((-76.9731089, 38.9175434)));
 
         agreement.process_points(&source_map);
 
-        source_map.entry(String::from("source1")).and_modify(|e| *e = Some((-76.9717141,38.9309358)));
-        source_map.entry(String::from("source2")).and_modify(|e| *e = Some((-76.9710302,38.9312738)));
-        source_map.entry(String::from("source3")).and_modify(|e| *e = Some((-76.9720950,38.9308064)));
+        source_map
+            .entry(String::from("source1"))
+            .and_modify(|e| *e = Some((-76.9717141, 38.9309358)));
+        source_map
+            .entry(String::from("source2"))
+            .and_modify(|e| *e = Some((-76.9710302, 38.9312738)));
+        source_map
+            .entry(String::from("source3"))
+            .and_modify(|e| *e = Some((-76.9720950, 38.9308064)));
 
         agreement.process_points(&source_map);
 
@@ -159,15 +175,21 @@ mod tests {
         let mut agreement = Agreement::new(25);
 
         let mut source_map = HashMap::new();
-        source_map.insert(String::from("source1"), Some((-76.9732081,38.9168672)));
-        source_map.insert(String::from("source2"), Some((-76.9733476,38.9163518)));
+        source_map.insert(String::from("source1"), Some((-76.9732081, 38.9168672)));
+        source_map.insert(String::from("source2"), Some((-76.9733476, 38.9163518)));
         source_map.insert(String::from("source3"), None);
 
         agreement.process_points(&source_map);
 
-        source_map.entry(String::from("source1")).and_modify(|e| *e = None);
-        source_map.entry(String::from("source2")).and_modify(|e| *e = Some((-76.9710302,38.9312738)));
-        source_map.entry(String::from("source3")).and_modify(|e| *e = Some((-76.9720950,38.9308064)));
+        source_map
+            .entry(String::from("source1"))
+            .and_modify(|e| *e = None);
+        source_map
+            .entry(String::from("source2"))
+            .and_modify(|e| *e = Some((-76.9710302, 38.9312738)));
+        source_map
+            .entry(String::from("source3"))
+            .and_modify(|e| *e = Some((-76.9720950, 38.9308064)));
 
         agreement.process_points(&source_map);
 
@@ -191,16 +213,53 @@ mod tests {
         source_map.insert(String::from("Framingham"), Some((-71.4166667, 42.2791667)));
         source_map.insert(String::from("Marlborough"), Some((-71.5527778, 42.3458333)));
         source_map.insert(String::from("Northbridge"), Some((-71.6500000, 42.1513889)));
-        source_map.insert(String::from("Southborough"), Some((-71.5250000, 42.3055556)));
+        source_map.insert(
+            String::from("Southborough"),
+            Some((-71.5250000, 42.3055556)),
+        );
         source_map.insert(String::from("Westborough"), Some((-71.6166667, 42.2694444)));
 
         agreement.process_points(&source_map);
 
-        assert_eq!(agreement.results.get("Fitchburg").unwrap().agreement_count, 0);
-        assert_eq!(agreement.results.get("Framingham").unwrap().agreement_count, 1);
-        assert_eq!(agreement.results.get("Marlborough").unwrap().agreement_count, 1);
-        assert_eq!(agreement.results.get("Northbridge").unwrap().agreement_count, 1);
-        assert_eq!(agreement.results.get("Southborough").unwrap().agreement_count, 1);
-        assert_eq!(agreement.results.get("Westborough").unwrap().agreement_count, 1);
+        assert_eq!(
+            agreement.results.get("Fitchburg").unwrap().agreement_count,
+            0
+        );
+        assert_eq!(
+            agreement.results.get("Framingham").unwrap().agreement_count,
+            1
+        );
+        assert_eq!(
+            agreement
+                .results
+                .get("Marlborough")
+                .unwrap()
+                .agreement_count,
+            1
+        );
+        assert_eq!(
+            agreement
+                .results
+                .get("Northbridge")
+                .unwrap()
+                .agreement_count,
+            1
+        );
+        assert_eq!(
+            agreement
+                .results
+                .get("Southborough")
+                .unwrap()
+                .agreement_count,
+            1
+        );
+        assert_eq!(
+            agreement
+                .results
+                .get("Westborough")
+                .unwrap()
+                .agreement_count,
+            1
+        );
     }
 }

--- a/native/src/consensus/mod.rs
+++ b/native/src/consensus/mod.rs
@@ -1,19 +1,19 @@
-use std::convert::From;
 use postgres::{Connection, TlsMode};
 use std::collections::HashMap;
+use std::convert::From;
 
 mod agreement;
 
 use neon::prelude::*;
 
 use crate::{
-    Address,
+    stream::{AddrStream, GeoStream},
     util::linker,
-    stream::{GeoStream, AddrStream}
+    Address,
 };
 
 use super::pg;
-use super::pg::{Table, InputTable};
+use super::pg::{InputTable, Table};
 
 const SEARCH_RADIUS: f64 = 0.01;
 const WGS84: i32 = 4326;
@@ -26,7 +26,7 @@ struct ConsensusArgs {
     sources: Vec<String>,
     query_points: String,
     error_sources: Option<String>,
-    error_query_points: Option<String>
+    error_query_points: Option<String>,
 }
 
 impl ConsensusArgs {
@@ -38,7 +38,7 @@ impl ConsensusArgs {
             sources: vec![String::from("")],
             query_points: String::from(""),
             error_sources: None,
-            error_query_points: None
+            error_query_points: None,
         }
     }
 }
@@ -75,28 +75,46 @@ pub fn consensus(mut cx: FunctionContext) -> JsResult<JsValue> {
     let sources = args.sources;
     let query_points = args.query_points;
 
-    let conn = Connection::connect(format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(), TlsMode::None).unwrap();
+    let conn = Connection::connect(
+        format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(),
+        TlsMode::None,
+    )
+    .unwrap();
 
     let context = match args.context {
         Some(context) => crate::Context::from(context),
-        None => crate::Context::new(String::from(""), None, crate::Tokens::new(HashMap::new(), HashMap::new()))
+        None => crate::Context::new(
+            String::from(""),
+            None,
+            crate::Tokens::new(HashMap::new(), HashMap::new()),
+        ),
     };
 
     let pgaddress = pg::Address::new();
     pgaddress.create(&conn);
     for source in sources {
-        pgaddress.input(&conn, AddrStream::new(GeoStream::new(Some(source)), context.clone(), args.error_sources.clone()));
+        pgaddress.input(
+            &conn,
+            AddrStream::new(
+                GeoStream::new(Some(source)),
+                context.clone(),
+                args.error_sources.clone(),
+            ),
+        );
     }
     pgaddress.index(&conn);
 
     let mut source_map: HashMap<String, Option<(f64, f64)>> = HashMap::new();
-    let rows = conn.query("SELECT source FROM address GROUP BY source", &[]).unwrap();
+    let rows = conn
+        .query("SELECT source FROM address GROUP BY source", &[])
+        .unwrap();
     for row in rows.iter() {
         let source: String = row.get(0);
         source_map.insert(source, None);
     }
 
-    let query = format!("
+    let query = format!(
+        "
         SELECT
             ST_Distance(ST_SetSRID(ST_Point($2, $3), {0}), p.geom),
             json_build_object(
@@ -115,16 +133,27 @@ pub fn consensus(mut cx: FunctionContext) -> JsResult<JsValue> {
             p.number = $1
             AND p.source = $4
             AND ST_DWithin(ST_SetSRID(ST_Point($2, $3), {0}), p.geom, {1});
-    ", WGS84, SEARCH_RADIUS);
+    ",
+        WGS84, SEARCH_RADIUS
+    );
 
     let sources: Vec<String> = source_map.keys().cloned().collect();
     let threshold = args.threshold.unwrap_or(25);
     let mut agreement = agreement::Agreement::new(threshold);
 
-    for addr in AddrStream::new(GeoStream::new(Some(query_points)), context.clone(), args.error_query_points) {
+    for addr in AddrStream::new(
+        GeoStream::new(Some(query_points)),
+        context.clone(),
+        args.error_query_points,
+    ) {
         for source in &sources {
             // pull the addresses matching this address number within 1 km
-            let rows = conn.query(&query, &[ &addr.number, &addr.geom[0], &addr.geom[1], &source ]).unwrap();
+            let rows = conn
+                .query(
+                    &query,
+                    &[&addr.number, &addr.geom[0], &addr.geom[1], &source],
+                )
+                .unwrap();
 
             // populate potential_matches with db response
             let mut potential_matches: Vec<Address> = Vec::with_capacity(rows.len());
@@ -137,9 +166,10 @@ pub fn consensus(mut cx: FunctionContext) -> JsResult<JsValue> {
             // find a match using linker
             match compare(&addr, &mut potential_matches) {
                 Some(link_id) => {
-                    let mut pmatches: Vec<Address> = potential_matches.into_iter().filter(|potential| {
-                        link_id == potential.id.unwrap()
-                    }).collect();
+                    let mut pmatches: Vec<Address> = potential_matches
+                        .into_iter()
+                        .filter(|potential| link_id == potential.id.unwrap())
+                        .collect();
 
                     match pmatches.len() {
                         0 => continue,
@@ -147,12 +177,17 @@ pub fn consensus(mut cx: FunctionContext) -> JsResult<JsValue> {
                             let paddr = pmatches.pop();
                             let coords = paddr.map(|p| (p.geom[0], p.geom[1]));
                             // update source_map with current match for source
-                            source_map.entry(source.to_string()).and_modify(|e| *e = coords);
-                        },
-                        _ => panic!("{} is a duplicate ID - this is not allowed in input data", link_id)
+                            source_map
+                                .entry(source.to_string())
+                                .and_modify(|e| *e = coords);
+                        }
+                        _ => panic!(
+                            "{} is a duplicate ID - this is not allowed in input data",
+                            link_id
+                        ),
                     }
-                },
-                None => ()
+                }
+                None => (),
             };
         }
 
@@ -177,9 +212,10 @@ pub fn compare(addr: &Address, potentials: &mut Vec<Address>) -> Option<i64> {
         return None;
     }
     let addr_link = linker::Link::new(0, &addr.names);
-    let potential_links: Vec<linker::Link> = potentials.iter().map(|potential| {
-        linker::Link::new(potential.id.unwrap(), &potential.names)
-    }).collect();
+    let potential_links: Vec<linker::Link> = potentials
+        .iter()
+        .map(|potential| linker::Link::new(potential.id.unwrap(), &potential.names))
+        .collect();
 
     linker::linker(addr_link, potential_links, true).map(|link| link.id)
 }

--- a/native/src/dedupe/mod.rs
+++ b/native/src/dedupe/mod.rs
@@ -1,20 +1,20 @@
-use std::convert::From;
 use postgres::{Connection, TlsMode};
 use std::collections::HashMap;
-use std::thread;
+use std::convert::From;
 use std::fs::File;
 use std::io::{BufWriter, Write};
+use std::thread;
 
 use neon::prelude::*;
 
 use crate::{
-    Address,
+    stream::{AddrStream, GeoStream, PolyStream},
     types::hecate,
-    stream::{GeoStream, AddrStream, PolyStream}
+    Address,
 };
 
 use super::pg;
-use super::pg::{Table, InputTable};
+use super::pg::{InputTable, Table};
 
 #[derive(Serialize, Deserialize, Debug)]
 struct DedupeArgs {
@@ -23,7 +23,7 @@ struct DedupeArgs {
     buildings: Option<String>,
     input: Option<String>,
     output: Option<String>,
-    hecate: Option<bool>
+    hecate: Option<bool>,
 }
 
 impl DedupeArgs {
@@ -34,7 +34,7 @@ impl DedupeArgs {
             buildings: None,
             input: None,
             output: None,
-            hecate: None
+            hecate: None,
         }
     }
 }
@@ -54,16 +54,27 @@ pub fn dedupe(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
     let is_hecate = args.hecate.unwrap_or(false);
 
-    let conn = Connection::connect(format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(), TlsMode::None).unwrap();
+    let conn = Connection::connect(
+        format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(),
+        TlsMode::None,
+    )
+    .unwrap();
 
     let context = match args.context {
         Some(context) => crate::Context::from(context),
-        None => crate::Context::new(String::from(""), None, crate::Tokens::new(HashMap::new(), HashMap::new()))
+        None => crate::Context::new(
+            String::from(""),
+            None,
+            crate::Tokens::new(HashMap::new(), HashMap::new()),
+        ),
     };
 
     let address = pg::Address::new();
     address.create(&conn);
-    address.input(&conn, AddrStream::new(GeoStream::new(args.input), context, None));
+    address.input(
+        &conn,
+        AddrStream::new(GeoStream::new(args.input), context, None),
+    );
 
     if !is_hecate {
         // Hecate Addresses will already have ids present
@@ -77,10 +88,13 @@ pub fn dedupe(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         Some(buildings) => {
             let polygon = pg::Polygon::new(String::from("buildings"));
             polygon.create(&conn);
-            polygon.input(&conn, PolyStream::new(GeoStream::new(Some(buildings)), None));
+            polygon.input(
+                &conn,
+                PolyStream::new(GeoStream::new(Some(buildings)), None),
+            );
             polygon.index(&conn);
-        },
-        None => ()
+        }
+        None => (),
     };
 
     let count = address.count(&conn);
@@ -96,23 +110,28 @@ pub fn dedupe(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         let db_conn = args.db.clone();
         let tx_n = tx.clone();
 
-        let strand = match thread::Builder::new().name(format!("Exact Dup #{}", &cpu)).spawn(move || {
-            let mut min_id = batch * cpu;
-            let max_id = batch * cpu + batch + batch_extra;
+        let strand = match thread::Builder::new()
+            .name(format!("Exact Dup #{}", &cpu))
+            .spawn(move || {
+                let mut min_id = batch * cpu;
+                let max_id = batch * cpu + batch + batch_extra;
 
-            if cpu != 0 {
-                min_id = min_id + batch_extra + 1;
-            }
+                if cpu != 0 {
+                    min_id = min_id + batch_extra + 1;
+                }
 
-            let conn = match Connection::connect(format!("postgres://postgres@localhost:5432/{}", &db_conn).as_str(), TlsMode::None) {
-                Ok(conn) => conn,
-                Err(err) => panic!("Connection Error: {}", err.to_string())
-            };
+                let conn = match Connection::connect(
+                    format!("postgres://postgres@localhost:5432/{}", &db_conn).as_str(),
+                    TlsMode::None,
+                ) {
+                    Ok(conn) => conn,
+                    Err(err) => panic!("Connection Error: {}", err.to_string()),
+                };
 
-            exact_batch(is_hecate, min_id, max_id, conn, tx_n);
-        }) {
+                exact_batch(is_hecate, min_id, max_id, conn, tx_n);
+            }) {
             Ok(strand) => strand,
-            Err(err) => panic!("Thread Creation Error: {}", err.to_string())
+            Err(err) => panic!("Thread Creation Error: {}", err.to_string()),
         };
 
         web.push(strand);
@@ -124,12 +143,14 @@ pub fn dedupe(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         Some(outpath) => {
             let outfile = match File::create(outpath) {
                 Ok(outfile) => outfile,
-                Err(err) => { panic!("Unable to write to output file: {}", err); }
+                Err(err) => {
+                    panic!("Unable to write to output file: {}", err);
+                }
             };
 
             output(is_hecate, rx, BufWriter::new(outfile))
-        },
-        None => output(is_hecate, rx, std::io::stdout().lock())
+        }
+        None => output(is_hecate, rx, std::io::stdout().lock()),
     }
 
     for strand in web {
@@ -141,10 +162,11 @@ pub fn dedupe(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
 fn output(is_hecate: bool, receive: crossbeam::Receiver<Address>, mut sink: impl Write) {
     for result in receive.iter() {
-
         let result: String = match is_hecate {
-            true => geojson::GeoJson::Feature(result.to_geojson(hecate::Action::Delete, false)).to_string(),
-            false => geojson::GeoJson::Feature(result.to_geojson(hecate::Action::None, false)).to_string()
+            true => geojson::GeoJson::Feature(result.to_geojson(hecate::Action::Delete, false))
+                .to_string(),
+            false => geojson::GeoJson::Feature(result.to_geojson(hecate::Action::None, false))
+                .to_string(),
         };
 
         if sink.write(format!("{}\n", result).as_bytes()).is_err() {
@@ -157,8 +179,17 @@ fn output(is_hecate: bool, receive: crossbeam::Receiver<Address>, mut sink: impl
     }
 }
 
-fn exact_batch(is_hecate: bool, min_id: i64, max_id: i64, conn: postgres::Connection, tx: crossbeam::Sender<Address>) {
-    let exact_dups = match pg::Cursor::new(conn, format!(r#"
+fn exact_batch(
+    is_hecate: bool,
+    min_id: i64,
+    max_id: i64,
+    conn: postgres::Connection,
+    tx: crossbeam::Sender<Address>,
+) {
+    let exact_dups = match pg::Cursor::new(
+        conn,
+        format!(
+            r#"
         SELECT
             JSON_Build_Object(
                 'primary', JSON_Build_Object(
@@ -195,48 +226,51 @@ fn exact_batch(is_hecate: bool, min_id: i64, max_id: i64, conn: postgres::Connec
             a.id >= {min_id}
             AND a.id <= {max_id}
     "#,
-        min_id = min_id,
-        max_id = max_id
-    )) {
+            min_id = min_id,
+            max_id = max_id
+        ),
+    ) {
         Ok(cursor) => cursor,
-        Err(err) => panic!("ERR: {}", err.to_string())
+        Err(err) => panic!("ERR: {}", err.to_string()),
     };
 
     for dup_feats in exact_dups {
         let mut dup_feats = match dup_feats {
             serde_json::value::Value::Object(object) => object,
-            _ => panic!("result must be JSON Object")
+            _ => panic!("result must be JSON Object"),
         };
 
-        let feat: Address = match Address::from_value(dup_feats.remove(&String::from("primary")).unwrap()) {
-            Ok(feat) => feat,
-            Err(err) => panic!("Address Error: {}", err.to_string())
-        };
+        let feat: Address =
+            match Address::from_value(dup_feats.remove(&String::from("primary")).unwrap()) {
+                Ok(feat) => feat,
+                Err(err) => panic!("Address Error: {}", err.to_string()),
+            };
 
-        let mut dup_feats: Vec<Address> = match dup_feats.remove(&String::from("proximal")).unwrap() {
+        let mut dup_feats: Vec<Address> = match dup_feats.remove(&String::from("proximal")).unwrap()
+        {
             serde_json::value::Value::Array(feats) => {
                 let mut addrfeats = Vec::with_capacity(feats.len());
 
                 for feat in feats {
                     addrfeats.push(match Address::from_value(feat) {
                         Ok(feat) => feat,
-                        Err(err) => panic!("Vec<Address> Error: {}", err.to_string())
+                        Err(err) => panic!("Vec<Address> Error: {}", err.to_string()),
                     });
                 }
 
                 addrfeats
-            },
-            _ => panic!("Duplicate Features should be Vec<Value>")
+            }
+            _ => panic!("Duplicate Features should be Vec<Value>"),
         };
 
         //
         // For now the dup logic is rather simple & strict
         // - Number must be the same - apt numbers included
         // - Text synonyms must match
-        dup_feats = dup_feats.into_iter().filter(|dup_feat| {
-            dup_feat.number == feat.number
-            && dup_feat.names == feat.names
-        }).collect();
+        dup_feats = dup_feats
+            .into_iter()
+            .filter(|dup_feat| dup_feat.number == feat.number && dup_feat.names == feat.names)
+            .collect();
 
         dup_feats.sort_by(|a, b| {
             if a.id.unwrap() < b.id.unwrap() {
@@ -254,7 +288,10 @@ fn exact_batch(is_hecate: bool, min_id: i64, max_id: i64, conn: postgres::Connec
         // the dup_feat will only be processed if the lowest ID in the match falls within
         // the min_id/max_id that the given thread is processing
         //
-        if dup_feats[0].id.unwrap() < feat.id.unwrap() || dup_feats[0].id.unwrap() < min_id || dup_feats[0].id.unwrap() > max_id {
+        if dup_feats[0].id.unwrap() < feat.id.unwrap()
+            || dup_feats[0].id.unwrap() < min_id
+            || dup_feats[0].id.unwrap() > max_id
+        {
             continue;
         }
 

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1,47 +1,50 @@
-#[macro_use] extern crate neon;
-#[macro_use] extern crate serde_derive;
-#[macro_use] extern crate lazy_static;
-extern crate serde_json;
-extern crate neon_serde;
+#[macro_use]
+extern crate neon;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate lazy_static;
 extern crate crossbeam;
+extern crate geo;
+extern crate geojson;
+extern crate kodama;
+extern crate neon_serde;
 extern crate num_cpus;
 extern crate postgres;
-extern crate geojson;
-extern crate rstar;
 extern crate regex;
-extern crate geo;
-extern crate kodama;
+extern crate rstar;
+extern crate serde_json;
 
 // Internal Helper Libraries
-pub mod util;
 pub mod stream;
 pub mod text;
+pub mod util;
 
-pub mod types;
 pub mod pg;
+pub mod types;
 
 // Helper to current node fn
 pub mod map;
 
 // External PT2ITP Modes
-pub mod convert;
-pub mod stats;
-pub mod dedupe;
 pub mod classify;
 pub mod conflate;
 pub mod consensus;
+pub mod convert;
+pub mod dedupe;
+pub mod stats;
 
 pub use self::types::Address;
 pub use self::types::Network;
 pub use self::types::Polygon;
 
+pub use self::text::Tokenized;
+pub use self::text::Tokens;
 pub use self::types::hecate;
 pub use self::types::Context;
-pub use self::text::Tokens;
-pub use self::text::Tokenized;
 
-pub use self::types::Names;
 pub use self::types::Name;
+pub use self::types::Names;
 pub use self::types::Source;
 
 // Functions registered here will be made avaliable to be called from NodeJS

--- a/native/src/map/mod.rs
+++ b/native/src/map/mod.rs
@@ -1,30 +1,29 @@
-use std::convert::From;
 use postgres::{Connection, TlsMode};
 use std::collections::HashMap;
+use std::convert::From;
 use std::thread;
 
-use crate::Context as CrateContext;
-use crate::{Tokens, Name, Names};
 use crate::util::linker;
+use crate::Context as CrateContext;
+use crate::{Name, Names, Tokens};
 
 use neon::prelude::*;
 
-use super::stream::{
-    GeoStream,
-    AddrStream,
-    NetStream
-};
+use super::stream::{AddrStream, GeoStream, NetStream};
 
 use super::pg;
-use super::pg::{Table, InputTable};
+use super::pg::{InputTable, Table};
 
 pub fn pg_init(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     let db = match cx.argument_opt(0) {
         Some(arg) => arg.downcast::<JsString>().or_throw(&mut cx)?.value(),
-        None => String::from("pt_test")
+        None => String::from("pt_test"),
     };
 
-    let conn = match Connection::connect(format!("postgres://postgres@localhost:5432/{}", &db).as_str(), TlsMode::None) {
+    let conn = match Connection::connect(
+        format!("postgres://postgres@localhost:5432/{}", &db).as_str(),
+        TlsMode::None,
+    ) {
         Ok(conn) => conn,
         Err(err) => {
             println!("Connection Error: {}", err.to_string());
@@ -59,10 +58,13 @@ pub fn pg_init(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 pub fn pg_optimize(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     let db = match cx.argument_opt(0) {
         Some(arg) => arg.downcast::<JsString>().or_throw(&mut cx)?.value(),
-        None => String::from("pt_test")
+        None => String::from("pt_test"),
     };
 
-    let conn = match Connection::connect(format!("postgres://postgres@localhost:5432/{}", &db).as_str(), TlsMode::None) {
+    let conn = match Connection::connect(
+        format!("postgres://postgres@localhost:5432/{}", &db).as_str(),
+        TlsMode::None,
+    ) {
         Ok(conn) => conn,
         Err(err) => {
             println!("Connection Error: {}", err.to_string());
@@ -88,7 +90,7 @@ struct MapArgs {
     context: Option<super::types::InputContext>,
     seq: bool,
     input: Option<String>,
-    errors: Option<String>
+    errors: Option<String>,
 }
 
 impl MapArgs {
@@ -98,7 +100,7 @@ impl MapArgs {
             seq: true,
             context: None,
             input: None,
-            errors: None
+            errors: None,
         }
     }
 }
@@ -116,7 +118,10 @@ pub fn import_addr(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         }
     };
 
-    let conn = match Connection::connect(format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(), TlsMode::None) {
+    let conn = match Connection::connect(
+        format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(),
+        TlsMode::None,
+    ) {
         Ok(conn) => conn,
         Err(err) => {
             println!("Connection Error: {}", err.to_string());
@@ -126,12 +131,19 @@ pub fn import_addr(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
     let context = match args.context {
         Some(context) => CrateContext::from(context),
-        None => CrateContext::new(String::from(""), None, Tokens::new(HashMap::new(), HashMap::new()))
+        None => CrateContext::new(
+            String::from(""),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        ),
     };
 
     let address = pg::Address::new();
     address.create(&conn);
-    address.input(&conn, AddrStream::new(GeoStream::new(args.input), context, args.errors));
+    address.input(
+        &conn,
+        AddrStream::new(GeoStream::new(args.input), context, args.errors),
+    );
     if args.seq {
         address.seq_id(&conn);
     }
@@ -153,7 +165,10 @@ pub fn import_net(mut cx: FunctionContext) -> JsResult<JsBoolean> {
         }
     };
 
-    let conn = match Connection::connect(format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(), TlsMode::None) {
+    let conn = match Connection::connect(
+        format!("postgres://postgres@localhost:5432/{}", &args.db).as_str(),
+        TlsMode::None,
+    ) {
         Ok(conn) => conn,
         Err(err) => {
             println!("Connection Error: {}", err.to_string());
@@ -163,12 +178,19 @@ pub fn import_net(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 
     let context = match args.context {
         Some(context) => CrateContext::from(context),
-        None => CrateContext::new(String::from(""), None, Tokens::new(HashMap::new(), HashMap::new()))
+        None => CrateContext::new(
+            String::from(""),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        ),
     };
 
     let network = pg::Network::new();
     network.create(&conn);
-    network.input(&conn, NetStream::new(GeoStream::new(args.input), context, args.errors));
+    network.input(
+        &conn,
+        NetStream::new(GeoStream::new(args.input), context, args.errors),
+    );
     if args.seq {
         network.seq_id(&conn);
     }
@@ -180,15 +202,18 @@ pub fn import_net(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 pub fn cluster_addr(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     let db = match cx.argument_opt(0) {
         Some(arg) => arg.downcast::<JsString>().or_throw(&mut cx)?.value(),
-        None => String::from("pt_test")
+        None => String::from("pt_test"),
     };
 
     let orphan = match cx.argument_opt(1) {
         Some(arg) => arg.downcast::<JsBoolean>().or_throw(&mut cx)?.value(),
-        None => false
+        None => false,
     };
 
-    let conn = match Connection::connect(format!("postgres://postgres@localhost:5432/{}", &db).as_str(), TlsMode::None) {
+    let conn = match Connection::connect(
+        format!("postgres://postgres@localhost:5432/{}", &db).as_str(),
+        TlsMode::None,
+    ) {
         Ok(conn) => conn,
         Err(err) => {
             println!("Connection Error: {}", err.to_string());
@@ -207,10 +232,13 @@ pub fn cluster_addr(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 pub fn link_addr(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     let db = match cx.argument_opt(0) {
         Some(arg) => arg.downcast::<JsString>().or_throw(&mut cx)?.value(),
-        None => String::from("pt_test")
+        None => String::from("pt_test"),
     };
 
-    let conn = match Connection::connect(format!("postgres://postgres@localhost:5432/{}", &db).as_str(), TlsMode::None) {
+    let conn = match Connection::connect(
+        format!("postgres://postgres@localhost:5432/{}", &db).as_str(),
+        TlsMode::None,
+    ) {
         Ok(conn) => conn,
         Err(err) => {
             println!("Connection Error: {}", err.to_string());
@@ -224,33 +252,38 @@ pub fn link_addr(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     let mut web = Vec::new();
 
     let batch_extra = count % cpus;
-    let batch = (count  - batch_extra) / cpus;
+    let batch = (count - batch_extra) / cpus;
 
     for cpu in 0..cpus {
         let db_conn = db.clone();
 
-        let strand = match thread::Builder::new().name(format!("Linker #{}", &cpu)).spawn(move || {
-            let mut min_id = batch * cpu;
-            let max_id = batch * cpu + batch + batch_extra;
+        let strand = match thread::Builder::new()
+            .name(format!("Linker #{}", &cpu))
+            .spawn(move || {
+                let mut min_id = batch * cpu;
+                let max_id = batch * cpu + batch + batch_extra;
 
-            if cpu != 0 {
-                min_id = min_id + batch_extra + 1;
-            }
-
-            let conn = match Connection::connect(format!("postgres://postgres@localhost:5432/{}", &db_conn).as_str(), TlsMode::None) {
-                Ok(conn) => conn,
-                Err(err) => {
-                    println!("Connection Error: {}", err.to_string());
-                    panic!("Connection Error: {}", err.to_string());
+                if cpu != 0 {
+                    min_id = min_id + batch_extra + 1;
                 }
-            };
 
-            let mut it = min_id;
-            while it < max_id {
-                link_process(&conn, it, it + 5000);
-                it += 5001;
-            }
-        }) {
+                let conn = match Connection::connect(
+                    format!("postgres://postgres@localhost:5432/{}", &db_conn).as_str(),
+                    TlsMode::None,
+                ) {
+                    Ok(conn) => conn,
+                    Err(err) => {
+                        println!("Connection Error: {}", err.to_string());
+                        panic!("Connection Error: {}", err.to_string());
+                    }
+                };
+
+                let mut it = min_id;
+                while it < max_id {
+                    link_process(&conn, it, it + 5000);
+                    it += 5001;
+                }
+            }) {
             Ok(strand) => strand,
             Err(err) => {
                 println!("Thread Creation Error: {}", err.to_string());
@@ -271,8 +304,8 @@ pub fn link_addr(mut cx: FunctionContext) -> JsResult<JsBoolean> {
                     println!("Thread Error: {:?}", err);
                     panic!("Thread Error: {:?}", err);
                 }
-            },
-            _ => ()
+            }
+            _ => (),
         };
     }
 
@@ -282,16 +315,17 @@ pub fn link_addr(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 #[derive(Serialize, Deserialize)]
 pub struct DbSerial {
     id: i64,
-    names: Vec<Name>
+    names: Vec<Name>,
 }
 
 pub struct DbType {
     id: i64,
-    names: Names
+    names: Names,
 }
 
 pub fn link_process(conn: &impl postgres::GenericConnection, min: i64, max: i64) {
-    match conn.query("
+    match conn.query(
+        "
         SELECT
             a.id AS id,
             a.names::JSON AS name,
@@ -311,14 +345,16 @@ pub fn link_process(conn: &impl postgres::GenericConnection, min: i64, max: i64)
             a.id,
             a.names,
             a.geom
-    ", &[&min, &max]) {
+    ",
+        &[&min, &max],
+    ) {
         Ok(results) => {
             let trans = match conn.transaction() {
                 Err(err) => {
                     println!("Transaction Create Error: {}", err.to_string());
                     panic!("Transaction Create Error: {}", err.to_string());
-                },
-                Ok(trans) => trans
+                }
+                Ok(trans) => trans,
             };
 
             for result in results.iter() {
@@ -328,13 +364,11 @@ pub fn link_process(conn: &impl postgres::GenericConnection, min: i64, max: i64)
                     Err(err) => {
                         println!("JSON Failure: {}", err.to_string());
                         panic!("JSON Failure: {}", err.to_string());
-                    },
-                    Ok(names) => names
+                    }
+                    Ok(names) => names,
                 };
 
-                let names = Names {
-                    names: names
-                };
+                let names = Names { names: names };
 
                 let dbpotentials: serde_json::Value = result.get(2);
 
@@ -342,8 +376,8 @@ pub fn link_process(conn: &impl postgres::GenericConnection, min: i64, max: i64)
                     Err(err) => {
                         println!("JSON Failure: {}", err.to_string());
                         panic!("JSON Failure: {}", err.to_string());
-                    },
-                    Ok(names) => names
+                    }
+                    Ok(names) => names,
                 };
 
                 let mut potentials: Vec<DbType> = Vec::with_capacity(dbpotentials.len());
@@ -351,29 +385,33 @@ pub fn link_process(conn: &impl postgres::GenericConnection, min: i64, max: i64)
                     potentials.push(DbType {
                         id: potential.id,
                         names: Names {
-                            names: potential.names
-                        }
+                            names: potential.names,
+                        },
                     });
                 }
 
                 let primary = linker::Link::new(id, &names);
-                let potentials: Vec<linker::Link> = potentials.iter().map(|potential| {
-                    linker::Link::new(potential.id, &potential.names)
-                }).collect();
+                let potentials: Vec<linker::Link> = potentials
+                    .iter()
+                    .map(|potential| linker::Link::new(potential.id, &potential.names))
+                    .collect();
 
                 match linker::linker(primary, potentials, false) {
                     Some(link_match) => {
-                        match trans.execute(&*"
+                        match trans.execute(
+                            &*"
                             UPDATE address SET netid = $1 WHERE id = $2;
-                        ", &[&link_match.id, &id]) {
+                        ",
+                            &[&link_match.id, &id],
+                        ) {
                             Err(err) => {
                                 println!("Transaction Statement Error: {}", err.to_string());
                                 panic!("Transaction Statement Error: {}", err.to_string());
-                            },
-                            Ok(trans) => trans
+                            }
+                            Ok(trans) => trans,
                         };
-                    },
-                    None => ()
+                    }
+                    None => (),
                 };
             }
 
@@ -381,10 +419,10 @@ pub fn link_process(conn: &impl postgres::GenericConnection, min: i64, max: i64)
                 Err(err) => {
                     println!("Transaction Commit Error: {}", err.to_string());
                     panic!("Transaction Commit Error: {}", err.to_string());
-                },
-                _ => ()
+                }
+                _ => (),
             };
-        },
+        }
         Err(err) => {
             println!("{}", err.to_string());
             panic!("{}", err.to_string());
@@ -395,15 +433,18 @@ pub fn link_process(conn: &impl postgres::GenericConnection, min: i64, max: i64)
 pub fn cluster_net(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     let db = match cx.argument_opt(0) {
         Some(arg) => arg.downcast::<JsString>().or_throw(&mut cx)?.value(),
-        None => String::from("pt_test")
+        None => String::from("pt_test"),
     };
 
     let orphan = match cx.argument_opt(1) {
         Some(arg) => arg.downcast::<JsBoolean>().or_throw(&mut cx)?.value(),
-        None => false
+        None => false,
     };
 
-    let conn = match Connection::connect(format!("postgres://postgres@localhost:5432/{}", &db).as_str(), TlsMode::None) {
+    let conn = match Connection::connect(
+        format!("postgres://postgres@localhost:5432/{}", &db).as_str(),
+        TlsMode::None,
+    ) {
         Ok(conn) => conn,
         Err(err) => {
             println!("Connection Error: {}", err.to_string());
@@ -422,10 +463,13 @@ pub fn cluster_net(mut cx: FunctionContext) -> JsResult<JsBoolean> {
 pub fn intersections(mut cx: FunctionContext) -> JsResult<JsBoolean> {
     let db = match cx.argument_opt(0) {
         Some(arg) => arg.downcast::<JsString>().or_throw(&mut cx)?.value(),
-        None => String::from("pt_test")
+        None => String::from("pt_test"),
     };
 
-    let conn = match Connection::connect(format!("postgres://postgres@localhost:5432/{}", &db).as_str(), TlsMode::None) {
+    let conn = match Connection::connect(
+        format!("postgres://postgres@localhost:5432/{}", &db).as_str(),
+        TlsMode::None,
+    ) {
         Ok(conn) => conn,
         Err(err) => {
             println!("Connection Error: {}", err.to_string());
@@ -458,12 +502,12 @@ pub fn dedupe_syn(mut cx: FunctionContext) -> JsResult<JsArray> {
         }
     };
 
-    if names.len() == 0 { return Ok(cx.empty_array()); }
+    if names.len() == 0 {
+        return Ok(cx.empty_array());
+    }
 
     // don't use Names::new() so we're not generating synonyms again
-    let mut names = Names {
-        names: names
-    };
+    let mut names = Names { names: names };
 
     names.empty();
     names.sort();
@@ -474,8 +518,8 @@ pub fn dedupe_syn(mut cx: FunctionContext) -> JsResult<JsArray> {
     let out = JsArray::new(&mut cx, display_names.len() as u32);
 
     for (i, name) in display_names.iter().enumerate() {
-            let js_string = cx.string(name);
-            out.set(&mut cx, i as u32, js_string).unwrap();
+        let js_string = cx.string(name);
+        out.set(&mut cx, i as u32, js_string).unwrap();
     }
 
     Ok(out)

--- a/native/src/pg/address.rs
+++ b/native/src/pg/address.rs
@@ -1,8 +1,8 @@
-use postgres::{Connection};
+use super::{InputTable, Table};
+use postgres::Connection;
 use std::io::Read;
-use super::{Table, InputTable};
 
-pub struct Address ();
+pub struct Address();
 
 impl Address {
     pub fn new() -> Self {
@@ -10,29 +10,41 @@ impl Address {
     }
 
     pub fn max(&self, conn: &Connection) -> i64 {
-        match conn.query(r#"
+        match conn.query(
+            r#"
             SELECT max(id) FROM address
-        "#, &[]) {
+        "#,
+            &[],
+        ) {
             Ok(res) => {
                 let max: i64 = res.get(0).get(0);
                 max
-            },
-            _ => 0
+            }
+            _ => 0,
         }
     }
 }
 
 impl Table for Address {
     fn create(&self, conn: &Connection) {
-        conn.execute(r#"
+        conn.execute(
+            r#"
              CREATE EXTENSION IF NOT EXISTS POSTGIS
-        "#, &[]).unwrap();
+        "#,
+            &[],
+        )
+        .unwrap();
 
-        conn.execute(r#"
+        conn.execute(
+            r#"
             DROP TABLE IF EXISTS address;
-        "#, &[]).unwrap();
+        "#,
+            &[],
+        )
+        .unwrap();
 
-        conn.execute(r#"
+        conn.execute(
+            r#"
             CREATE UNLOGGED TABLE address (
                 id BIGINT,
                 version BIGINT,
@@ -44,18 +56,24 @@ impl Table for Address {
                 props JSONB,
                 geom GEOMETRY(POINT, 4326)
             )
-        "#, &[]).unwrap();
+        "#,
+            &[],
+        )
+        .unwrap();
     }
 
     fn count(&self, conn: &Connection) -> i64 {
-        match conn.query(r#"
+        match conn.query(
+            r#"
             SELECT count(*) FROM address
-        "#, &[]) {
+        "#,
+            &[],
+        ) {
             Ok(res) => {
                 let cnt: i64 = res.get(0).get(0);
                 cnt
-            },
-            _ => 0
+            }
+            _ => 0,
         }
     }
 
@@ -67,27 +85,46 @@ impl Table for Address {
                 USING ST_SetSRID(ST_MakePoint(ST_X(geom), ST_Y(geom), COALESCE(id::FLOAT, 0)), 4326);
         "#, &[]).unwrap();
 
-        conn.execute(r#"
+        conn.execute(
+            r#"
             CREATE INDEX address_idx ON address (id);
-        "#, &[]).unwrap();
+        "#,
+            &[],
+        )
+        .unwrap();
 
-        conn.execute(r#"
+        conn.execute(
+            r#"
             CREATE INDEX address_gix ON address USING GIST (geom);
-        "#, &[]).unwrap();
+        "#,
+            &[],
+        )
+        .unwrap();
 
-        conn.execute(r#"
+        conn.execute(
+            r#"
             CLUSTER address USING address_idx;
-        "#, &[]).unwrap();
+        "#,
+            &[],
+        )
+        .unwrap();
 
-        conn.execute(r#"
+        conn.execute(
+            r#"
             ANALYZE address;
-        "#, &[]).unwrap();
+        "#,
+            &[],
+        )
+        .unwrap();
     }
 }
 
 impl InputTable for Address {
     fn input(&self, conn: &Connection, mut data: impl Read) {
-        let stmt = conn.prepare(format!(r#"
+        let stmt = conn
+            .prepare(
+                format!(
+                    r#"
             COPY address (
                 id,
                 version,
@@ -105,24 +142,40 @@ impl InputTable for Address {
                 DELIMITER E'\t',
                 QUOTE E'\b'
             )
-        "#).as_str()).unwrap();
+        "#
+                )
+                .as_str(),
+            )
+            .unwrap();
 
         stmt.copy_in(&[], &mut data).unwrap();
     }
 
     fn seq_id(&self, conn: &Connection) {
-        conn.execute(r#"
+        conn.execute(
+            r#"
             DROP SEQUENCE IF EXISTS address_seq;
-        "#, &[]).unwrap();
+        "#,
+            &[],
+        )
+        .unwrap();
 
-        conn.execute(r#"
+        conn.execute(
+            r#"
             CREATE SEQUENCE address_seq;
-        "#, &[]).unwrap();
+        "#,
+            &[],
+        )
+        .unwrap();
 
-        conn.execute(r#"
+        conn.execute(
+            r#"
             UPDATE address
                 SET id = nextval('address_seq');
-        "#, &[]).unwrap();
+        "#,
+            &[],
+        )
+        .unwrap();
     }
 }
 
@@ -130,11 +183,16 @@ impl InputTable for Address {
 // for all past versions of a feature.
 // This ensures that past features are not modified but will match addresses being conflated.
 pub fn pre_conflate(conn: &Connection) {
-    conn.execute(r#"
+    conn.execute(
+        r#"
         DROP TABLE IF EXISTS address_id_to_version;
-    "#, &[]).unwrap();
+    "#,
+        &[],
+    )
+    .unwrap();
 
-    conn.execute(r#"
+    conn.execute(
+        r#"
         CREATE TABLE IF NOT EXISTS address_id_to_version as
             SELECT
                 id,
@@ -143,9 +201,13 @@ pub fn pre_conflate(conn: &Connection) {
                 address
             GROUP BY
                 id
-    "#, &[]).unwrap();
+    "#,
+        &[],
+    )
+    .unwrap();
 
-    conn.execute(r#"
+    conn.execute(
+        r#"
         UPDATE address
         SET
             output = false,
@@ -155,5 +217,8 @@ pub fn pre_conflate(conn: &Connection) {
         WHERE
             address.id = address_id_to_version.id
             AND address.version != address_id_to_version.max_version
-    "#, &[]).unwrap();
+    "#,
+        &[],
+    )
+    .unwrap();
 }

--- a/native/src/pg/intersections.rs
+++ b/native/src/pg/intersections.rs
@@ -1,7 +1,7 @@
-use postgres::Connection;
 use super::Table;
+use postgres::Connection;
 
-pub struct Intersections ();
+pub struct Intersections();
 
 impl Intersections {
     pub fn new() -> Self {
@@ -12,7 +12,8 @@ impl Intersections {
     /// Create intersections from network data
     ///
     pub fn generate(&self, conn: &Connection) {
-        conn.execute("
+        conn.execute(
+            "
             INSERT INTO intersections (a_id, b_id, geom) (
                 SELECT
                     a.id,
@@ -25,35 +26,55 @@ impl Intersections {
                         a.id != b.id
                         AND ST_Intersects(a.geom, b.geom)
             )
-        ", &[]).unwrap();
+        ",
+            &[],
+        )
+        .unwrap();
 
-        conn.execute("
+        conn.execute(
+            "
             UPDATE intersections
                 SET b_street = network_cluster.names
                 FROM network_cluster
                 WHERE intersections.b_id = network_cluster.id
-        ", &[]).unwrap();
+        ",
+            &[],
+        )
+        .unwrap();
 
-        conn.execute("
+        conn.execute(
+            "
             UPDATE intersections
                 SET a_street = network_cluster.names
                 FROM network_cluster
                 WHERE intersections.a_id = network_cluster.id
-        ", &[]).unwrap();
+        ",
+            &[],
+        )
+        .unwrap();
     }
 }
 
 impl Table for Intersections {
     fn create(&self, conn: &Connection) {
-        conn.execute(r#"
+        conn.execute(
+            r#"
              CREATE EXTENSION IF NOT EXISTS POSTGIS
-        "#, &[]).unwrap();
+        "#,
+            &[],
+        )
+        .unwrap();
 
-        conn.execute(r#"
+        conn.execute(
+            r#"
             DROP TABLE IF EXISTS intersections;
-        "#, &[]).unwrap();
+        "#,
+            &[],
+        )
+        .unwrap();
 
-        conn.execute(r#"
+        conn.execute(
+            r#"
             CREATE UNLOGGED TABLE intersections (
                 id SERIAL,
                 a_id BIGINT,
@@ -62,24 +83,34 @@ impl Table for Intersections {
                 b_street JSONB,
                 geom GEOMETRY(POINT, 4326)
             )
-        "#, &[]).unwrap();
+        "#,
+            &[],
+        )
+        .unwrap();
     }
 
     fn count(&self, conn: &Connection) -> i64 {
-        match conn.query("
+        match conn.query(
+            "
             SELECT count(*) FROM intersections
-        ", &[]) {
+        ",
+            &[],
+        ) {
             Ok(res) => {
                 let cnt: i64 = res.get(0).get(0);
                 cnt
-            },
-            _ => 0
+            }
+            _ => 0,
         }
     }
 
     fn index(&self, conn: &Connection) {
-        conn.execute("
+        conn.execute(
+            "
             CREATE INDEX IF NOT EXISTS intersections_gix ON intersections USING GIST (geom);
-        ", &[]).unwrap();
+        ",
+            &[],
+        )
+        .unwrap();
     }
 }

--- a/native/src/pg/polygon.rs
+++ b/native/src/pg/polygon.rs
@@ -1,68 +1,114 @@
-use postgres::{Connection};
+use super::{InputTable, Table};
+use postgres::Connection;
 use std::io::Read;
-use super::{Table, InputTable};
 
 ///
 /// Polygon table are special in that they don't make assumptions about the underlying
 /// data. They can be any one of a number of types - building polys, parcels, places
 ///
 pub struct Polygon {
-    name: String
+    name: String,
 }
 
 impl Polygon {
     pub fn new(name: impl ToString) -> Self {
         Polygon {
-            name: name.to_string()
+            name: name.to_string(),
         }
     }
 }
 
 impl Table for Polygon {
     fn create(&self, conn: &Connection) {
-        conn.execute(r#"
+        conn.execute(
+            r#"
              CREATE EXTENSION IF NOT EXISTS POSTGIS
-        "#, &[]).unwrap();
+        "#,
+            &[],
+        )
+        .unwrap();
 
-        conn.execute(format!(r#"
+        conn.execute(
+            format!(
+                r#"
             DROP TABLE IF EXISTS {};
-        "#, &self.name).as_str(), &[]).unwrap();
+        "#,
+                &self.name
+            )
+            .as_str(),
+            &[],
+        )
+        .unwrap();
 
-        conn.execute(format!(r#"
+        conn.execute(
+            format!(
+                r#"
             CREATE UNLOGGED TABLE {} (
                 id BIGINT,
                 props JSONB,
                 geom GEOMETRY(MultiPolygon, 4326)
             )
-        "#, &self.name).as_str(), &[]).unwrap();
+        "#,
+                &self.name
+            )
+            .as_str(),
+            &[],
+        )
+        .unwrap();
     }
 
     fn count(&self, conn: &Connection) -> i64 {
-        match conn.query(format!(r#"
+        match conn.query(
+            format!(
+                r#"
             SELECT count(*) FROM {}
-        "#, &self.name).as_str(), &[]) {
+        "#,
+                &self.name
+            )
+            .as_str(),
+            &[],
+        ) {
             Ok(res) => {
                 let cnt: i64 = res.get(0).get(0);
                 cnt
-            },
-            _ => 0
+            }
+            _ => 0,
         }
     }
 
     fn index(&self, conn: &Connection) {
-        conn.execute(format!(r#"
+        conn.execute(
+            format!(
+                r#"
             CREATE INDEX {name}_idx ON {name} (id);
-        "#, name = &self.name).as_str(), &[]).unwrap();
+        "#,
+                name = &self.name
+            )
+            .as_str(),
+            &[],
+        )
+        .unwrap();
 
-        conn.execute(format!(r#"
+        conn.execute(
+            format!(
+                r#"
             CREATE INDEX {name}_gix ON {name} USING GIST (geom);
-        "#, name = &self.name).as_str(), &[]).unwrap();
+        "#,
+                name = &self.name
+            )
+            .as_str(),
+            &[],
+        )
+        .unwrap();
     }
 }
 
 impl InputTable for Polygon {
     fn input(&self, conn: &Connection, mut data: impl Read) {
-        let stmt = conn.prepare(format!(r#"
+        let stmt = conn
+            .prepare(
+                format!(
+                    r#"
             COPY {} (
                 props,
                 geom
@@ -74,28 +120,65 @@ impl InputTable for Polygon {
                 DELIMITER E'\t',
                 QUOTE E'\b'
             )
-        "#, &self.name).as_str()).unwrap();
+        "#,
+                    &self.name
+                )
+                .as_str(),
+            )
+            .unwrap();
 
         stmt.copy_in(&[], &mut data).unwrap();
 
-        conn.execute(format!(r#"
+        conn.execute(
+            format!(
+                r#"
             UPDATE {name}
                 SET geom = ST_CollectionExtract(ST_MakeValid(geom), 3)
-        "#, name = &self.name).as_str(), &[]).unwrap();
+        "#,
+                name = &self.name
+            )
+            .as_str(),
+            &[],
+        )
+        .unwrap();
     }
 
     fn seq_id(&self, conn: &Connection) {
-        conn.execute(format!(r#"
+        conn.execute(
+            format!(
+                r#"
             DROP SEQUENCE IF EXISTS {}_seq;
-        "#, &self.name).as_str(), &[]).unwrap();
+        "#,
+                &self.name
+            )
+            .as_str(),
+            &[],
+        )
+        .unwrap();
 
-        conn.execute(format!(r#"
+        conn.execute(
+            format!(
+                r#"
             CREATE SEQUENCE {}_seq;
-        "#, &self.name).as_str(), &[]).unwrap();
+        "#,
+                &self.name
+            )
+            .as_str(),
+            &[],
+        )
+        .unwrap();
 
-        conn.execute(format!(r#"
+        conn.execute(
+            format!(
+                r#"
             UPDATE {name}
                 SET id = nextval('{name}_seq');
-        "#, name = &self.name).as_str(), &[]).unwrap();
+        "#,
+                name = &self.name
+            )
+            .as_str(),
+            &[],
+        )
+        .unwrap();
     }
 }

--- a/native/src/stats/count.rs
+++ b/native/src/stats/count.rs
@@ -26,8 +26,8 @@ pub fn addresses(feat: &geojson::Feature) -> i64 {
 
                     addr
                 }
-            }
-        }
+            },
+        },
     }
 }
 
@@ -59,8 +59,8 @@ pub fn intersections(feat: &geojson::Feature) -> i64 {
 
                     intsecs
                 }
-            }
-        }
+            },
+        },
     }
 }
 

--- a/native/src/stats/explode.rs
+++ b/native/src/stats/explode.rs
@@ -3,12 +3,12 @@ pub struct StatAddress {
     pub geom: Vec<f64>,
     pub number: String,
     pub accuracy: Option<String>,
-    pub postcode: Option<String>
+    pub postcode: Option<String>,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct StatIntersection {
-    pub geom: Vec<f64>
+    pub geom: Vec<f64>,
 }
 
 ///
@@ -20,11 +20,11 @@ pub fn addresses(feat: &geojson::Feature) -> Vec<StatAddress> {
     let (numbers, ele) = match feat.properties {
         None => {
             return addrs;
-        },
+        }
         Some(ref props) => match props.get(&String::from("carmen:addressnumber")) {
             None => {
                 return addrs;
-            },
+            }
             Some(ref array) => {
                 if !array.is_array() {
                     return addrs;
@@ -53,7 +53,7 @@ pub fn addresses(feat: &geojson::Feature) -> Vec<StatAddress> {
                     (array[ele].as_array().unwrap(), ele)
                 }
             }
-        }
+        },
     };
 
     let coords = match &feat.geometry {
@@ -61,11 +61,11 @@ pub fn addresses(feat: &geojson::Feature) -> Vec<StatAddress> {
             geojson::Value::MultiPoint(mp) => mp,
             geojson::Value::GeometryCollection(gc) => match &gc[ele].value {
                 geojson::Value::MultiPoint(mp) => mp,
-                _ => panic!("Expected MultiPoint geometry")
-            }
-            _ => panic!("Only MultiPoint & GeometryCollections are supported")
+                _ => panic!("Expected MultiPoint geometry"),
+            },
+            _ => panic!("Only MultiPoint & GeometryCollections are supported"),
         },
-        None => panic!("geometry required")
+        None => panic!("geometry required"),
     };
 
     if coords.len() != numbers.len() {
@@ -78,20 +78,19 @@ pub fn addresses(feat: &geojson::Feature) -> Vec<StatAddress> {
             number: match &numbers[ele] {
                 serde_json::Value::String(string) => string.to_string(),
                 serde_json::Value::Number(num) => num.to_string(),
-                _ => panic!("Address numbers must be a string/numeric")
+                _ => panic!("Address numbers must be a string/numeric"),
             },
             accuracy: match get_prop(&feat, "accuracy", ele.to_string()) {
                 None => None,
                 Some(serde_json::Value::String(string)) => Some(string),
-                _ => panic!("accuracy property should be string")
+                _ => panic!("accuracy property should be string"),
             },
             postcode: match get_prop(&feat, "override:postcode", ele.to_string()) {
                 None => None,
                 Some(serde_json::Value::String(string)) => Some(string),
                 Some(serde_json::Value::Number(num)) => Some(num.to_string()),
-                _ => panic!("postcode property should be string/number")
-
-            }
+                _ => panic!("postcode property should be string/number"),
+            },
         };
 
         addrs.push(stat);
@@ -112,18 +111,22 @@ fn get_prop(feat: &geojson::Feature, key: impl ToString, ele: String) -> Option<
                     } else {
                         Some(prop.clone())
                     }
-                },
-                Some(override_prop) => Some(override_prop)
+                }
+                Some(override_prop) => Some(override_prop),
             },
             None => match get_override(props, &key, ele) {
                 None => None,
-                Some(override_prop) => Some(override_prop)
-            }
-        }
+                Some(override_prop) => Some(override_prop),
+            },
+        },
     }
 }
 
-fn get_override(props: &serde_json::Map<String, serde_json::Value>, key: &String, ele: String) -> Option<serde_json::Value> {
+fn get_override(
+    props: &serde_json::Map<String, serde_json::Value>,
+    key: &String,
+    ele: String,
+) -> Option<serde_json::Value> {
     match props.get(&String::from("carmen:addressprops")) {
         None => None,
         Some(ref props) => match props.get(&key) {
@@ -137,8 +140,8 @@ fn get_override(props: &serde_json::Map<String, serde_json::Value>, key: &String
                         Some(prop_value.clone())
                     }
                 }
-            }
-        }
+            },
+        },
     }
 }
 
@@ -176,16 +179,16 @@ pub fn intersections(feat: &geojson::Feature) -> Vec<StatIntersection> {
                     Some(geom) => match &geom.value {
                         geojson::Value::GeometryCollection(gc) => match &gc[ele].value {
                             geojson::Value::MultiPoint(mp) => mp,
-                            _ => panic!("Expected MultiPoint geometry")
-                        }
-                        _ => panic!("Only GeometryCollections are supported for intersections")
+                            _ => panic!("Expected MultiPoint geometry"),
+                        },
+                        _ => panic!("Only GeometryCollections are supported for intersections"),
                     },
-                    None => panic!("geometry required")
+                    None => panic!("geometry required"),
                 };
 
                 for ele in 0..coords.len() {
                     let stat = StatIntersection {
-                        geom: coords[ele].clone()
+                        geom: coords[ele].clone(),
                     };
 
                     ints.push(stat);
@@ -193,6 +196,6 @@ pub fn intersections(feat: &geojson::Feature) -> Vec<StatIntersection> {
 
                 ints
             }
-        }
+        },
     }
 }

--- a/native/src/stream/addr.rs
+++ b/native/src/stream/addr.rs
@@ -1,7 +1,7 @@
 use std::convert::From;
-use std::iter::Iterator;
-use std::io::{Write, BufWriter};
 use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::iter::Iterator;
 
 use crate::{stream::geo::GeoStream, Address, Context};
 
@@ -9,7 +9,7 @@ pub struct AddrStream {
     context: Context,
     input: GeoStream,
     buffer: Option<Vec<u8>>, //Used by Read impl for storing partial features
-    errors: Option<BufWriter<File>>
+    errors: Option<BufWriter<File>>,
 }
 
 impl AddrStream {
@@ -20,8 +20,8 @@ impl AddrStream {
             buffer: None,
             errors: match errors {
                 None => None,
-                Some(path) => Some(BufWriter::new(File::create(path).unwrap()))
-            }
+                Some(path) => Some(BufWriter::new(File::create(path).unwrap())),
+            },
         }
     }
 }
@@ -38,7 +38,7 @@ impl std::io::Read for AddrStream {
             } else {
                 let feat = match self.next() {
                     Some(feat) => feat.to_tsv(),
-                    None => String::from("")
+                    None => String::from(""),
                 };
 
                 let mut bytes = feat.into_bytes();
@@ -83,9 +83,11 @@ impl Iterator for AddrStream {
 
                             Err(err)
                         }
-                    }
+                    },
                 },
-                None => { return None; }
+                None => {
+                    return None;
+                }
             };
         }
 

--- a/native/src/stream/geo.rs
+++ b/native/src/stream/geo.rs
@@ -1,10 +1,10 @@
+use std::convert::From;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader};
-use std::convert::From;
 use std::iter::Iterator;
 
 pub struct GeoStream {
-    input: Input
+    input: Input,
 }
 
 pub enum Input {
@@ -17,15 +17,15 @@ impl GeoStream {
         let stream = match input {
             Some(inpath) => match File::open(inpath) {
                 Ok(file) => GeoStream {
-                    input: Input::File(BufReader::new(file).lines())
+                    input: Input::File(BufReader::new(file).lines()),
                 },
-                Err(err) => { panic!("Unable to open input file: {}", err); }
-            },
-            None => {
-                GeoStream {
-                    input: Input::StdIn(Box::leak(Box::new(io::stdin())).lock().lines())
+                Err(err) => {
+                    panic!("Unable to open input file: {}", err);
                 }
-            }
+            },
+            None => GeoStream {
+                input: Input::StdIn(Box::leak(Box::new(io::stdin())).lock().lines()),
+            },
         };
 
         stream
@@ -37,16 +37,16 @@ impl GeoStream {
                 None => None,
                 Some(file) => match file {
                     Ok(line) => Some(line),
-                    Err(err) => panic!("{}", err)
-                }
+                    Err(err) => panic!("{}", err),
+                },
             },
             Input::StdIn(ref mut stdin) => match stdin.next() {
                 None => None,
                 Some(stdin) => match stdin {
                     Ok(line) => Some(line),
-                    Err(err) => panic!("{}", err)
-                }
-            }
+                    Err(err) => panic!("{}", err),
+                },
+            },
         }
     }
 }
@@ -60,14 +60,14 @@ impl Iterator for GeoStream {
         while line.is_some() && line.as_ref().unwrap().trim().len() == 0 {
             line = match GeoStream::line(&mut self.input) {
                 None => None,
-                Some(line) => Some(line)
+                Some(line) => Some(line),
             };
         }
 
         match line {
             None => {
                 return None;
-            },
+            }
             Some(mut line) => {
                 //Remove Ascii Record Separators at beginning or end of line
                 if line.ends_with("\u{001E}") {

--- a/native/src/stream/mod.rs
+++ b/native/src/stream/mod.rs
@@ -3,7 +3,7 @@ pub mod geo;
 pub mod net;
 pub mod poly;
 
-pub use self::poly::PolyStream;
-pub use self::geo::GeoStream;
 pub use self::addr::AddrStream;
+pub use self::geo::GeoStream;
 pub use self::net::NetStream;
+pub use self::poly::PolyStream;

--- a/native/src/stream/net.rs
+++ b/native/src/stream/net.rs
@@ -1,15 +1,15 @@
 use std::convert::From;
-use std::iter::Iterator;
-use std::io::{Write, BufWriter};
 use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::iter::Iterator;
 
-use crate::{stream::geo::GeoStream, Network, Context};
+use crate::{stream::geo::GeoStream, Context, Network};
 
 pub struct NetStream {
     context: Context,
     input: GeoStream,
     buffer: Option<Vec<u8>>, //Used by Read impl for storing partial features
-    errors: Option<BufWriter<File>>
+    errors: Option<BufWriter<File>>,
 }
 
 impl NetStream {
@@ -20,8 +20,8 @@ impl NetStream {
             buffer: None,
             errors: match errors {
                 None => None,
-                Some(path) => Some(BufWriter::new(File::create(path).unwrap()))
-            }
+                Some(path) => Some(BufWriter::new(File::create(path).unwrap())),
+            },
         }
     }
 }
@@ -38,7 +38,7 @@ impl std::io::Read for NetStream {
             } else {
                 let feat = match self.next() {
                     Some(feat) => feat.to_tsv(),
-                    None => String::from("")
+                    None => String::from(""),
                 };
 
                 let mut bytes = feat.into_bytes();
@@ -83,13 +83,14 @@ impl Iterator for NetStream {
 
                             Err(err)
                         }
-                    }
+                    },
                 },
-                None => { return None; }
+                None => {
+                    return None;
+                }
             };
         }
 
         Some(next.unwrap())
-
     }
 }

--- a/native/src/stream/poly.rs
+++ b/native/src/stream/poly.rs
@@ -1,14 +1,14 @@
 use std::convert::From;
-use std::iter::Iterator;
-use std::io::{Write, BufWriter};
 use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::iter::Iterator;
 
 use crate::{stream::geo::GeoStream, Polygon};
 
 pub struct PolyStream {
     input: GeoStream,
     buffer: Option<Vec<u8>>, //Used by Read impl for storing partial features
-    errors: Option<BufWriter<File>>
+    errors: Option<BufWriter<File>>,
 }
 
 impl PolyStream {
@@ -18,8 +18,8 @@ impl PolyStream {
             buffer: None,
             errors: match errors {
                 None => None,
-                Some(path) => Some(BufWriter::new(File::create(path).unwrap()))
-            }
+                Some(path) => Some(BufWriter::new(File::create(path).unwrap())),
+            },
         }
     }
 }
@@ -36,7 +36,7 @@ impl std::io::Read for PolyStream {
             } else {
                 let feat = match self.next() {
                     Some(feat) => feat.to_tsv(),
-                    None => String::from("")
+                    None => String::from(""),
                 };
 
                 let mut bytes = feat.into_bytes();
@@ -81,9 +81,11 @@ impl Iterator for PolyStream {
 
                             Err(err)
                         }
-                    }
+                    },
                 },
-                None => { return None; }
+                None => {
+                    return None;
+                }
             };
         }
 

--- a/native/src/text/diacritics.rs
+++ b/native/src/text/diacritics.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use regex::Regex;
+use std::collections::HashMap;
 
 ///
 /// Remove all diacritics from the given string
@@ -9,7 +9,6 @@ use regex::Regex;
 pub fn diacritics(text: &String) -> String {
     lazy_static! {
         static ref HAS_DIACRITICS: Regex = Regex::new(r"[^\u0000-\u007e]").unwrap();
-
         static ref DIACRITICS: HashMap<char, &'static str> = {
             let mut m = HashMap::new();
             m.insert('\u{00a0}', " ");
@@ -868,10 +867,10 @@ pub fn diacritics(text: &String) -> String {
         let mut no_dia = String::new();
 
         for text_char in text.chars() {
-             match DIACRITICS.get(&text_char) {
-                 Some(replacement) => no_dia.push_str(replacement),
-                 None => no_dia.push(text_char)
-             }
+            match DIACRITICS.get(&text_char) {
+                Some(replacement) => no_dia.push_str(replacement),
+                None => no_dia.push(text_char),
+            }
         }
 
         no_dia
@@ -886,18 +885,30 @@ mod tests {
 
     #[test]
     fn remove_diacritics() {
-        assert_eq!(diacritics(&String::from("Iлｔèｒｎåｔïｏｎɑｌíƶａｔï߀ԉ")), String::from("Internationalizati0n"));
+        assert_eq!(
+            diacritics(&String::from("Iлｔèｒｎåｔïｏｎɑｌíƶａｔï߀ԉ")),
+            String::from("Internationalizati0n")
+        );
 
         assert_eq!(diacritics(&String::from("Båｃòл íｐѕùｍ ðｏɭ߀ｒ ѕïｔ ａϻèｔ âùþê ａԉᏧ߀üïｌɭê ƃëéｆ ｃｕｌρá ｆïｌèｔ ϻｉǥｎòｎ ｃｕρｉᏧａｔａｔ ｕｔ êлｉｍ ｔòлɢùê.")), String::from("Bacon ipѕum dhol0r ѕit aMet authe and0uille beef culpa filet Mignon cupidatat ut enim tonGue."));
 
         assert_eq!(diacritics(&String::from("ᴎᴑᴅᴇȷʂ")), String::from("NoDEJs"));
 
-        assert_eq!(diacritics(&String::from("hambúrguer")), String::from("hamburguer"));
+        assert_eq!(
+            diacritics(&String::from("hambúrguer")),
+            String::from("hamburguer")
+        );
 
         assert_eq!(diacritics(&String::from("hŒllœ")), String::from("hOElloe"));
 
-        assert_eq!(diacritics(&String::from("Fußball")), String::from("Fussball"));
+        assert_eq!(
+            diacritics(&String::from("Fußball")),
+            String::from("Fussball")
+        );
 
-        assert_eq!(diacritics(&String::from("ABCDEFGHIJKLMNOPQRSTUVWXYZé")), String::from("ABCDEFGHIJKLMNOPQRSTUVWXYZe"));
+        assert_eq!(
+            diacritics(&String::from("ABCDEFGHIJKLMNOPQRSTUVWXYZé")),
+            String::from("ABCDEFGHIJKLMNOPQRSTUVWXYZe")
+        );
     }
 }

--- a/native/src/text/replace.rs
+++ b/native/src/text/replace.rs
@@ -1,6 +1,6 @@
-use fancy_regex::{Regex, Captures, Error};
-use std::str;
+use fancy_regex::{Captures, Error, Regex};
 use memchr::memchr;
+use std::str;
 
 pub trait ReplaceAll {
     fn replace_all(&self, text: &str, rep: &str) -> Result<String, Error>;
@@ -18,7 +18,7 @@ impl ReplaceAll for Regex {
                     None => {
                         new.push_str(&input);
                         break;
-                    },
+                    }
                     Some(m) => {
                         // capture group 0 always corresponds to the entire match
                         let pos = (m.pos(0).unwrap().0, m.pos(0).unwrap().1);
@@ -37,7 +37,7 @@ impl ReplaceAll for Regex {
                     None => {
                         new.push_str(&input);
                         break;
-                    },
+                    }
                     Some(m) => {
                         new.push_str(&input[..m.0]);
                         new.push_str(&rep);
@@ -63,11 +63,7 @@ struct CaptureRef {
     end: usize,
 }
 
-fn expand_str(
-    caps: &Captures,
-    mut replacement: &str,
-    dst: &mut String,
-) {
+fn expand_str(caps: &Captures, mut replacement: &str, dst: &mut String) {
     while !replacement.is_empty() {
         match memchr(b'$', replacement.as_bytes()) {
             None => break,
@@ -99,9 +95,7 @@ fn expand_str(
 /// starting at the beginning of `replacement`.
 ///
 /// If no such valid reference could be found, None is returned.
-fn find_cap_ref<T: ?Sized + AsRef<[u8]>>(
-    replacement: &T,
-) -> Option<CaptureRef> {
+fn find_cap_ref<T: ?Sized + AsRef<[u8]>>(replacement: &T) -> Option<CaptureRef> {
     let mut i = 0;
     let rep: &[u8] = replacement.as_ref();
     if rep.len() <= 1 || rep[0] != b'$' {
@@ -118,17 +112,14 @@ fn find_cap_ref<T: ?Sized + AsRef<[u8]>>(
     // We just verified that the range 0..cap_end is valid ASCII, so it must
     // therefore be valid UTF-8. If we really cared, we could avoid this UTF-8
     // check with either unsafe or by parsing the number straight from &[u8].
-    let cap = str::from_utf8(&rep[i..cap_end])
-                  .expect("valid UTF-8 capture name");
+    let cap = str::from_utf8(&rep[i..cap_end]).expect("valid UTF-8 capture name");
 
     match cap.parse::<u32>() {
-        Ok(i) => {
-            Some(CaptureRef {
-                cap: i as usize,
-                end: cap_end
-            })
-        },
-        Err(_) => None
+        Ok(i) => Some(CaptureRef {
+            cap: i as usize,
+            end: cap_end,
+        }),
+        Err(_) => None,
     }
 }
 
@@ -136,7 +127,7 @@ fn find_cap_ref<T: ?Sized + AsRef<[u8]>>(
 /// Modified to only support numbered capture groups
 fn is_valid_cap(b: &u8) -> bool {
     match *b {
-        b'0' ..= b'9' => true,
+        b'0'..=b'9' => true,
         _ => false,
     }
 }
@@ -147,17 +138,71 @@ mod tests {
 
     #[test]
     fn test_replace() {
-        assert_eq!(Regex::new(r"(?:floor|fl) #?\d{1,3}").unwrap().replace_all("123 main st", "").unwrap(), "123 main st");
+        assert_eq!(
+            Regex::new(r"(?:floor|fl) #?\d{1,3}")
+                .unwrap()
+                .replace_all("123 main st", "")
+                .unwrap(),
+            "123 main st"
+        );
         assert_eq!(Regex::new(r"(?:apartment|apt|bldg|building|rm|room|unit) #?(?:[A-Z]|\d+|[A-Z]\d+|\d+[A-Z]|\d+-\d+[A-Z]?)").unwrap().replace_all("123 main st apt #5 washington dc", "").unwrap(), "123 main st  washington dc");
-        assert_eq!(Regex::new(r"(?:floor|fl) #?\d{1,3}").unwrap().replace_all("123 main st floor 5", "").unwrap(), "123 main st ");
-        assert_eq!(Regex::new(r"\d{1,3}(?:st|nd|rd|th) (?:floor|fl)").unwrap().replace_all("5th floor", "").unwrap(), "");
-        assert_eq!(Regex::new(r"[１1]丁目").unwrap().replace_all("1丁目 意思", "一丁目").unwrap(), "一丁目 意思");
+        assert_eq!(
+            Regex::new(r"(?:floor|fl) #?\d{1,3}")
+                .unwrap()
+                .replace_all("123 main st floor 5", "")
+                .unwrap(),
+            "123 main st "
+        );
+        assert_eq!(
+            Regex::new(r"\d{1,3}(?:st|nd|rd|th) (?:floor|fl)")
+                .unwrap()
+                .replace_all("5th floor", "")
+                .unwrap(),
+            ""
+        );
+        assert_eq!(
+            Regex::new(r"[１1]丁目")
+                .unwrap()
+                .replace_all("1丁目 意思", "一丁目")
+                .unwrap(),
+            "一丁目 意思"
+        );
 
-        assert_eq!(Regex::new(r"([a-z]+)vagen").unwrap().replace_all("123 main st", "$1v").unwrap(), "123 main st");
-        assert_eq!(Regex::new(r"([a-z]+)vagen").unwrap().replace_all("amanuensvagen 5 stockholm sweden", "$1v").unwrap(), "amanuensv 5 stockholm sweden");
-        assert_eq!(Regex::new(r"([a-z]+)vagen").unwrap().replace_all("amanuensvagen 5 stockholm sweden gutenvagen", "$1v").unwrap(), "amanuensv 5 stockholm sweden gutenv");
-        assert_eq!(Regex::new(r"([^ ]+)(strasse|straße|str)").unwrap().replace_all("wilhelmstraße 3", "$1 str").unwrap(), "wilhelm str 3");
-        assert_eq!(Regex::new(r"(foo) (bar)").unwrap().replace_all("foo bar", "$2 $1").unwrap(), "bar foo");
+        assert_eq!(
+            Regex::new(r"([a-z]+)vagen")
+                .unwrap()
+                .replace_all("123 main st", "$1v")
+                .unwrap(),
+            "123 main st"
+        );
+        assert_eq!(
+            Regex::new(r"([a-z]+)vagen")
+                .unwrap()
+                .replace_all("amanuensvagen 5 stockholm sweden", "$1v")
+                .unwrap(),
+            "amanuensv 5 stockholm sweden"
+        );
+        assert_eq!(
+            Regex::new(r"([a-z]+)vagen")
+                .unwrap()
+                .replace_all("amanuensvagen 5 stockholm sweden gutenvagen", "$1v")
+                .unwrap(),
+            "amanuensv 5 stockholm sweden gutenv"
+        );
+        assert_eq!(
+            Regex::new(r"([^ ]+)(strasse|straße|str)")
+                .unwrap()
+                .replace_all("wilhelmstraße 3", "$1 str")
+                .unwrap(),
+            "wilhelm str 3"
+        );
+        assert_eq!(
+            Regex::new(r"(foo) (bar)")
+                .unwrap()
+                .replace_all("foo bar", "$2 $1")
+                .unwrap(),
+            "bar foo"
+        );
     }
 
     /// Tests from the core Rust regex crate
@@ -178,7 +223,10 @@ mod tests {
 
     macro_rules! c {
         ($name_or_number:expr, $pos:expr) => {
-            CaptureRef { cap: $name_or_number, end: $pos }
+            CaptureRef {
+                cap: $name_or_number,
+                end: $pos,
+            }
         };
     }
 

--- a/native/src/text/titlecase.rs
+++ b/native/src/text/titlecase.rs
@@ -1,6 +1,6 @@
+use crate::Context;
 use regex::Regex;
 use unicode_segmentation::UnicodeSegmentation;
-use crate::Context;
 
 ///
 /// Titlecase input strings
@@ -8,11 +8,16 @@ use crate::Context;
 
 pub fn titlecase(text: &String, context: &Context) -> String {
     lazy_static! {
-        static ref WORD_BOUNDARY: Regex = Regex::new(r#"[\s\u2000-\u206F\u2E00-\u2E7F\\!#$%&()"*+,\-./:;<=>?@\[\]\^_{\|}~]+"#).unwrap();
+        static ref WORD_BOUNDARY: Regex =
+            Regex::new(r#"[\s\u2000-\u206F\u2E00-\u2E7F\\!#$%&()"*+,\-./:;<=>?@\[\]\^_{\|}~]+"#)
+                .unwrap();
     }
 
     let mut text = text.trim().to_lowercase();
-    text = Regex::new(r"\s+").unwrap().replace_all(&text, " ").to_string();
+    text = Regex::new(r"\s+")
+        .unwrap()
+        .replace_all(&text, " ")
+        .to_string();
     let mut new = String::new();
     let mut word_count = 0;
     let mut last_match = 0;
@@ -32,8 +37,7 @@ pub fn titlecase(text: &String, context: &Context) -> String {
         new.push_str(&capitalize(word, word_count, context));
     }
 
-    if context.country == String::from("US")
-    || context.country == String::from("CA") {
+    if context.country == String::from("US") || context.country == String::from("CA") {
         new = normalize_cardinals(&new)
     }
 
@@ -42,28 +46,28 @@ pub fn titlecase(text: &String, context: &Context) -> String {
 
 pub fn capitalize(word: &str, word_count: usize, context: &Context) -> String {
     const MINOR_EN: [&str; 40] = [
-        "a", "an", "and", "as", "at", "but", "by", "en", "for", "from", "how", "if", "in", "neither", "nor",
-        "of", "on", "only", "onto", "out", "or", "per", "so", "than", "that", "the", "to", "until", "up",
-        "upon", "v", "v.", "versus", "vs", "vs.", "via", "when", "with", "without", "yet"
+        "a", "an", "and", "as", "at", "but", "by", "en", "for", "from", "how", "if", "in",
+        "neither", "nor", "of", "on", "only", "onto", "out", "or", "per", "so", "than", "that",
+        "the", "to", "until", "up", "upon", "v", "v.", "versus", "vs", "vs.", "via", "when",
+        "with", "without", "yet",
     ];
 
     const MAJOR_EN: [&str; 2] = ["us", "dc"];
 
     const MINOR_DE: [&str; 1] = ["du"];
 
-    if (context.country == String::from("US")
-        || context.country == String::from("CA"))
-        && MAJOR_EN.contains(&word) {
+    if (context.country == String::from("US") || context.country == String::from("CA"))
+        && MAJOR_EN.contains(&word)
+    {
         return String::from(word).to_uppercase();
     }
     // don't apply lower casing to the first word in the string
     if word_count > 1 {
-        if (context.country == String::from("US")
-            || context.country == String::from("CA"))
-            && MINOR_EN.contains(&word) {
+        if (context.country == String::from("US") || context.country == String::from("CA"))
+            && MINOR_EN.contains(&word)
+        {
             return String::from(word);
-        } else if context.country == String::from("DE")
-            && MINOR_DE.contains(&word) {
+        } else if context.country == String::from("DE") && MINOR_DE.contains(&word) {
             return String::from(word);
         }
     }
@@ -71,26 +75,26 @@ pub fn capitalize(word: &str, word_count: usize, context: &Context) -> String {
     let mut graphemes = UnicodeSegmentation::graphemes(word, true);
     let first_grapheme = match graphemes.next() {
         Some(g) => g,
-        None => return String::from(word)
+        None => return String::from(word),
     };
     first_grapheme.to_uppercase() + graphemes.as_str()
 }
 
 pub fn normalize_cardinals(text: &str) -> String {
     lazy_static! {
-        static ref CARDINAL: Regex = Regex::new(r"(?i)(^|\s)(?P<cardinal>(n\.w\.|nw|n\.e\.|ne|s\.w\.|sw|s\.e\.|se))(\s|$)").unwrap();
+        static ref CARDINAL: Regex =
+            Regex::new(r"(?i)(^|\s)(?P<cardinal>(n\.w\.|nw|n\.e\.|ne|s\.w\.|sw|s\.e\.|se))(\s|$)")
+                .unwrap();
     }
     let output = match CARDINAL.captures(text) {
-        Some(capture) => {
-            match capture.name("cardinal") {
-                Some(mat) => {
-                    let cardinal = mat.as_str().to_uppercase().replace(".", "");
-                    text[..mat.start()].to_string() + &cardinal + &text[mat.end()..]
-                },
-                None => text.to_string()
+        Some(capture) => match capture.name("cardinal") {
+            Some(mat) => {
+                let cardinal = mat.as_str().to_uppercase().replace(".", "");
+                text[..mat.start()].to_string() + &cardinal + &text[mat.end()..]
             }
+            None => text.to_string(),
         },
-        None => text.to_string()
+        None => text.to_string(),
     };
     output
 }
@@ -98,49 +102,156 @@ pub fn normalize_cardinals(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
     use crate::Tokens;
+    use std::collections::HashMap;
 
     #[test]
     fn test_titlecase() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
-        assert_eq!(titlecase(&String::from("Väike-Sõjamäe"), &context), String::from("Väike-Sõjamäe"));
-        assert_eq!(titlecase(&String::from("Väike-sõjamäe"), &context), String::from("Väike-Sõjamäe"));
-        assert_eq!(titlecase(&String::from("väike-sõjamäe"), &context), String::from("Väike-Sõjamäe"));
-        assert_eq!(titlecase(&String::from("väike sõjamäe"), &context), String::from("Väike Sõjamäe"));
-        assert_eq!(titlecase(&String::from("väike  sõjamäe"), &context), String::from("Väike Sõjamäe"));
-        assert_eq!(titlecase(&String::from("Väike Sõjamäe"), &context), String::from("Väike Sõjamäe"));
-        assert_eq!(titlecase(&String::from("VäikeSõjamäe"), &context), String::from("Väikesõjamäe"));
-        assert_eq!(titlecase(&String::from("ámbar"), &context), String::from("Ámbar"));
-        assert_eq!(titlecase(&String::from("y̆ámbary̆"), &context), String::from("Y̆ámbary̆"));
-        assert_eq!(titlecase(&String::from("y\u{306}ámbary\u{306}"), &context), String::from("Y\u{306}ámbary\u{306}"));
+        assert_eq!(
+            titlecase(&String::from("Väike-Sõjamäe"), &context),
+            String::from("Väike-Sõjamäe")
+        );
+        assert_eq!(
+            titlecase(&String::from("Väike-sõjamäe"), &context),
+            String::from("Väike-Sõjamäe")
+        );
+        assert_eq!(
+            titlecase(&String::from("väike-sõjamäe"), &context),
+            String::from("Väike-Sõjamäe")
+        );
+        assert_eq!(
+            titlecase(&String::from("väike sõjamäe"), &context),
+            String::from("Väike Sõjamäe")
+        );
+        assert_eq!(
+            titlecase(&String::from("väike  sõjamäe"), &context),
+            String::from("Väike Sõjamäe")
+        );
+        assert_eq!(
+            titlecase(&String::from("Väike Sõjamäe"), &context),
+            String::from("Väike Sõjamäe")
+        );
+        assert_eq!(
+            titlecase(&String::from("VäikeSõjamäe"), &context),
+            String::from("Väikesõjamäe")
+        );
+        assert_eq!(
+            titlecase(&String::from("ámbar"), &context),
+            String::from("Ámbar")
+        );
+        assert_eq!(
+            titlecase(&String::from("y̆ámbary̆"), &context),
+            String::from("Y̆ámbary̆")
+        );
+        assert_eq!(
+            titlecase(&String::from("y\u{306}ámbary\u{306}"), &context),
+            String::from("Y\u{306}ámbary\u{306}")
+        );
         assert_eq!(titlecase(&String::from("ç"), &context), String::from("Ç"));
-        assert_eq!(titlecase(&String::from("Здравствуйте"), &context), String::from("Здравствуйте"));
-        assert_eq!(titlecase(&String::from("नमस्त"), &context), String::from("नमस्त"));
-        assert_eq!(titlecase(&String::from("abra CAda -bra"), &context), String::from("Abra Cada -Bra"));
-        assert_eq!(titlecase(&String::from("abra-CAda-bra"), &context), String::from("Abra-Cada-Bra"));
-        assert_eq!(titlecase(&String::from("our lady of whatever"), &context), String::from("Our Lady of Whatever"));
-        assert_eq!(titlecase(&String::from("our lady OF whatever"), &context), String::from("Our Lady of Whatever"));
-        assert_eq!(titlecase(&String::from("St Martin\"s Neck Road"), &context), String::from("St Martin\"S Neck Road"));
-        assert_eq!(titlecase(&String::from("St Martin's Neck Road"), &context), String::from("St Martin's Neck Road"));
-        assert_eq!(titlecase(&String::from("MT. MOOSILAUKE HWY"), &context), String::from("Mt. Moosilauke Hwy"));
-        assert_eq!(titlecase(&String::from("some  miscellaneous rd (what happens to parentheses?)"), &context), String::from("Some Miscellaneous Rd (What Happens to Parentheses?)"));
-        assert_eq!(titlecase(&String::from("main st NE"), &context), String::from("Main St NE"));
-        assert_eq!(titlecase(&String::from("main St NW"), &context), String::from("Main St NW"));
-        assert_eq!(titlecase(&String::from("SW Main St."), &context), String::from("SW Main St."));
-        assert_eq!(titlecase(&String::from("Main S.E. St"), &context), String::from("Main SE St"));
-        assert_eq!(titlecase(&String::from("main st ne"), &context), String::from("Main St NE"));
-        assert_eq!(titlecase(&String::from("nE. Main St"), &context), String::from("Ne. Main St"));
-        assert_eq!(titlecase(&String::from("us hwy 1"), &context), String::from("US Hwy 1"));
-        assert_eq!(titlecase(&String::from(" -a nice road- "), &context), String::from("-A Nice Road-"));
+        assert_eq!(
+            titlecase(&String::from("Здравствуйте"), &context),
+            String::from("Здравствуйте")
+        );
+        assert_eq!(
+            titlecase(&String::from("नमस्त"), &context),
+            String::from("नमस्त")
+        );
+        assert_eq!(
+            titlecase(&String::from("abra CAda -bra"), &context),
+            String::from("Abra Cada -Bra")
+        );
+        assert_eq!(
+            titlecase(&String::from("abra-CAda-bra"), &context),
+            String::from("Abra-Cada-Bra")
+        );
+        assert_eq!(
+            titlecase(&String::from("our lady of whatever"), &context),
+            String::from("Our Lady of Whatever")
+        );
+        assert_eq!(
+            titlecase(&String::from("our lady OF whatever"), &context),
+            String::from("Our Lady of Whatever")
+        );
+        assert_eq!(
+            titlecase(&String::from("St Martin\"s Neck Road"), &context),
+            String::from("St Martin\"S Neck Road")
+        );
+        assert_eq!(
+            titlecase(&String::from("St Martin's Neck Road"), &context),
+            String::from("St Martin's Neck Road")
+        );
+        assert_eq!(
+            titlecase(&String::from("MT. MOOSILAUKE HWY"), &context),
+            String::from("Mt. Moosilauke Hwy")
+        );
+        assert_eq!(
+            titlecase(
+                &String::from("some  miscellaneous rd (what happens to parentheses?)"),
+                &context
+            ),
+            String::from("Some Miscellaneous Rd (What Happens to Parentheses?)")
+        );
+        assert_eq!(
+            titlecase(&String::from("main st NE"), &context),
+            String::from("Main St NE")
+        );
+        assert_eq!(
+            titlecase(&String::from("main St NW"), &context),
+            String::from("Main St NW")
+        );
+        assert_eq!(
+            titlecase(&String::from("SW Main St."), &context),
+            String::from("SW Main St.")
+        );
+        assert_eq!(
+            titlecase(&String::from("Main S.E. St"), &context),
+            String::from("Main SE St")
+        );
+        assert_eq!(
+            titlecase(&String::from("main st ne"), &context),
+            String::from("Main St NE")
+        );
+        assert_eq!(
+            titlecase(&String::from("nE. Main St"), &context),
+            String::from("Ne. Main St")
+        );
+        assert_eq!(
+            titlecase(&String::from("us hwy 1"), &context),
+            String::from("US Hwy 1")
+        );
+        assert_eq!(
+            titlecase(&String::from(" -a nice road- "), &context),
+            String::from("-A Nice Road-")
+        );
         assert_eq!(titlecase(&String::from("-x"), &context), String::from("-X"));
         assert_eq!(titlecase(&String::from("x-"), &context), String::from("X-"));
-        assert_eq!(titlecase(&String::from(" *$&#()__ "), &context), String::from("*$&#()__"));
-        assert_eq!(titlecase(&String::from("BrandywiNE Street Northwest"), &context), String::from("Brandywine Street Northwest"));
+        assert_eq!(
+            titlecase(&String::from(" *$&#()__ "), &context),
+            String::from("*$&#()__")
+        );
+        assert_eq!(
+            titlecase(&String::from("BrandywiNE Street Northwest"), &context),
+            String::from("Brandywine Street Northwest")
+        );
 
-        let context = Context::new(String::from("de"), None, Tokens::new(HashMap::new(), HashMap::new()));
-        assert_eq!(titlecase(&String::from(" hast Du recht"), &context), String::from("Hast du Recht"));
-        assert_eq!(titlecase(&String::from("a 9, 80939 münchen, germany"), &context), String::from("A 9, 80939 München, Germany"));
+        let context = Context::new(
+            String::from("de"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
+        assert_eq!(
+            titlecase(&String::from(" hast Du recht"), &context),
+            String::from("Hast du Recht")
+        );
+        assert_eq!(
+            titlecase(&String::from("a 9, 80939 münchen, germany"), &context),
+            String::from("A 9, 80939 München, Germany")
+        );
     }
 }

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -11,7 +11,10 @@ pub struct Tokens {
 }
 
 impl Tokens {
-    pub fn new(tokens: HashMap<String, ParsedToken>, regex_tokens: HashMap<String, ParsedToken>) -> Self {
+    pub fn new(
+        tokens: HashMap<String, ParsedToken>,
+        regex_tokens: HashMap<String, ParsedToken>,
+    ) -> Self {
         Tokens {
             tokens: tokens,
             regex_tokens: regex_tokens,
@@ -19,7 +22,8 @@ impl Tokens {
     }
 
     pub fn generate(languages: Vec<String>) -> Self {
-        let import: HashMap<String, Vec<Token>> = geocoder_abbreviations::config(languages).unwrap();
+        let import: HashMap<String, Vec<Token>> =
+            geocoder_abbreviations::config(languages).unwrap();
         let mut map: HashMap<String, ParsedToken> = HashMap::new();
         let mut regex_map: HashMap<String, ParsedToken> = HashMap::new();
 
@@ -29,11 +33,13 @@ impl Tokens {
                     for tk in &group.tokens {
                         map.insert(
                             diacritics(&tk.to_lowercase()),
-                            ParsedToken::new(diacritics(&group.canonical.to_lowercase()), group.token_type.to_owned())
+                            ParsedToken::new(
+                                diacritics(&group.canonical.to_lowercase()),
+                                group.token_type.to_owned(),
+                            ),
                         );
                     }
-                }
-                else {
+                } else {
                     for tk in &group.tokens {
                         regex_map.insert(
                             tk.to_lowercase(),
@@ -71,9 +77,7 @@ impl Tokens {
                             let re = Regex::new(&format!(r"{}", regex_string)).unwrap();
                             if re.is_match(token) {
                                 let canonical: &str = &*v.canonical; // convert from std::string::String -> &str
-                                let regexed_token = re
-                                    .replace_all(&token, canonical)
-                                    .to_string();
+                                let regexed_token = re.replace_all(&token, canonical).to_string();
                                 no_token_match =
                                     Tokenized::new(regexed_token, v.token_type.to_owned());
                             }
@@ -137,16 +141,18 @@ impl Tokens {
         normalized = SPACEPUNC.replace_all(normalized.as_str(), " ").to_string();
         normalized = SPACE.replace_all(normalized.as_str(), " ").to_string();
 
-        let tokens: Vec<String> = normalized.split(" ").map(|split| {
-            String::from(split)
-        }).filter(|token| {
-            // Remove Empty Tokens (Double Space/Non Trimmed Input)
-            if token.len() == 0 {
-                false
-            } else {
-                true
-            }
-        }).collect();
+        let tokens: Vec<String> = normalized
+            .split(" ")
+            .map(|split| String::from(split))
+            .filter(|token| {
+                // Remove Empty Tokens (Double Space/Non Trimmed Input)
+                if token.len() == 0 {
+                    false
+                } else {
+                    true
+                }
+            })
+            .collect();
 
         tokens
     }
@@ -157,14 +163,14 @@ impl Tokens {
 #[derive(Debug, PartialEq, Clone)]
 pub struct ParsedToken {
     canonical: String,
-    token_type: Option<TokenType>
+    token_type: Option<TokenType>,
 }
 
 impl ParsedToken {
     pub fn new(canonical: String, token_type: Option<TokenType>) -> Self {
         ParsedToken {
             canonical,
-            token_type
+            token_type,
         }
     }
 }
@@ -172,15 +178,12 @@ impl ParsedToken {
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Tokenized {
     pub token: String,
-    pub token_type: Option<TokenType>
+    pub token_type: Option<TokenType>,
 }
 
 impl Tokenized {
     pub fn new(token: String, token_type: Option<TokenType>) -> Self {
-        Tokenized {
-            token,
-            token_type
-        }
+        Tokenized { token, token_type }
     }
 }
 
@@ -246,271 +249,470 @@ mod tests {
         let tokens = Tokens::new(HashMap::new(), HashMap::new());
 
         // diacritics are removed from latin text
-        assert_eq!(tokenized_string(tokens.process(&String::from("Hérê àrë søme wöřdš, including diacritics and puncatuation!"), &String::from(""))), String::from("here are some words including diacritics and puncatuation"));
+        assert_eq!(
+            tokenized_string(tokens.process(
+                &String::from("Hérê àrë søme wöřdš, including diacritics and puncatuation!"),
+                &String::from("")
+            )),
+            String::from("here are some words including diacritics and puncatuation")
+        );
 
         // nothing happens to latin text
-        assert_eq!(tokenized_string(tokens.process(&String::from("Cranberries are low, creeping shrubs or vines up to 2 metres (7 ft)"), &String::from(""))), String::from("cranberries are low creeping shrubs or vines up to 2 metres 7 ft"));
+        assert_eq!(
+            tokenized_string(tokens.process(
+                &String::from(
+                    "Cranberries are low, creeping shrubs or vines up to 2 metres (7 ft)"
+                ),
+                &String::from("")
+            )),
+            String::from("cranberries are low creeping shrubs or vines up to 2 metres 7 ft")
+        );
 
         // nothing happens to Japanese text
-        assert_eq!(tokenized_string(tokens.process(&String::from("堪《たま》らん！」と片息《かたいき》になつて、喚《わめ》"), &String::from(""))), String::from("堪《たま》らん！」と片息《かたいき》になつて、喚《わめ》"));
+        assert_eq!(
+            tokenized_string(tokens.process(
+                &String::from("堪《たま》らん！」と片息《かたいき》になつて、喚《わめ》"),
+                &String::from("")
+            )),
+            String::from("堪《たま》らん！」と片息《かたいき》になつて、喚《わめ》")
+        );
 
         // greek diacritics are removed and other characters stay the same
-        assert_eq!(tokenized_string(tokens.process(&String::from("άΆέΈήΉίΊόΌύΎ αΑεΕηΗιΙοΟυΥ"), &String::from(""))), String::from("άάέέήήίίόόύύ ααεεηηιιοουυ"));
+        assert_eq!(
+            tokenized_string(tokens.process(
+                &String::from("άΆέΈήΉίΊόΌύΎ αΑεΕηΗιΙοΟυΥ"),
+                &String::from("")
+            )),
+            String::from("άάέέήήίίόόύύ ααεεηηιιοουυ")
+        );
 
         // cyrillic diacritics are removed and other characters stay the same
-        assert_eq!(tokenized_string(tokens.process(&String::from("ўЎёЁѐЀґҐйЙ уУеЕеЕгГиИ"), &String::from(""))), String::from("ўўёёѐѐґґйй ууееееггии"));
+        assert_eq!(
+            tokenized_string(
+                tokens.process(&String::from("ўЎёЁѐЀґҐйЙ уУеЕеЕгГиИ"), &String::from(""))
+            ),
+            String::from("ўўёёѐѐґґйй ууееееггии")
+        );
     }
 
     #[test]
     fn test_tokenize() {
         let tokens = Tokens::new(HashMap::new(), HashMap::new());
 
-        assert_eq!(tokenized_string(tokens.process(&String::from(""), &String::from(""))), String::from(""));
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from(""), &String::from(""))),
+            String::from("")
+        );
 
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo"), &String::from(""))), String::from("foo"));
-        assert_eq!(tokenized_string(tokens.process(&String::from(" foo bar"), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo bar "), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo bar"), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo-bar"), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo+bar"), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo_bar"), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo:bar"), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo;bar"), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo|bar"), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo}bar"), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo{bar"), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo[bar"), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo]bar"), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo(bar"), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo)bar"), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo b.a.r"), &String::from(""))), String::from("foo bar"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("foo's bar"), &String::from(""))), String::from("foos bar"));
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo"), &String::from(""))),
+            String::from("foo")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from(" foo bar"), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo bar "), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo bar"), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo-bar"), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo+bar"), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo_bar"), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo:bar"), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo;bar"), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo|bar"), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo}bar"), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo{bar"), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo[bar"), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo]bar"), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo(bar"), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo)bar"), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo b.a.r"), &String::from(""))),
+            String::from("foo bar")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("foo's bar"), &String::from(""))),
+            String::from("foos bar")
+        );
 
-        assert_eq!(tokenized_string(tokens.process(&String::from("San José"), &String::from(""))), String::from("san jose"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("A Coruña"), &String::from(""))), String::from("a coruna"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("Chamonix-Mont-Blanc"), &String::from(""))), String::from("chamonix mont blanc"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("Rue d'Argout"), &String::from(""))), String::from("rue dargout"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("Hale’iwa Road"), &String::from(""))), String::from("haleiwa road"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("москва"), &String::from(""))), String::from("москва"));
-        assert_eq!(tokenized_string(tokens.process(&String::from("京都市"), &String::from(""))), String::from("京都市"));
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("San José"), &String::from(""))),
+            String::from("san jose")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("A Coruña"), &String::from(""))),
+            String::from("a coruna")
+        );
+        assert_eq!(
+            tokenized_string(
+                tokens.process(&String::from("Chamonix-Mont-Blanc"), &String::from(""))
+            ),
+            String::from("chamonix mont blanc")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("Rue d'Argout"), &String::from(""))),
+            String::from("rue dargout")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("Hale’iwa Road"), &String::from(""))),
+            String::from("haleiwa road")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("москва"), &String::from(""))),
+            String::from("москва")
+        );
+        assert_eq!(
+            tokenized_string(tokens.process(&String::from("京都市"), &String::from(""))),
+            String::from("京都市")
+        );
     }
 
     #[test]
     fn test_replacement_tokens() {
         let mut map: HashMap<String, ParsedToken> = HashMap::new();
         let mut regex_map: HashMap<String, ParsedToken> = HashMap::new();
-        map.insert(String::from("barter"), ParsedToken::new(String::from("foo"), None));
-        map.insert(String::from("saint"), ParsedToken::new(String::from("st"), None));
-        map.insert(String::from("street"), ParsedToken::new(String::from("st"), Some(TokenType::Way)));
+        map.insert(
+            String::from("barter"),
+            ParsedToken::new(String::from("foo"), None),
+        );
+        map.insert(
+            String::from("saint"),
+            ParsedToken::new(String::from("st"), None),
+        );
+        map.insert(
+            String::from("street"),
+            ParsedToken::new(String::from("st"), Some(TokenType::Way)),
+        );
 
         let tokens = Tokens::new(map, regex_map);
 
-        assert_eq!(tokens.process(&String::from("Main Street"), &String::from("")),
+        assert_eq!(
+            tokens.process(&String::from("Main Street"), &String::from("")),
             vec![
                 Tokenized::new(String::from("main"), None),
                 Tokenized::new(String::from("st"), Some(TokenType::Way))
-            ]);
+            ]
+        );
 
-        assert_eq!(tokens.process(&String::from("Main St"), &String::from("")),
+        assert_eq!(
+            tokens.process(&String::from("Main St"), &String::from("")),
             vec![
                 Tokenized::new(String::from("main"), None),
                 Tokenized::new(String::from("st"), None)
-            ]);
+            ]
+        );
 
-        assert_eq!(tokens.process(&String::from("foobarter"), &String::from("")),
-            vec![Tokenized::new(String::from("foobarter"), None)]);
+        assert_eq!(
+            tokens.process(&String::from("foobarter"), &String::from("")),
+            vec![Tokenized::new(String::from("foobarter"), None)]
+        );
 
-        assert_eq!(tokens.process(&String::from("foo barter"), &String::from("")),
+        assert_eq!(
+            tokens.process(&String::from("foo barter"), &String::from("")),
             vec![
                 Tokenized::new(String::from("foo"), None),
                 Tokenized::new(String::from("foo"), None)
-            ]);
+            ]
+        );
     }
 
     #[test]
     fn test_de_replacement() {
         let tokens = Tokens::generate(vec![String::from("de")]);
-        assert_eq!(tokens.process(&String::from("Fresenbergstr"), &String::from("DE")),
-        vec![
-            Tokenized::new(String::from("fresenberg str"), None),
-        ]);
+        assert_eq!(
+            tokens.process(&String::from("Fresenbergstr"), &String::from("DE")),
+            vec![Tokenized::new(String::from("fresenberg str"), None),]
+        );
     }
 
     #[test]
     fn test_generate_tokens() {
         let tokens = Tokens::generate(vec![String::from("en")]);
 
-        assert_eq!(tokens.process(&String::from("New Jersey Av NW"), &String::from("US")),
+        assert_eq!(
+            tokens.process(&String::from("New Jersey Av NW"), &String::from("US")),
             vec![
                 Tokenized::new(String::from("new"), None),
                 Tokenized::new(String::from("jersey"), None),
                 Tokenized::new(String::from("av"), Some(TokenType::Way)),
                 Tokenized::new(String::from("nw"), Some(TokenType::Cardinal))
-            ]);
+            ]
+        );
 
-        assert_eq!(tokens.process(&String::from("New Jersey Ave NW"), &String::from("US")),
+        assert_eq!(
+            tokens.process(&String::from("New Jersey Ave NW"), &String::from("US")),
             vec![
                 Tokenized::new(String::from("new"), None),
                 Tokenized::new(String::from("jersey"), None),
                 Tokenized::new(String::from("av"), Some(TokenType::Way)),
                 Tokenized::new(String::from("nw"), Some(TokenType::Cardinal))
-            ]);
+            ]
+        );
 
-        assert_eq!(tokens.process(&String::from("New Jersey Avenue Northwest"), &String::from("US")),
+        assert_eq!(
+            tokens.process(
+                &String::from("New Jersey Avenue Northwest"),
+                &String::from("US")
+            ),
             vec![
                 Tokenized::new(String::from("new"), None),
                 Tokenized::new(String::from("jersey"), None),
                 Tokenized::new(String::from("av"), Some(TokenType::Way)),
                 Tokenized::new(String::from("nw"), Some(TokenType::Cardinal))
-            ]);
+            ]
+        );
 
-        assert_eq!(tokens.process(&String::from("Saint Peter Street"), &String::from("US")),
+        assert_eq!(
+            tokens.process(&String::from("Saint Peter Street"), &String::from("US")),
             vec![
                 Tokenized::new(String::from("st"), None),
                 Tokenized::new(String::from("peter"), None),
                 Tokenized::new(String::from("st"), Some(TokenType::Way))
-            ]);
+            ]
+        );
 
-        assert_eq!(tokens.process(&String::from("St Peter St"), &String::from("US")),
+        assert_eq!(
+            tokens.process(&String::from("St Peter St"), &String::from("US")),
             vec![
                 Tokenized::new(String::from("st"), None),
                 Tokenized::new(String::from("peter"), None),
                 Tokenized::new(String::from("st"), Some(TokenType::Way))
-            ]);
+            ]
+        );
     }
 
     #[test]
     fn test_type_us_st() {
         assert_eq!(
-            type_us_st(&vec![String::from("")],
-            vec![Tokenized::new(String::from(""), None)]),
+            type_us_st(
+                &vec![String::from("")],
+                vec![Tokenized::new(String::from(""), None)]
+            ),
             vec![Tokenized::new(String::from(""), None)]
         );
 
         // main st
         assert_eq!(
-            type_us_st(&vec![String::from("main"), String::from("st")],
-            vec![
-                Tokenized::new(String::from("main"), None),
-                Tokenized::new(String::from("st"), None)
-            ]),
+            type_us_st(
+                &vec![String::from("main"), String::from("st")],
+                vec![
+                    Tokenized::new(String::from("main"), None),
+                    Tokenized::new(String::from("st"), None)
+                ]
+            ),
             vec![
                 Tokenized::new(String::from("main"), None),
                 Tokenized::new(String::from("st"), Some(TokenType::Way))
-            ]);
+            ]
+        );
         assert_eq!(
-            type_us_st(&vec![String::from("main"), String::from("st")],
+            type_us_st(
+                &vec![String::from("main"), String::from("st")],
+                vec![
+                    Tokenized::new(String::from("main"), None),
+                    Tokenized::new(String::from("st"), Some(TokenType::Way))
+                ]
+            ),
             vec![
                 Tokenized::new(String::from("main"), None),
                 Tokenized::new(String::from("st"), Some(TokenType::Way))
-            ]),
-            vec![
-                Tokenized::new(String::from("main"), None),
-                Tokenized::new(String::from("st"), Some(TokenType::Way))
-            ]);
+            ]
+        );
 
         // st peter st
         assert_eq!(
-            type_us_st(&vec![String::from("st"), String::from("peter"), String::from("st")],
-            vec![
-                Tokenized::new(String::from("st"), None),
-                Tokenized::new(String::from("peter"), None),
-                Tokenized::new(String::from("st"), None)
-            ]),
+            type_us_st(
+                &vec![
+                    String::from("st"),
+                    String::from("peter"),
+                    String::from("st")
+                ],
+                vec![
+                    Tokenized::new(String::from("st"), None),
+                    Tokenized::new(String::from("peter"), None),
+                    Tokenized::new(String::from("st"), None)
+                ]
+            ),
             vec![
                 Tokenized::new(String::from("st"), None),
                 Tokenized::new(String::from("peter"), None),
                 Tokenized::new(String::from("st"), Some(TokenType::Way))
-            ]);
+            ]
+        );
         assert_eq!(
-            type_us_st(&vec![String::from("st"), String::from("peter"), String::from("st")],
-            vec![
-                Tokenized::new(String::from("st"), Some(TokenType::Way)),
-                Tokenized::new(String::from("peter"), None),
-                Tokenized::new(String::from("st"), Some(TokenType::Way))
-            ]),
+            type_us_st(
+                &vec![
+                    String::from("st"),
+                    String::from("peter"),
+                    String::from("st")
+                ],
+                vec![
+                    Tokenized::new(String::from("st"), Some(TokenType::Way)),
+                    Tokenized::new(String::from("peter"), None),
+                    Tokenized::new(String::from("st"), Some(TokenType::Way))
+                ]
+            ),
             vec![
                 Tokenized::new(String::from("st"), None),
                 Tokenized::new(String::from("peter"), None),
                 Tokenized::new(String::from("st"), Some(TokenType::Way))
-            ]);
+            ]
+        );
 
         // st peter
         assert_eq!(
-            type_us_st(&vec![String::from("st"), String::from("peter")],
-            vec![
-                Tokenized::new(String::from("st"), None),
-                Tokenized::new(String::from("peter"), None),
-            ]),
+            type_us_st(
+                &vec![String::from("st"), String::from("peter")],
+                vec![
+                    Tokenized::new(String::from("st"), None),
+                    Tokenized::new(String::from("peter"), None),
+                ]
+            ),
             vec![
                 Tokenized::new(String::from("st"), Some(TokenType::Way)),
                 Tokenized::new(String::from("peter"), None),
-            ]);
+            ]
+        );
         assert_eq!(
-            type_us_st(&vec![String::from("st"), String::from("peter")],
+            type_us_st(
+                &vec![String::from("st"), String::from("peter")],
+                vec![
+                    Tokenized::new(String::from("st"), Some(TokenType::Way)),
+                    Tokenized::new(String::from("peter"), None),
+                ]
+            ),
             vec![
                 Tokenized::new(String::from("st"), Some(TokenType::Way)),
                 Tokenized::new(String::from("peter"), None),
-            ]),
-            vec![
-                Tokenized::new(String::from("st"), Some(TokenType::Way)),
-                Tokenized::new(String::from("peter"), None),
-            ]);
+            ]
+        );
 
         // st peter av
         assert_eq!(
-            type_us_st(&vec![String::from("st"), String::from("peter"), String::from("av")],
+            type_us_st(
+                &vec![
+                    String::from("st"),
+                    String::from("peter"),
+                    String::from("av")
+                ],
+                vec![
+                    Tokenized::new(String::from("st"), None),
+                    Tokenized::new(String::from("peter"), None),
+                    Tokenized::new(String::from("av"), Some(TokenType::Way))
+                ]
+            ),
             vec![
                 Tokenized::new(String::from("st"), None),
                 Tokenized::new(String::from("peter"), None),
                 Tokenized::new(String::from("av"), Some(TokenType::Way))
-            ]),
-            vec![
-                Tokenized::new(String::from("st"), None),
-                Tokenized::new(String::from("peter"), None),
-                Tokenized::new(String::from("av"), Some(TokenType::Way))
-            ]);
+            ]
+        );
         assert_eq!(
-            type_us_st(&vec![String::from("st"), String::from("peter"), String::from("av")],
-            vec![
-                Tokenized::new(String::from("st"), Some(TokenType::Way)),
-                Tokenized::new(String::from("peter"), None),
-                Tokenized::new(String::from("av"), Some(TokenType::Way))
-            ]),
+            type_us_st(
+                &vec![
+                    String::from("st"),
+                    String::from("peter"),
+                    String::from("av")
+                ],
+                vec![
+                    Tokenized::new(String::from("st"), Some(TokenType::Way)),
+                    Tokenized::new(String::from("peter"), None),
+                    Tokenized::new(String::from("av"), Some(TokenType::Way))
+                ]
+            ),
             vec![
                 Tokenized::new(String::from("st"), None),
                 Tokenized::new(String::from("peter"), None),
                 Tokenized::new(String::from("av"), Some(TokenType::Way))
-            ]);
+            ]
+        );
 
         // rue st francois st
         assert_eq!(
-            type_us_st(&vec![String::from("rue"), String::from("st"), String::from("francois"), String::from("st")],
-            vec![
-                Tokenized::new(String::from("rue"), None),
-                Tokenized::new(String::from("st"), None),
-                Tokenized::new(String::from("francois"), None),
-                Tokenized::new(String::from("st"), None)
-            ]),
+            type_us_st(
+                &vec![
+                    String::from("rue"),
+                    String::from("st"),
+                    String::from("francois"),
+                    String::from("st")
+                ],
+                vec![
+                    Tokenized::new(String::from("rue"), None),
+                    Tokenized::new(String::from("st"), None),
+                    Tokenized::new(String::from("francois"), None),
+                    Tokenized::new(String::from("st"), None)
+                ]
+            ),
             vec![
                 Tokenized::new(String::from("rue"), None),
                 Tokenized::new(String::from("st"), None),
                 Tokenized::new(String::from("francois"), None),
                 Tokenized::new(String::from("st"), Some(TokenType::Way))
-            ]);
+            ]
+        );
         assert_eq!(
-            type_us_st(&vec![String::from("rue"), String::from("st"), String::from("francois"), String::from("st")],
-            vec![
-                Tokenized::new(String::from("rue"), None),
-                Tokenized::new(String::from("st"), Some(TokenType::Way)),
-                Tokenized::new(String::from("francois"), None),
-                Tokenized::new(String::from("st"), Some(TokenType::Way))
-            ]),
+            type_us_st(
+                &vec![
+                    String::from("rue"),
+                    String::from("st"),
+                    String::from("francois"),
+                    String::from("st")
+                ],
+                vec![
+                    Tokenized::new(String::from("rue"), None),
+                    Tokenized::new(String::from("st"), Some(TokenType::Way)),
+                    Tokenized::new(String::from("francois"), None),
+                    Tokenized::new(String::from("st"), Some(TokenType::Way))
+                ]
+            ),
             vec![
                 Tokenized::new(String::from("rue"), None),
                 Tokenized::new(String::from("st"), None),
                 Tokenized::new(String::from("francois"), None),
                 Tokenized::new(String::from("st"), Some(TokenType::Way))
-            ]);
+            ]
+        );
     }
 }

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -2,7 +2,7 @@ use postgis::ewkb::AsEwkbPoint;
 use postgis::ewkb::EwkbWrite;
 use regex::{Regex, RegexSet};
 
-use crate::{Context, Names, Name, Source, hecate, types::name::InputName};
+use crate::{hecate, types::name::InputName, Context, Name, Names, Source};
 
 /// A representation of a single Address
 #[derive(Debug)]
@@ -31,26 +31,30 @@ pub struct Address {
     pub props: serde_json::Map<String, serde_json::Value>,
 
     /// Simple representation of Lng/Lat geometry
-    pub geom: geojson::PointType
+    pub geom: geojson::PointType,
 }
 
 impl Address {
     pub fn new(feat: geojson::GeoJson, context: &Context) -> Result<Self, String> {
         let feat = match feat {
             geojson::GeoJson::Feature(feat) => feat,
-            _ => { return Err(String::from("Not a GeoJSON Feature")); }
+            _ => {
+                return Err(String::from("Not a GeoJSON Feature"));
+            }
         };
 
         let mut props = match feat.properties {
             Some(props) => props,
-            None => { return Err(String::from("Feature has no properties")); }
+            None => {
+                return Err(String::from("Feature has no properties"));
+            }
         };
 
         let number = get_number(&mut props)?;
 
         let version = match feat.foreign_members {
             Some(mut props) => get_version(&mut props)?,
-            None => 0
+            None => 0,
         };
 
         let source = get_source(&mut props)?;
@@ -71,10 +75,14 @@ impl Address {
                     }
 
                     pt
-                },
-                _ => { return Err(String::from("Addresses must have Point geometry")); }
+                }
+                _ => {
+                    return Err(String::from("Addresses must have Point geometry"));
+                }
             },
-            None => { return Err(String::from("Addresses must have geometry")); }
+            None => {
+                return Err(String::from("Addresses must have geometry"));
+            }
         };
 
         let street = match props.remove(&String::from("street")) {
@@ -82,8 +90,8 @@ impl Address {
                 props.insert(String::from("street"), street.clone());
 
                 Some(street)
-            },
-            None => None
+            }
+            None => None,
         };
 
         let names = Names::from_value(street, Some(Source::Address), &context)?;
@@ -95,7 +103,7 @@ impl Address {
         let mut addr = Address {
             id: match feat.id {
                 Some(geojson::feature::Id::Number(id)) => id.as_i64(),
-                _ => None
+                _ => None,
             },
             number: number,
             version: version,
@@ -104,7 +112,7 @@ impl Address {
             source: source,
             interpolate: interpolate,
             props: props,
-            geom: geom
+            geom: geom,
         };
 
         addr.std()?;
@@ -118,7 +126,11 @@ impl Address {
     pub fn from_value(value: serde_json::Value) -> Result<Self, String> {
         let mut value = match value {
             serde_json::Value::Object(obj) => obj,
-            _ => { return Err(String::from("Address::from_value value must be JSON Object")); }
+            _ => {
+                return Err(String::from(
+                    "Address::from_value value must be JSON Object",
+                ));
+            }
         };
 
         let names: Names = match value.get(&String::from("names")) {
@@ -127,39 +139,57 @@ impl Address {
 
                 let names: Vec<Name> = match serde_json::from_value(names) {
                     Ok(names) => names,
-                    Err(err) => { return Err(format!("Names Conversion Error: {}", err.to_string())); }
+                    Err(err) => {
+                        return Err(format!("Names Conversion Error: {}", err.to_string()));
+                    }
                 };
 
-                Names {
-                    names: names
-                }
-            },
-            None => { return Err(String::from("names key/value is required")); }
+                Names { names: names }
+            }
+            None => {
+                return Err(String::from("names key/value is required"));
+            }
         };
 
         let props = match value.remove(&String::from("props")) {
             Some(props) => match props {
                 serde_json::Value::Object(obj) => obj,
-                _ => { return Err(String::from("Address::from_value value must be JSON Object")); }
+                _ => {
+                    return Err(String::from(
+                        "Address::from_value value must be JSON Object",
+                    ));
+                }
             },
-            None => { return Err(String::from("props key/value is required")); }
+            None => {
+                return Err(String::from("props key/value is required"));
+            }
         };
 
         let geom = match value.remove(&String::from("geom")) {
             Some(geom) => match geom {
                 serde_json::value::Value::String(geom) => match geom.parse::<geojson::GeoJson>() {
-                    Ok (geom) => match geom {
+                    Ok(geom) => match geom {
                         geojson::GeoJson::Geometry(geom) => match geom.value {
                             geojson::Value::Point(pt) => pt,
-                            _ => { return Err(String::from("Geometry must be point type")); }
+                            _ => {
+                                return Err(String::from("Geometry must be point type"));
+                            }
                         },
-                        _ => { return Err(String::from("Geometry must be point type")); }
+                        _ => {
+                            return Err(String::from("Geometry must be point type"));
+                        }
                     },
-                    Err(err) => { return Err(format!("geom parse error: {}", err.to_string())); }
+                    Err(err) => {
+                        return Err(format!("geom parse error: {}", err.to_string()));
+                    }
                 },
-                _ => { return Err(String::from("geom only supports TEXT type")); }
+                _ => {
+                    return Err(String::from("geom only supports TEXT type"));
+                }
             },
-            None => { return Err(String::from("geom key/value is required")); }
+            None => {
+                return Err(String::from("geom key/value is required"));
+            }
         };
 
         Ok(Address {
@@ -171,7 +201,7 @@ impl Address {
             source: get_source(&mut value)?,
             interpolate: get_interpolate(&mut value)?,
             props: props,
-            geom: geom
+            geom: geom,
         })
     }
 
@@ -188,7 +218,8 @@ impl Address {
                 r"^(\d+)([nsew])(\d+)[a-z]?$",
                 r"^([nesw])(\d+)([nesw]\d+)?$",
                 r"^\d+(к\d+)?(с\d+)?$"
-            ]).unwrap();
+            ])
+            .unwrap();
         }
 
         self.number = HALF.replace(self.number.as_str(), "").to_string();
@@ -213,12 +244,15 @@ impl Address {
     ///name, number, source, props, geom
     ///
     pub fn to_tsv(self) -> String {
-        let geom = postgis::ewkb::Point::new(self.geom[0], self.geom[1], Some(4326)).as_ewkb().to_hex_ewkb();
+        let geom = postgis::ewkb::Point::new(self.geom[0], self.geom[1], Some(4326))
+            .as_ewkb()
+            .to_hex_ewkb();
 
-        format!("{id}\t{version}\t{names}\t{number}\t{source}\t{output}\t{props}\t{geom}\n",
+        format!(
+            "{id}\t{version}\t{names}\t{number}\t{source}\t{output}\t{props}\t{geom}\n",
             id = match self.id {
                 None => String::from(""),
-                Some(id) => id.to_string()
+                Some(id) => id.to_string(),
             },
             version = self.version,
             names = serde_json::to_string(&self.names.names).unwrap_or(String::from("")),
@@ -237,8 +271,14 @@ impl Address {
     ///features or if they are being infrequently written.
     ///to_tsv with a copy stream is far more efficient
     ///
-    pub fn to_db(&self, conn: &impl postgres::GenericConnection, table: impl ToString) -> Result<(), postgres::error::Error> {
-        conn.execute(format!("
+    pub fn to_db(
+        &self,
+        conn: &impl postgres::GenericConnection,
+        table: impl ToString,
+    ) -> Result<(), postgres::error::Error> {
+        conn.execute(
+            format!(
+                "
             INSERT INTO {table} (
                 id,
                 version,
@@ -259,22 +299,24 @@ impl Address {
                 ST_SetSRID(ST_MakePoint($8, $9), 4326)
             )
         ",
-            table = table.to_string()
-        ).as_str(), &[
-            &self.id,
-            &self.version,
-            &serde_json::to_value(&self.names.names).unwrap(),
-            &self.number,
-            &self.source,
-            &self.output,
-            &serde_json::value::Value::from(self.props.clone()),
-            &self.geom[0],
-            &self.geom[1]
-        ])?;
+                table = table.to_string()
+            )
+            .as_str(),
+            &[
+                &self.id,
+                &self.version,
+                &serde_json::to_value(&self.names.names).unwrap(),
+                &self.number,
+                &self.source,
+                &self.output,
+                &serde_json::value::Value::from(self.props.clone()),
+                &self.geom[0],
+                &self.geom[1],
+            ],
+        )?;
 
         Ok(())
     }
-
 
     ///
     /// Outputs Hecate Compatible GeoJSON feature,
@@ -284,60 +326,87 @@ impl Address {
     /// generated: Should generated synonyms be output
     ///
     pub fn to_geojson(mut self, action: hecate::Action, generated: bool) -> geojson::Feature {
-        let mut members: serde_json::map::Map<String, serde_json::Value> = serde_json::map::Map::new();
+        let mut members: serde_json::map::Map<String, serde_json::Value> =
+            serde_json::map::Map::new();
 
         if action != hecate::Action::None {
-            members.insert(String::from("version"), serde_json::value::Value::Number(serde_json::Number::from(self.version)));
+            members.insert(
+                String::from("version"),
+                serde_json::value::Value::Number(serde_json::Number::from(self.version)),
+            );
         }
 
         match action {
             hecate::Action::Create => {
-                members.insert(String::from("action"), serde_json::value::Value::String("create".to_string()));
+                members.insert(
+                    String::from("action"),
+                    serde_json::value::Value::String("create".to_string()),
+                );
                 members.remove(&String::from("version"));
-            },
+            }
             hecate::Action::Modify => {
-                members.insert(String::from("action"), serde_json::value::Value::String("modify".to_string()));
-            },
+                members.insert(
+                    String::from("action"),
+                    serde_json::value::Value::String("modify".to_string()),
+                );
+            }
             hecate::Action::Delete => {
-                members.insert(String::from("action"), serde_json::value::Value::String("delete".to_string()));
-            },
+                members.insert(
+                    String::from("action"),
+                    serde_json::value::Value::String("delete".to_string()),
+                );
+            }
             hecate::Action::Restore => {
-                members.insert(String::from("action"), serde_json::value::Value::String("restore".to_string()));
-            },
-            _ => ()
+                members.insert(
+                    String::from("action"),
+                    serde_json::value::Value::String("restore".to_string()),
+                );
+            }
+            _ => (),
         };
 
-        let names: Vec<InputName> = self.names.names.into_iter().filter(|name| {
-            if !generated {
-                name.source != Some(Source::Generated)
-            } else {
-                true
-            }
-        }).map(|name| {
-            InputName::from(name)
-        }).collect();
+        let names: Vec<InputName> = self
+            .names
+            .names
+            .into_iter()
+            .filter(|name| {
+                if !generated {
+                    name.source != Some(Source::Generated)
+                } else {
+                    true
+                }
+            })
+            .map(|name| InputName::from(name))
+            .collect();
 
-        self.props.insert(String::from("street"), serde_json::to_value(names).unwrap());
+        self.props
+            .insert(String::from("street"), serde_json::to_value(names).unwrap());
 
         if self.source != String::from("") {
-            self.props.insert(String::from("source"), serde_json::value::Value::String(self.source));
+            self.props.insert(
+                String::from("source"),
+                serde_json::value::Value::String(self.source),
+            );
         }
 
-        self.props.insert(String::from("number"), serde_json::value::Value::String(self.number));
+        self.props.insert(
+            String::from("number"),
+            serde_json::value::Value::String(self.number),
+        );
 
         geojson::Feature {
             id: match self.id {
                 None => None,
-                Some(id) => Some(geojson::feature::Id::Number(serde_json::Number::from(id)))
+                Some(id) => Some(geojson::feature::Id::Number(serde_json::Number::from(id))),
             },
             bbox: None,
             geometry: Some(geojson::Geometry {
                 bbox: None,
                 value: geojson::Value::Point(self.geom),
-                foreign_members: None
+                foreign_members: None,
             }),
             properties: Some(self.props),
-            foreign_members: Some(members)
+            foreign_members: Some(members),
         }
     }
 }
@@ -346,24 +415,20 @@ fn get_id(map: &mut serde_json::Map<String, serde_json::Value>) -> Result<Option
     match map.remove(&String::from("id")) {
         Some(id) => match id.as_i64() {
             Some(id) => Ok(Some(id)),
-            None => Err(String::from("ID must be numeric"))
+            None => Err(String::from("ID must be numeric")),
         },
-        None => Ok(None)
+        None => Ok(None),
     }
 }
 
 fn get_number(map: &mut serde_json::Map<String, serde_json::Value>) -> Result<String, String> {
     match map.get(&String::from("number")) {
         Some(number) => match number.clone() {
-            serde_json::value::Value::Number(num) => {
-                Ok(String::from(num.to_string()))
-            },
-            serde_json::value::Value::String(num) => {
-                Ok(num)
-            },
-            _ => Err(String::from("Number property must be String or Numeric"))
+            serde_json::value::Value::Number(num) => Ok(String::from(num.to_string())),
+            serde_json::value::Value::String(num) => Ok(num),
+            _ => Err(String::from("Number property must be String or Numeric")),
         },
-        None => Err(String::from("Number property required"))
+        None => Err(String::from("Number property required")),
     }
 }
 
@@ -371,9 +436,9 @@ fn get_version(map: &mut serde_json::Map<String, serde_json::Value>) -> Result<i
     match map.remove(&String::from("version")) {
         Some(version) => match version.as_i64() {
             Some(version) => Ok(version),
-            _ => Err(String::from("Version must be numeric"))
+            _ => Err(String::from("Version must be numeric")),
         },
-        None => Ok(0)
+        None => Ok(0),
     }
 }
 
@@ -381,9 +446,9 @@ fn get_source(map: &mut serde_json::Map<String, serde_json::Value>) -> Result<St
     match map.get(&String::from("source")) {
         Some(source) => match source.clone() {
             serde_json::value::Value::String(source) => Ok(source),
-            _ => Ok(String::from(""))
+            _ => Ok(String::from("")),
         },
-        None => Ok(String::from(""))
+        None => Ok(String::from("")),
     }
 }
 
@@ -391,9 +456,9 @@ fn get_output(map: &mut serde_json::Map<String, serde_json::Value>) -> Result<bo
     match map.remove(&String::from("output")) {
         Some(output) => match output.as_bool() {
             None => Ok(true),
-            Some(output) => Ok(output)
+            Some(output) => Ok(output),
         },
-        None => Ok(true)
+        None => Ok(true),
     }
 }
 
@@ -401,9 +466,9 @@ fn get_interpolate(map: &mut serde_json::Map<String, serde_json::Value>) -> Resu
     match map.remove(&String::from("interpolate")) {
         Some(itp) => match itp.as_bool() {
             None => Ok(true),
-            Some(itp) => Ok(itp)
+            Some(itp) => Ok(itp),
         },
-        None => Ok(true)
+        None => Ok(true),
     }
 }
 
@@ -420,7 +485,7 @@ mod tests {
             let context = Context::new(
                 String::from("us"),
                 Some(String::from("mn")),
-                Tokens::generate(vec![String::from("en")])
+                Tokens::generate(vec![String::from("en")]),
             );
 
             let addr = Address::new(feat, &context).unwrap();
@@ -435,7 +500,7 @@ mod tests {
             let context = Context::new(
                 String::from("us"),
                 Some(String::from("mn")),
-                Tokens::generate(vec![String::from("en")])
+                Tokens::generate(vec![String::from("en")]),
             );
 
             let addr = Address::new(feat, &context).unwrap();

--- a/native/src/types/context.rs
+++ b/native/src/types/context.rs
@@ -1,18 +1,18 @@
-use std::collections::HashMap;
 use crate::text::Tokens;
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct InputContext {
     pub country: Option<String>,
     pub region: Option<String>,
-    pub languages: Option<Vec<String>>
+    pub languages: Option<Vec<String>>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Context {
     pub country: String,
     pub region: Option<String>,
-    pub tokens: Tokens
+    pub tokens: Tokens,
 }
 
 impl From<InputContext> for Context {
@@ -21,13 +21,12 @@ impl From<InputContext> for Context {
         let region = input.region;
         let tokens = match input.languages {
             None => Tokens::new(HashMap::new(), HashMap::new()),
-            Some(languages) => Tokens::generate(languages)
+            Some(languages) => Tokens::generate(languages),
         };
 
         Context::new(country, region, tokens)
     }
 }
-
 
 impl Context {
     pub fn new(country: String, region: Option<String>, tokens: Tokens) -> Self {
@@ -35,16 +34,16 @@ impl Context {
             country: country.to_uppercase(),
             region: match region {
                 None => None,
-                Some(region) => Some(region.to_uppercase())
+                Some(region) => Some(region.to_uppercase()),
             },
-            tokens: tokens
+            tokens: tokens,
         }
     }
 
     pub fn region_code(&self) -> Option<String> {
         match self.region {
             None => None,
-            Some(ref region) => Some(format!("{}-{}", self.country, region))
+            Some(ref region) => Some(format!("{}-{}", self.country, region)),
         }
     }
 
@@ -108,7 +107,10 @@ impl Context {
                 m.insert(String::from("US-GU"), "Guam");
                 m.insert(String::from("US-MP"), "Northern Mariana Islands");
                 m.insert(String::from("US-PR"), "Puerto Rico");
-                m.insert(String::from("US-UM"), "United States Minor Outlying Islands");
+                m.insert(
+                    String::from("US-UM"),
+                    "United States Minor Outlying Islands",
+                );
                 m.insert(String::from("US-VI"), "Virgin Islands");
 
                 m.insert(String::from("CA-ON"), "Ontario");
@@ -133,8 +135,8 @@ impl Context {
             None => None,
             Some(ref code) => match REGIONS.get(code) {
                 None => None,
-                Some(name) => Some(format!("{}", name))
-            }
+                Some(name) => Some(format!("{}", name)),
+            },
         }
     }
 }
@@ -145,19 +147,37 @@ mod tests {
 
     #[test]
     fn context_test() {
-        assert_eq!(Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new())), Context {
-            country: String::from("US"),
-            region: None,
-            tokens: Tokens::new(HashMap::new(), HashMap::new())
-        });
+        assert_eq!(
+            Context::new(
+                String::from("us"),
+                None,
+                Tokens::new(HashMap::new(), HashMap::new())
+            ),
+            Context {
+                country: String::from("US"),
+                region: None,
+                tokens: Tokens::new(HashMap::new(), HashMap::new())
+            }
+        );
 
-        assert_eq!(Context::new(String::from("uS"), Some(String::from("wv")), Tokens::new(HashMap::new(), HashMap::new())), Context {
-            country: String::from("US"),
-            region: Some(String::from("WV")),
-            tokens: Tokens::new(HashMap::new(), HashMap::new())
-        });
+        assert_eq!(
+            Context::new(
+                String::from("uS"),
+                Some(String::from("wv")),
+                Tokens::new(HashMap::new(), HashMap::new())
+            ),
+            Context {
+                country: String::from("US"),
+                region: Some(String::from("WV")),
+                tokens: Tokens::new(HashMap::new(), HashMap::new())
+            }
+        );
 
-        let cntx = Context::new(String::from("uS"), Some(String::from("wv")), Tokens::new(HashMap::new(), HashMap::new()));
+        let cntx = Context::new(
+            String::from("uS"),
+            Some(String::from("wv")),
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
         assert_eq!(cntx.region_code(), Some(String::from("US-WV")));
 

--- a/native/src/types/hecate.rs
+++ b/native/src/types/hecate.rs
@@ -4,5 +4,5 @@ pub enum Action {
     Create,
     Modify,
     Delete,
-    Restore
+    Restore,
 }

--- a/native/src/types/mod.rs
+++ b/native/src/types/mod.rs
@@ -2,16 +2,16 @@ mod address;
 mod network;
 mod polygon;
 
-pub mod name;
 pub mod context;
 pub mod hecate;
+pub mod name;
 
 pub use self::address::Address;
 pub use self::network::Network;
 pub use self::polygon::Polygon;
 
-pub use self::name::Name;
-pub use self::name::Source;
-pub use self::name::Names;
 pub use self::context::Context;
 pub use self::context::InputContext;
+pub use self::name::Name;
+pub use self::name::Names;
+pub use self::name::Source;

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
-use crate::{Context, text};
-use crate::Tokenized;
-use geocoder_abbreviations::TokenType;
 use crate::text::titlecase;
+use crate::Tokenized;
+use crate::{text, Context};
+use geocoder_abbreviations::TokenType;
+use std::collections::HashMap;
 
 ///
 /// InputName is only used internally to serialize a names array to the
@@ -14,28 +14,26 @@ pub struct InputName {
     pub display: String,
 
     /// When choosing which street name is primary, order by priority
-    pub priority: i8
+    pub priority: i8,
 }
 
 impl From<Name> for InputName {
     fn from(name: Name) -> Self {
         InputName {
             display: name.display,
-            priority: name.priority
+            priority: name.priority,
         }
     }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Names {
-    pub names: Vec<Name>
+    pub names: Vec<Name>,
 }
 
 impl Names {
     pub fn new(names: Vec<Name>, context: &Context) -> Self {
-        let mut names = Names {
-            names: names
-        };
+        let mut names = Names { names: names };
 
         if names.names.len() == 0 {
             return names;
@@ -91,15 +89,24 @@ impl Names {
     /// Parse a Names object from a serde_json value, returning
     /// an empty names vec if unparseable
     ///
-    pub fn from_value(value: Option<serde_json::Value>, source: Option<Source>, context: &Context) -> Result<Self, String> {
+    pub fn from_value(
+        value: Option<serde_json::Value>,
+        source: Option<Source>,
+        context: &Context,
+    ) -> Result<Self, String> {
         let names: Vec<Name> = match value {
             Some(street) => {
                 let mut names: Vec<InputName> = if street.is_string() {
-                    vec![InputName { display: street.as_str().unwrap().to_string(), priority: 0 }]
+                    vec![InputName {
+                        display: street.as_str().unwrap().to_string(),
+                        priority: 0,
+                    }]
                 } else {
                     match serde_json::from_value(street) {
                         Ok(street) => street,
-                        Err(err) => { return Err(format!("Invalid Street Property: {}", err)); }
+                        Err(err) => {
+                            return Err(format!("Invalid Street Property: {}", err));
+                        }
                     }
                 };
                 // network features must have a name with a higher priority than alternative names
@@ -116,13 +123,14 @@ impl Names {
                     }
                 }
 
-                let names: Vec<Name> = names.into_iter().map(|name| {
-                    Name::new(name.display, name.priority, source.clone(), &context)
-                }).collect();
+                let names: Vec<Name> = names
+                    .into_iter()
+                    .map(|name| Name::new(name.display, name.priority, source.clone(), &context))
+                    .collect();
 
                 names
-            },
-            None => Vec::new()
+            }
+            None => Vec::new(),
         };
 
         Ok(Names::new(names, &context))
@@ -165,14 +173,11 @@ impl Names {
     pub fn dedupe(&mut self) {
         struct Dedupe {
             name: Name,
-            first_index: usize
+            first_index: usize,
         }
         impl Dedupe {
             fn new(name: Name, first_index: usize) -> Self {
-                Dedupe {
-                    name,
-                    first_index
-                }
+                Dedupe { name, first_index }
             }
         }
 
@@ -188,21 +193,23 @@ impl Names {
                         continue;
                     // if the new name is generated or had a longer, potentially unabbreviated form,
                     // overwrite the entire Name, keeping the existing priority and freq values
-                    } else if name.source == Some(Source::Generated) || name.display.len() > d.name.display.len() {
+                    } else if name.source == Some(Source::Generated)
+                        || name.display.len() > d.name.display.len()
+                    {
                         let priority = d.name.priority;
                         let freq = d.name.freq;
                         d.name = name;
                         d.name.priority = priority;
                         d.name.freq = freq;
                     }
-                },
+                }
                 // if it doesn't yet exist, add it
                 None => {
                     tokenized.insert(name.tokenized_string(), Dedupe::new(name, i));
                 }
             }
         }
-        let mut names: Vec<Dedupe> = tokenized.into_iter().map(|(_,name)| name).collect();
+        let mut names: Vec<Dedupe> = tokenized.into_iter().map(|(_, name)| name).collect();
         names.sort_by(|a, b| a.first_index.partial_cmp(&b.first_index).unwrap());
         names.into_iter().for_each(|d| self.names.push(d.name));
     }
@@ -244,7 +251,8 @@ impl Names {
     /// Remove all Name instances where display is whitespace
     ///
     pub fn empty(&mut self) {
-        self.names.retain(|name| name.display.trim() != String::from(""));
+        self.names
+            .retain(|name| name.display.trim() != String::from(""));
     }
 }
 
@@ -263,18 +271,17 @@ pub struct Name {
     pub tokenized: Vec<Tokenized>,
 
     /// Frequency of the given name
-    pub freq: i64
+    pub freq: i64,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum Source {
     Address,
     Network,
-    Generated
+    Generated,
 }
 
 impl Name {
-
     /// Returns a representation of a street name
     ///
     /// # Arguments
@@ -282,11 +289,13 @@ impl Name {
     /// * `display` - A string containing the street name (Main St)
     ///
     /// ```
-    pub fn new(display: impl ToString, mut priority: i8, source: Option<Source>, context: &Context) -> Self {
-        let mut display = display
-            .to_string()
-            .replace(r#"""#, "")
-            .replace(r#","#, ""); // commas are not allowed as they are used to delimit synonyms on output
+    pub fn new(
+        display: impl ToString,
+        mut priority: i8,
+        source: Option<Source>,
+        context: &Context,
+    ) -> Self {
+        let mut display = display.to_string().replace(r#"""#, "").replace(r#","#, ""); // commas are not allowed as they are used to delimit synonyms on output
 
         // only title case non-generated names
         if source != Some(Source::Generated) {
@@ -308,7 +317,7 @@ impl Name {
             priority: priority,
             source: source,
             tokenized: tokenized,
-            freq: 1
+            freq: 1,
         }
     }
 
@@ -342,10 +351,7 @@ impl Name {
     /// Tokenize the name object and return it as a string
     ///
     pub fn tokenized_string(&self) -> String {
-        let tokens: Vec<String> = self.tokenized
-            .iter()
-            .map(|x| x.token.to_owned())
-            .collect();
+        let tokens: Vec<String> = self.tokenized.iter().map(|x| x.token.to_owned()).collect();
 
         let tokenized = String::from(tokens.join(" ").trim());
 
@@ -360,7 +366,8 @@ impl Name {
     /// N Main St => Main
     ///
     pub fn tokenless_string(&self) -> String {
-        let tokens: Vec<String> = self.tokenized
+        let tokens: Vec<String> = self
+            .tokenized
             .iter()
             .filter(|x| x.token_type.is_none())
             .map(|x| x.token.to_owned())
@@ -375,7 +382,8 @@ impl Name {
     /// the remaining tokens as a String
     ///
     pub fn remove_type_string(&self, token_type: Option<TokenType>) -> String {
-        let tokens: Vec<String> = self.tokenized
+        let tokens: Vec<String> = self
+            .tokenized
             .iter()
             .filter(|x| x.token_type != token_type)
             .map(|x| x.token.to_string())
@@ -389,89 +397,120 @@ impl Name {
     /// contains the given token
     ///
     pub fn has_type(&self, token_type: Option<TokenType>) -> bool {
-        let tokens: Vec<&Tokenized> = self.tokenized
+        let tokens: Vec<&Tokenized> = self
+            .tokenized
             .iter()
             .filter(|x| x.token_type == token_type)
             .collect();
 
         tokens.len() > 0
     }
-
 }
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
     use super::*;
-    use std::collections::HashMap;
     use crate::Tokens;
+    use serde_json::json;
+    use std::collections::HashMap;
 
     #[test]
     fn test_name() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
-        assert_eq!(Name::new(String::from("main ST nw"), 0, None, &context), Name {
-            display: String::from("Main St NW"),
-            priority: 0,
-            source: None,
-            tokenized: vec![
-                Tokenized::new(String::from("main"), None),
-                Tokenized::new(String::from("st"), Some(TokenType::Way)),
-                Tokenized::new(String::from("nw"), None)],
-            freq: 1
-        });
+        assert_eq!(
+            Name::new(String::from("main ST nw"), 0, None, &context),
+            Name {
+                display: String::from("Main St NW"),
+                priority: 0,
+                source: None,
+                tokenized: vec![
+                    Tokenized::new(String::from("main"), None),
+                    Tokenized::new(String::from("st"), Some(TokenType::Way)),
+                    Tokenized::new(String::from("nw"), None)
+                ],
+                freq: 1
+            }
+        );
 
-        assert_eq!(Name::new(String::from("HiGHway #12 \" wEST"), 0, None, &context), Name {
-            display: String::from("Highway 12 West"),
-            priority: 0,
-            source: None,
-            tokenized: vec![
-                Tokenized::new(String::from("highway"), None),
-                Tokenized::new(String::from("12"), None),
-                Tokenized::new(String::from("west"), None)],
-            freq: 1
-        });
+        assert_eq!(
+            Name::new(String::from("HiGHway #12 \" wEST"), 0, None, &context),
+            Name {
+                display: String::from("Highway 12 West"),
+                priority: 0,
+                source: None,
+                tokenized: vec![
+                    Tokenized::new(String::from("highway"), None),
+                    Tokenized::new(String::from("12"), None),
+                    Tokenized::new(String::from("west"), None)
+                ],
+                freq: 1
+            }
+        );
 
-        assert_eq!(Name::new(String::from("\thighway #12 west ext 1\n"), -1, None, &context), Name {
-            display: String::from("Highway 12 West Ext 1"),
-            priority: -2,
-            source: None,
-            tokenized: vec![
-                Tokenized::new(String::from("highway"), None),
-                Tokenized::new(String::from("12"), None),
-                Tokenized::new(String::from("west"), None),
-                Tokenized::new(String::from("ext"), None),
-                Tokenized::new(String::from("1"), None)],
-            freq: 1
-        });
+        assert_eq!(
+            Name::new(
+                String::from("\thighway #12 west ext 1\n"),
+                -1,
+                None,
+                &context
+            ),
+            Name {
+                display: String::from("Highway 12 West Ext 1"),
+                priority: -2,
+                source: None,
+                tokenized: vec![
+                    Tokenized::new(String::from("highway"), None),
+                    Tokenized::new(String::from("12"), None),
+                    Tokenized::new(String::from("west"), None),
+                    Tokenized::new(String::from("ext"), None),
+                    Tokenized::new(String::from("1"), None)
+                ],
+                freq: 1
+            }
+        );
 
-        assert_eq!(Name::new(String::from("\""), 0, None, &context), Name {
-            display: String::from(""),
-            priority: 0,
-            source: None,
-            tokenized: vec![],
-            freq: 1
-        });
+        assert_eq!(
+            Name::new(String::from("\""), 0, None, &context),
+            Name {
+                display: String::from(""),
+                priority: 0,
+                source: None,
+                tokenized: vec![],
+                freq: 1
+            }
+        );
 
-        assert_eq!(Name::new(String::from(","), 0, None, &context), Name {
-            display: String::from(""),
-            priority: 0,
-            source: None,
-            tokenized: vec![],
-            freq: 1
-        });
+        assert_eq!(
+            Name::new(String::from(","), 0, None, &context),
+            Name {
+                display: String::from(""),
+                priority: 0,
+                source: None,
+                tokenized: vec![],
+                freq: 1
+            }
+        );
     }
 
     #[test]
     fn test_names_sort() {
-        let context = Context::new(String::from("us"), None, Tokens::generate(vec![String::from("en")]));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::generate(vec![String::from("en")]),
+        );
 
         let mut names = Names {
             names: vec![
                 Name::new(String::from("Highway 123"), -1, None, &context),
                 Name::new(String::from("Route 123"), 2, None, &context),
-                Name::new(String::from("Test 123"), 0, None, &context)
-            ]
+                Name::new(String::from("Test 123"), 0, None, &context),
+            ],
         };
 
         names.sort();
@@ -480,8 +519,8 @@ mod tests {
             names: vec![
                 Name::new(String::from("Route 123"), 2, None, &context),
                 Name::new(String::from("Test 123"), 0, None, &context),
-                Name::new(String::from("Highway 123"), -1, None, &context)
-            ]
+                Name::new(String::from("Highway 123"), -1, None, &context),
+            ],
         };
 
         assert_eq!(names, names_sorted);
@@ -492,8 +531,8 @@ mod tests {
                 Name::new(String::from("highway 3"), -1, None, &context),
                 Name::new(String::from("hwy 2"), -1, None, &context).set_freq(2),
                 Name::new(String::from("hwy 1"), -1, None, &context).set_freq(3),
-                Name::new(String::from("hwy 1"), 1, None, &context)
-            ]
+                Name::new(String::from("hwy 1"), 1, None, &context),
+            ],
         };
 
         names.sort();
@@ -505,28 +544,29 @@ mod tests {
                 Name::new(String::from("hwy 2"), -1, None, &context).set_freq(2),
                 Name::new(String::from("hwy 3"), -1, None, &context),
                 Name::new(String::from("highway 3"), -1, None, &context),
-            ]
+            ],
         };
 
         assert_eq!(names, names_sorted);
-
     }
 
     #[test]
     fn test_names_concat() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
         let mut names = Names {
             names: vec![
                 Name::new(String::from("Highway 123"), -1, None, &context),
-                Name::new(String::from("Highway 123"), -1, None, &context)
-            ]
+                Name::new(String::from("Highway 123"), -1, None, &context),
+            ],
         };
 
         let names2 = Names {
-            names: vec![
-                Name::new(String::from("Highway 123"), -1, None, &context)
-            ]
+            names: vec![Name::new(String::from("Highway 123"), -1, None, &context)],
         };
 
         names.concat(names2);
@@ -536,8 +576,8 @@ mod tests {
             names: vec![
                 Name::new(String::from("Highway 123"), -1, None, &context),
                 Name::new(String::from("Highway 123"), -1, None, &context),
-                Name::new(String::from("Highway 123"), -1, None, &context)
-            ]
+                Name::new(String::from("Highway 123"), -1, None, &context),
+            ],
         };
 
         assert_eq!(names, names_concat);
@@ -545,7 +585,11 @@ mod tests {
 
     #[test]
     fn test_names_dedupe() {
-        let context = Context::new(String::from("us"), None, Tokens::generate(vec![String::from("en")]));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::generate(vec![String::from("en")]),
+        );
 
         // deduping does not sort by priority and frequency-- must call .sort() first
         let mut names = Names {
@@ -555,95 +599,169 @@ mod tests {
                 Name::new(String::from("hwy 2"), -1, None, &context).set_freq(1),
                 Name::new(String::from("hwy 2"), -1, None, &context).set_freq(2),
                 Name::new(String::from("hwy 1"), -1, None, &context),
-                Name::new(String::from("hwy 1"), 1, None, &context)
-            ]
+                Name::new(String::from("hwy 1"), 1, None, &context),
+            ],
         };
         names.dedupe();
         let names_deduped = Names {
             names: vec![
                 Name::new(String::from("highway 3"), -1, None, &context).set_freq(1),
                 Name::new(String::from("hwy 2"), -1, None, &context).set_freq(1),
-                Name::new(String::from("hwy 1"), -1, None, &context)
-            ]
+                Name::new(String::from("hwy 1"), -1, None, &context),
+            ],
         };
         assert_eq!(names, names_deduped);
 
         // Will only overwrite with a longer name if it's not generated
         let mut names = Names {
             names: vec![
-                Name::new(String::from("E Main Street"), 0, Some(Source::Generated), &context),
+                Name::new(
+                    String::from("E Main Street"),
+                    0,
+                    Some(Source::Generated),
+                    &context,
+                ),
                 Name::new(String::from("East Main Street"), 0, None, &context),
-                Name::new(String::from("E Main St"), 0, None, &context)
-            ]
+                Name::new(String::from("E Main St"), 0, None, &context),
+            ],
         };
         names.dedupe();
         let names_deduped = Names {
-            names: vec![Name::new(String::from("E Main Street"), 0, Some(Source::Generated), &context)]
+            names: vec![Name::new(
+                String::from("E Main Street"),
+                0,
+                Some(Source::Generated),
+                &context,
+            )],
         };
         assert_eq!(names, names_deduped);
-
 
         // Will only overwrite with a longer name if it's not generated
         let mut names = Names {
             names: vec![
                 Name::new(String::from("East Main Street"), 0, None, &context),
                 Name::new(String::from("E Main St"), -1, None, &context),
-                Name::new(String::from("E Main Street"), -1, Some(Source::Generated), &context)
-            ]
+                Name::new(
+                    String::from("E Main Street"),
+                    -1,
+                    Some(Source::Generated),
+                    &context,
+                ),
+            ],
         };
         names.dedupe();
         let names_deduped = Names {
-            names: vec![Name::new(String::from("E Main Street"), 0, Some(Source::Generated), &context)]
+            names: vec![Name::new(
+                String::from("E Main Street"),
+                0,
+                Some(Source::Generated),
+                &context,
+            )],
         };
         assert_eq!(names, names_deduped);
     }
 
     #[test]
     fn test_names_from_value() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
-        let expected = Names::new(vec![Name::new(String::from("Main St NE"), 0, Some(Source::Network), &context)], &context);
+        let expected = Names::new(
+            vec![Name::new(
+                String::from("Main St NE"),
+                0,
+                Some(Source::Network),
+                &context,
+            )],
+            &context,
+        );
 
-        assert_eq!(Names::from_value(Some(json!("Main St NE")), Some(Source::Network), &context).unwrap(), expected);
+        assert_eq!(
+            Names::from_value(Some(json!("Main St NE")), Some(Source::Network), &context).unwrap(),
+            expected
+        );
 
-        assert_eq!(Names::from_value(Some(json!([{
-            "display": "Main St NE",
-            "priority": 0
-        }])), Some(Source::Network), &context).unwrap(), expected);
+        assert_eq!(
+            Names::from_value(
+                Some(json!([{
+                    "display": "Main St NE",
+                    "priority": 0
+                }])),
+                Some(Source::Network),
+                &context
+            )
+            .unwrap(),
+            expected
+        );
 
         // Address features can have multiple names with the same priority
         // Names from address features should have a priority of -1
-        let expected = Names::new(vec![Name::new(String::from("Main St NE"), -1, Some(Source::Address), &context)], &context);
+        let expected = Names::new(
+            vec![Name::new(
+                String::from("Main St NE"),
+                -1,
+                Some(Source::Address),
+                &context,
+            )],
+            &context,
+        );
 
-        assert_eq!(Names::from_value(Some(json!("Main St NE")), Some(Source::Address), &context).unwrap(), expected);
+        assert_eq!(
+            Names::from_value(Some(json!("Main St NE")), Some(Source::Address), &context).unwrap(),
+            expected
+        );
 
-        assert_eq!(Names::from_value(Some(json!([{
-            "display": "Main St NE",
-            "priority": 0
-        }, {
-            "display": "Main St NE",
-            "priority": 0
-        }])), Some(Source::Address), &context).unwrap(), expected);
+        assert_eq!(
+            Names::from_value(
+                Some(json!([{
+                    "display": "Main St NE",
+                    "priority": 0
+                }, {
+                    "display": "Main St NE",
+                    "priority": 0
+                }])),
+                Some(Source::Address),
+                &context
+            )
+            .unwrap(),
+            expected
+        );
     }
 
     #[test]
-    #[should_panic(expected = "1 network synonym must have greater priority: [InputName { display: \"Main St\", priority: -1 }, InputName { display: \"E Main St\", priority: -1 }]")]
+    #[should_panic(
+        expected = "1 network synonym must have greater priority: [InputName { display: \"Main St\", priority: -1 }, InputName { display: \"E Main St\", priority: -1 }]"
+    )]
     fn test_names_from_value_invalid_priority() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
-        let _names = Names::from_value(Some(json!([{
-            "display": "Main St",
-            "priority": -1
-        }, {
-            "display": "E Main St",
-            "priority": -1
-        }])), Some(Source::Network), &context);
+        let _names = Names::from_value(
+            Some(json!([{
+                "display": "Main St",
+                "priority": -1
+            }, {
+                "display": "E Main St",
+                "priority": -1
+            }])),
+            Some(Source::Network),
+            &context,
+        );
     }
-
 
     #[test]
     fn test_names_has_diff() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
         let a_name = Names::new(vec![Name::new("Main St", 0, None, &context)], &context);
         let b_name = Names::new(vec![Name::new("Main St", 0, None, &context)], &context);
@@ -653,222 +771,528 @@ mod tests {
         let b_name = Names::new(vec![Name::new("us route 1", 0, None, &context)], &context);
         assert_eq!(a_name.has_diff(&b_name), false);
 
-        let a_name = Names::new(vec![Name::new("highway 1", 0, None, &context), Name::new("US Route 1", 0, None, &context)], &context);
+        let a_name = Names::new(
+            vec![
+                Name::new("highway 1", 0, None, &context),
+                Name::new("US Route 1", 0, None, &context),
+            ],
+            &context,
+        );
         let b_name = Names::new(vec![Name::new("us route 1", 0, None, &context)], &context);
         assert_eq!(a_name.has_diff(&b_name), false);
 
         let a_name = Names::new(vec![Name::new("us route 1", 0, None, &context)], &context);
-        let b_name = Names::new(vec![Name::new("highway 1", 0, None, &context), Name::new("US Route 1", 0, None, &context)], &context);
+        let b_name = Names::new(
+            vec![
+                Name::new("highway 1", 0, None, &context),
+                Name::new("US Route 1", 0, None, &context),
+            ],
+            &context,
+        );
         assert_eq!(a_name.has_diff(&b_name), true);
 
-        let a_name = Names::new(vec![Name::new("us route 1", 0, None, &context), Name::new("Main St", 0, None, &context)], &context);
+        let a_name = Names::new(
+            vec![
+                Name::new("us route 1", 0, None, &context),
+                Name::new("Main St", 0, None, &context),
+            ],
+            &context,
+        );
         let b_name = Names::new(vec![Name::new("us route 1", 0, None, &context)], &context);
         assert_eq!(a_name.has_diff(&b_name), false);
     }
 
     #[test]
     fn test_names() {
-        let mut context = Context::new(String::from("us"), None, Tokens::generate(vec![String::from("en")]));
+        let mut context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::generate(vec![String::from("en")]),
+        );
 
-        assert_eq!(Names::new(vec![], &context), Names {
-            names: Vec::new()
-        });
+        assert_eq!(Names::new(vec![], &context), Names { names: Vec::new() });
 
-        assert_eq!(Names::new(vec![Name::new(String::from("Main St NW"), 0, None, &context)], &context), Names {
-            names: vec![Name::new(String::from("Main St NW"), 0, None, &context)]
-        });
+        assert_eq!(
+            Names::new(
+                vec![Name::new(String::from("Main St NW"), 0, None, &context)],
+                &context
+            ),
+            Names {
+                names: vec![Name::new(String::from("Main St NW"), 0, None, &context)]
+            }
+        );
 
         // Ensure invalid whitespace-only names are removed
-        assert_eq!(Names::new(vec![Name::new(String::from(""), 0, None, &context), Name::new(String::from("\t  \n"), 0, None, &context)], &context), Names {
-            names: Vec::new()
-        });
+        assert_eq!(
+            Names::new(
+                vec![
+                    Name::new(String::from(""), 0, None, &context),
+                    Name::new(String::from("\t  \n"), 0, None, &context)
+                ],
+                &context
+            ),
+            Names { names: Vec::new() }
+        );
 
         // Dedupe identical names
         assert_eq!(
             Names::new(
-                vec![Name::new(String::from("Main Street"), 0, None, &context),
-                    Name::new(String::from("Main Street"), 0, None, &context)],
-                    &context),
-            Names { names: vec![Name::new(String::from("Main Street"), 0, None, &context)]}
+                vec![
+                    Name::new(String::from("Main Street"), 0, None, &context),
+                    Name::new(String::from("Main Street"), 0, None, &context)
+                ],
+                &context
+            ),
+            Names {
+                names: vec![Name::new(String::from("Main Street"), 0, None, &context)]
+            }
         );
 
         // Dedupe names with the same tokenized name and priority, preference longer display name
         assert_eq!(
             Names::new(
-                vec![Name::new(String::from("Main St"), 0, None, &context),
+                vec![
+                    Name::new(String::from("Main St"), 0, None, &context),
                     Name::new(String::from("Main Street"), 0, None, &context),
                     Name::new(String::from("E Main St"), 0, None, &context),
-                    Name::new(String::from("East Main Street"), 0, None, &context)],
-                    &context),
+                    Name::new(String::from("East Main Street"), 0, None, &context)
+                ],
+                &context
+            ),
             Names {
                 names: vec![
                     Name::new(String::from("Main Street"), 0, None, &context),
                     Name::new(String::from("East Main Street"), 0, None, &context)
-                ]}
+                ]
+            }
         );
 
         // Dedupe names with the same tokenized name but different priorities, preference longer display name
         assert_eq!(
             Names::new(
-                vec![Name::new(String::from("Main St"), 1, None, &context),
+                vec![
+                    Name::new(String::from("Main St"), 1, None, &context),
                     Name::new(String::from("Main Street"), 0, None, &context),
                     Name::new(String::from("E Main St"), 1, None, &context),
-                    Name::new(String::from("East Main Street"), 0, None, &context)],
-                    &context),
+                    Name::new(String::from("East Main Street"), 0, None, &context)
+                ],
+                &context
+            ),
             Names {
                 names: vec![
                     Name::new(String::from("Main Street"), 1, None, &context),
                     Name::new(String::from("East Main Street"), 1, None, &context)
-                ]}
+                ]
+            }
         );
 
         // Ensure synonyms are being applied correctly
-        assert_eq!(Names::new(vec![Name::new(String::from("US Route 1"), 0, Some(Source::Network), &context)], &context), Names {
-            names: vec![
-                Name::new(String::from("US Route 1"), 1, Some(Source::Generated), &context),
-                Name::new(String::from("US 1"), -1, Some(Source::Generated), &context),
-                Name::new(String::from("US Highway 1"), -1, Some(Source::Generated), &context),
-                Name::new(String::from("United States Route 1"), -1, Some(Source::Generated), &context),
-                Name::new(String::from("United States Highway 1"), -1, Some(Source::Generated), &context)
-            ]
-        });
+        assert_eq!(
+            Names::new(
+                vec![Name::new(
+                    String::from("US Route 1"),
+                    0,
+                    Some(Source::Network),
+                    &context
+                )],
+                &context
+            ),
+            Names {
+                names: vec![
+                    Name::new(
+                        String::from("US Route 1"),
+                        1,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new(String::from("US 1"), -1, Some(Source::Generated), &context),
+                    Name::new(
+                        String::from("US Highway 1"),
+                        -1,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new(
+                        String::from("United States Route 1"),
+                        -1,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new(
+                        String::from("United States Highway 1"),
+                        -1,
+                        Some(Source::Generated),
+                        &context
+                    )
+                ]
+            }
+        );
 
         // Ensure highway synonyms are being applied correctly but are downgraded
         // if the highway is not the highest priority name
-        assert_eq!(Names::new(vec![
-            Name::new(String::from("Main St"), 0, Some(Source::Network), &context),
-            Name::new(String::from("US Route 1"), -1, Some(Source::Network), &context)
-        ], &context), Names {
-            names: vec![
-                Name::new(String::from("Main St"), 0, Some(Source::Network), &context),
-                Name::new(String::from("US Route 1"), -1, Some(Source::Generated), &context),
-                Name::new(String::from("US 1"), -2, Some(Source::Generated), &context),
-                Name::new(String::from("US Highway 1"), -2, Some(Source::Generated), &context),
-                Name::new(String::from("United States Route 1"), -2, Some(Source::Generated), &context),
-                Name::new(String::from("United States Highway 1"), -2, Some(Source::Generated), &context)
-            ]
-        });
+        assert_eq!(
+            Names::new(
+                vec![
+                    Name::new(String::from("Main St"), 0, Some(Source::Network), &context),
+                    Name::new(
+                        String::from("US Route 1"),
+                        -1,
+                        Some(Source::Network),
+                        &context
+                    )
+                ],
+                &context
+            ),
+            Names {
+                names: vec![
+                    Name::new(String::from("Main St"), 0, Some(Source::Network), &context),
+                    Name::new(
+                        String::from("US Route 1"),
+                        -1,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new(String::from("US 1"), -2, Some(Source::Generated), &context),
+                    Name::new(
+                        String::from("US Highway 1"),
+                        -2,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new(
+                        String::from("United States Route 1"),
+                        -2,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new(
+                        String::from("United States Highway 1"),
+                        -2,
+                        Some(Source::Generated),
+                        &context
+                    )
+                ]
+            }
+        );
 
         // Don't preference generated highway synonyms over local names if there are addresses
         // that match the lower priority network name in the cluster
-        assert_eq!(Names::new(vec![
-            Name::new(String::from("US Highway 1"), -1, Some(Source::Address), &context),
-            Name::new(String::from("Main Street"), -1, Some(Source::Address), &context),
-            Name::new(String::from("US Highway 1"), -1, Some(Source::Network), &context),
-            Name::new(String::from("Main St"), 0, Some(Source::Network), &context)
-        ], &context), Names {
-            names: vec![
-                Name::new(String::from("Main Street"), 0, Some(Source::Address), &context),
-                Name::new(String::from("US Highway 1"), -1, Some(Source::Generated), &context),
-                Name::new(String::from("US Route 1"), -1, Some(Source::Generated), &context),
-                Name::new(String::from("US 1"), -2, Some(Source::Generated), &context),
-                Name::new(String::from("United States Route 1"), -2, Some(Source::Generated), &context),
-                Name::new(String::from("United States Highway 1"), -2, Some(Source::Generated), &context)
-            ]
-        });
+        assert_eq!(
+            Names::new(
+                vec![
+                    Name::new(
+                        String::from("US Highway 1"),
+                        -1,
+                        Some(Source::Address),
+                        &context
+                    ),
+                    Name::new(
+                        String::from("Main Street"),
+                        -1,
+                        Some(Source::Address),
+                        &context
+                    ),
+                    Name::new(
+                        String::from("US Highway 1"),
+                        -1,
+                        Some(Source::Network),
+                        &context
+                    ),
+                    Name::new(String::from("Main St"), 0, Some(Source::Network), &context)
+                ],
+                &context
+            ),
+            Names {
+                names: vec![
+                    Name::new(
+                        String::from("Main Street"),
+                        0,
+                        Some(Source::Address),
+                        &context
+                    ),
+                    Name::new(
+                        String::from("US Highway 1"),
+                        -1,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new(
+                        String::from("US Route 1"),
+                        -1,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new(String::from("US 1"), -2, Some(Source::Generated), &context),
+                    Name::new(
+                        String::from("United States Route 1"),
+                        -2,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new(
+                        String::from("United States Highway 1"),
+                        -2,
+                        Some(Source::Generated),
+                        &context
+                    )
+                ]
+            }
+        );
 
         // @TODO remove, real world test case
-        context = Context::new(String::from("us"), None, Tokens::generate(vec![String::from("en")]));
+        context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::generate(vec![String::from("en")]),
+        );
 
-        assert_eq!(Names::new(vec![
-            Name::new("NE M L King Blvd", -1, Some(Source::Address), &context).set_freq(1480),
-            Name::new("NE MARTIN LUTHER KING JR BLVD", -1, Some(Source::Address), &context).set_freq(110),
-            Name::new("NE M L KING BLVD", -1, Some(Source::Address), &context).set_freq(18),
-            Name::new("SE M L King Blvd", -1, Some(Source::Address), &context).set_freq(7),
-            Name::new("N M L King Blvd", -1, Some(Source::Address), &context).set_freq(3),
-            Name::new("SE MARTIN LUTHER KING JR BLVD", -1, Some(Source::Address), &context).set_freq(2),
-            Name::new("Northeast Martin Luther King Junior Boulevard", 0, Some(Source::Network), &context).set_freq(1),
-            Name::new("NE MLK", -1, Some(Source::Network), &context).set_freq(1),
-            Name::new("OR 99E", -1, Some(Source::Network), &context).set_freq(1),
-            Name::new("State Highway 99E", -1, Some(Source::Network), &context).set_freq(1)
-        ], &context), Names {
-            names: vec![
-                Name::new("Northeast Martin Luther King Jr Boulevard", 1, Some(Source::Generated), &context),
-                Name::new("NE M L King Blvd", -1, Some(Source::Address), &context).set_freq(1480),
-                Name::new("SE M L King Blvd", -1, Some(Source::Address), &context).set_freq(7),
-                Name::new("N M L King Blvd", -1, Some(Source::Address), &context).set_freq(3),
-                Name::new("SE Martin Luther King Jr Blvd", -1, Some(Source::Address), &context).set_freq(2),
-                Name::new("NE MLK", -1, Some(Source::Generated), &context),
-                Name::new("Or 99e", -1, Some(Source::Network), &context),
-                Name::new("State Highway 99e", -1, Some(Source::Network), &context),
-                Name::new("Northeast MLK Boulevard", -1, Some(Source::Generated), &context),
-                Name::new("Northeast M L K Boulevard", -1, Some(Source::Generated), &context),
-                Name::new("Northeast Martin Luther King Boulevard", -1, Some(Source::Generated), &context),
-                Name::new("Northeast MLK Jr Boulevard", -1, Some(Source::Generated), &context),
-                Name::new("Northeast M L K Jr Boulevard", -1, Some(Source::Generated), &context),
-                Name::new("NE Martin Luther King Jr", -1, Some(Source::Generated), &context),
-                Name::new("NE M L K", -2, Some(Source::Generated), &context),
-                Name::new("NE Martin Luther King", -2, Some(Source::Generated), &context),
-                Name::new("NE MLK Jr", -2, Some(Source::Generated), &context),
-                Name::new("NE M L K Jr", -2, Some(Source::Generated), &context)
-            ]
-        });
+        assert_eq!(
+            Names::new(
+                vec![
+                    Name::new("NE M L King Blvd", -1, Some(Source::Address), &context)
+                        .set_freq(1480),
+                    Name::new(
+                        "NE MARTIN LUTHER KING JR BLVD",
+                        -1,
+                        Some(Source::Address),
+                        &context
+                    )
+                    .set_freq(110),
+                    Name::new("NE M L KING BLVD", -1, Some(Source::Address), &context).set_freq(18),
+                    Name::new("SE M L King Blvd", -1, Some(Source::Address), &context).set_freq(7),
+                    Name::new("N M L King Blvd", -1, Some(Source::Address), &context).set_freq(3),
+                    Name::new(
+                        "SE MARTIN LUTHER KING JR BLVD",
+                        -1,
+                        Some(Source::Address),
+                        &context
+                    )
+                    .set_freq(2),
+                    Name::new(
+                        "Northeast Martin Luther King Junior Boulevard",
+                        0,
+                        Some(Source::Network),
+                        &context
+                    )
+                    .set_freq(1),
+                    Name::new("NE MLK", -1, Some(Source::Network), &context).set_freq(1),
+                    Name::new("OR 99E", -1, Some(Source::Network), &context).set_freq(1),
+                    Name::new("State Highway 99E", -1, Some(Source::Network), &context).set_freq(1)
+                ],
+                &context
+            ),
+            Names {
+                names: vec![
+                    Name::new(
+                        "Northeast Martin Luther King Jr Boulevard",
+                        1,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new("NE M L King Blvd", -1, Some(Source::Address), &context)
+                        .set_freq(1480),
+                    Name::new("SE M L King Blvd", -1, Some(Source::Address), &context).set_freq(7),
+                    Name::new("N M L King Blvd", -1, Some(Source::Address), &context).set_freq(3),
+                    Name::new(
+                        "SE Martin Luther King Jr Blvd",
+                        -1,
+                        Some(Source::Address),
+                        &context
+                    )
+                    .set_freq(2),
+                    Name::new("NE MLK", -1, Some(Source::Generated), &context),
+                    Name::new("Or 99e", -1, Some(Source::Network), &context),
+                    Name::new("State Highway 99e", -1, Some(Source::Network), &context),
+                    Name::new(
+                        "Northeast MLK Boulevard",
+                        -1,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new(
+                        "Northeast M L K Boulevard",
+                        -1,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new(
+                        "Northeast Martin Luther King Boulevard",
+                        -1,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new(
+                        "Northeast MLK Jr Boulevard",
+                        -1,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new(
+                        "Northeast M L K Jr Boulevard",
+                        -1,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new(
+                        "NE Martin Luther King Jr",
+                        -1,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new("NE M L K", -2, Some(Source::Generated), &context),
+                    Name::new(
+                        "NE Martin Luther King",
+                        -2,
+                        Some(Source::Generated),
+                        &context
+                    ),
+                    Name::new("NE MLK Jr", -2, Some(Source::Generated), &context),
+                    Name::new("NE M L K Jr", -2, Some(Source::Generated), &context)
+                ]
+            }
+        );
     }
 
     #[test]
     fn test_tokenized_string() {
-        let context = Context::new(String::from("us"), None, Tokens::generate(vec![String::from("en")]));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::generate(vec![String::from("en")]),
+        );
 
-        assert_eq!(Name::new(String::from("Main St NW"), 0, None, &context).tokenized_string(),
+        assert_eq!(
+            Name::new(String::from("Main St NW"), 0, None, &context).tokenized_string(),
             String::from("main st nw")
         );
-        assert_eq!(Name::new(String::from("Main Street Northwest"), 0, None, &context).tokenized_string(),
+        assert_eq!(
+            Name::new(String::from("Main Street Northwest"), 0, None, &context).tokenized_string(),
             String::from("main st nw")
         );
     }
 
     #[test]
     fn test_tokenless_string() {
-        let context = Context::new(String::from("us"), None, Tokens::generate(vec![String::from("en")]));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::generate(vec![String::from("en")]),
+        );
 
-        assert_eq!(Name::new(String::from("Main St NW"), 0, None, &context).tokenless_string(),
+        assert_eq!(
+            Name::new(String::from("Main St NW"), 0, None, &context).tokenless_string(),
             String::from("main")
         );
-        assert_eq!(Name::new(String::from("Main Street Northwest"), 0, None, &context).tokenless_string(),
+        assert_eq!(
+            Name::new(String::from("Main Street Northwest"), 0, None, &context).tokenless_string(),
             String::from("main")
         );
-        assert_eq!(Name::new(String::from("East College Road"), 0, None, &context).tokenless_string(),
+        assert_eq!(
+            Name::new(String::from("East College Road"), 0, None, &context).tokenless_string(),
             String::from("coll")
         );
     }
 
     #[test]
     fn test_remove_type_string() {
-        let context = Context::new(String::from("us"), None, Tokens::generate(vec![String::from("en")]));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::generate(vec![String::from("en")]),
+        );
 
-        assert_eq!(Name::new(String::from("Main St NW"), 0, None, &context).remove_type_string(Some(TokenType::Way)), String::from("main nw"));
-        assert_eq!(Name::new(String::from("Main St NW"), 0, None, &context).remove_type_string(Some(TokenType::Cardinal)), String::from("main st"));
-        assert_eq!(Name::new(String::from("Main St NW"), 0, None, &context).remove_type_string(None), String::from("st nw"));
-        assert_eq!(Name::new(String::from("Main St NW"), 0, None, &context).remove_type_string(Some(TokenType::PostalBox)), String::from("main st nw"));
+        assert_eq!(
+            Name::new(String::from("Main St NW"), 0, None, &context)
+                .remove_type_string(Some(TokenType::Way)),
+            String::from("main nw")
+        );
+        assert_eq!(
+            Name::new(String::from("Main St NW"), 0, None, &context)
+                .remove_type_string(Some(TokenType::Cardinal)),
+            String::from("main st")
+        );
+        assert_eq!(
+            Name::new(String::from("Main St NW"), 0, None, &context).remove_type_string(None),
+            String::from("st nw")
+        );
+        assert_eq!(
+            Name::new(String::from("Main St NW"), 0, None, &context)
+                .remove_type_string(Some(TokenType::PostalBox)),
+            String::from("main st nw")
+        );
     }
 
     #[test]
     fn test_has_type() {
-        let context = Context::new(String::from("us"), None, Tokens::generate(vec![String::from("en")]));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::generate(vec![String::from("en")]),
+        );
 
-        assert_eq!(Name::new(String::from("Main St NW"), 0, None, &context).has_type(Some(TokenType::Way)), true);
-        assert_eq!(Name::new(String::from("Main St NW"), 0, None, &context).has_type(Some(TokenType::Cardinal)), true);
-        assert_eq!(Name::new(String::from("Main St NW"), 0, None, &context).has_type(None), true);
-        assert_eq!(Name::new(String::from("Main St NW"), 0, None, &context).has_type(Some(TokenType::PostalBox)), false);
+        assert_eq!(
+            Name::new(String::from("Main St NW"), 0, None, &context).has_type(Some(TokenType::Way)),
+            true
+        );
+        assert_eq!(
+            Name::new(String::from("Main St NW"), 0, None, &context)
+                .has_type(Some(TokenType::Cardinal)),
+            true
+        );
+        assert_eq!(
+            Name::new(String::from("Main St NW"), 0, None, &context).has_type(None),
+            true
+        );
+        assert_eq!(
+            Name::new(String::from("Main St NW"), 0, None, &context)
+                .has_type(Some(TokenType::PostalBox)),
+            false
+        );
 
-        assert_eq!(Name::new(String::from("foo bar"), 0, None, &context).has_type(Some(TokenType::Way)), false);
-        assert_eq!(Name::new(String::from("foo bar"), 0, None, &context).has_type(Some(TokenType::Cardinal)), false);
-        assert_eq!(Name::new(String::from("foo bar"), 0, None, &context).has_type(None), true);
+        assert_eq!(
+            Name::new(String::from("foo bar"), 0, None, &context).has_type(Some(TokenType::Way)),
+            false
+        );
+        assert_eq!(
+            Name::new(String::from("foo bar"), 0, None, &context)
+                .has_type(Some(TokenType::Cardinal)),
+            false
+        );
+        assert_eq!(
+            Name::new(String::from("foo bar"), 0, None, &context).has_type(None),
+            true
+        );
     }
 
     #[test]
     fn test_empty() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
-        let mut empty_a = Names::new(vec![Name::new(String::from(""), 0, None, &context)], &context);
+        let mut empty_a = Names::new(
+            vec![Name::new(String::from(""), 0, None, &context)],
+            &context,
+        );
         empty_a.empty();
         assert_eq!(empty_a, Names { names: Vec::new() });
 
-        let mut empty_b = Names::new(vec![Name::new(String::from("\t  \n"), 0, None, &context)], &context);
+        let mut empty_b = Names::new(
+            vec![Name::new(String::from("\t  \n"), 0, None, &context)],
+            &context,
+        );
         empty_b.empty();
         assert_eq!(empty_b, Names { names: Vec::new() });
 
-        let mut empty_c = Names::new(vec![Name::new(String::from(""), 0, None, &context), Name::new(String::from("\t  \n"), 0, None, &context)], &context);
+        let mut empty_c = Names::new(
+            vec![
+                Name::new(String::from(""), 0, None, &context),
+                Name::new(String::from("\t  \n"), 0, None, &context),
+            ],
+            &context,
+        );
         empty_c.empty();
         assert_eq!(empty_c, Names { names: Vec::new() });
     }

--- a/native/src/types/network.rs
+++ b/native/src/types/network.rs
@@ -1,5 +1,5 @@
+use crate::{text, Context, Names, Source};
 use postgis::ewkb::EwkbWrite;
-use crate::{Context, text, Names, Source};
 
 #[derive(Debug)]
 ///
@@ -19,19 +19,23 @@ pub struct Network {
     pub props: serde_json::Map<String, serde_json::Value>,
 
     /// Simple representation of MultiLineString
-    pub geom: Vec<geojson::LineStringType>
+    pub geom: Vec<geojson::LineStringType>,
 }
 
 impl Network {
     pub fn new(feat: geojson::GeoJson, context: &Context) -> Result<Self, String> {
         let feat = match feat {
             geojson::GeoJson::Feature(feat) => feat,
-            _ => { return Err(String::from("Not a GeoJSON Feature")); }
+            _ => {
+                return Err(String::from("Not a GeoJSON Feature"));
+            }
         };
 
         let mut props = match feat.properties {
             Some(props) => props,
-            None => { return Err(String::from("Feature has no properties")); }
+            None => {
+                return Err(String::from("Feature has no properties"));
+            }
         };
 
         let source = match props.get(&String::from("source")) {
@@ -42,27 +46,30 @@ impl Network {
                 } else {
                     String::from("")
                 }
-            },
-            None => String::from("")
+            }
+            None => String::from(""),
         };
 
         let geom = match feat.geometry {
             Some(geom) => match geom.value {
                 geojson::Value::LineString(ln) => vec![ln],
                 geojson::Value::MultiLineString(mln) => mln,
-                _ => { return Err(String::from("Network must have (Multi)LineString geometry")); }
+                _ => {
+                    return Err(String::from("Network must have (Multi)LineString geometry"));
+                }
             },
-            None => { return Err(String::from("Network must have geometry")); }
+            None => {
+                return Err(String::from("Network must have geometry"));
+            }
         };
-
 
         let street = match props.remove(&String::from("street")) {
             Some(street) => {
                 props.insert(String::from("street"), street.clone());
 
                 Some(street)
-            },
-            None => None
+            }
+            None => None,
         };
 
         let names = Names::from_value(street, Some(Source::Network), &context)?;
@@ -74,12 +81,12 @@ impl Network {
         let mut net = Network {
             id: match feat.id {
                 Some(geojson::feature::Id::Number(id)) => id.as_i64(),
-                _ => None
+                _ => None,
             },
             names: names,
             source: source,
             props: props,
-            geom: geom
+            geom: geom,
         };
 
         net.std(&context)?;
@@ -104,19 +111,17 @@ impl Network {
     pub fn to_tsv(self) -> String {
         let mut twkb = postgis::twkb::MultiLineString {
             lines: Vec::with_capacity(self.geom.len()),
-            ids: None
+            ids: None,
         };
 
         for ln in self.geom {
             let mut line = postgis::twkb::LineString {
-                points: Vec::with_capacity(ln.len())
+                points: Vec::with_capacity(ln.len()),
             };
 
             for pt in ln {
-                line.points.push(postgis::twkb::Point {
-                    x: pt[0],
-                    y: pt[1]
-                });
+                line.points
+                    .push(postgis::twkb::Point { x: pt[0], y: pt[1] });
             }
 
             twkb.lines.push(line);
@@ -125,10 +130,12 @@ impl Network {
         let geom = postgis::ewkb::EwkbMultiLineString {
             geom: &twkb,
             srid: Some(4326),
-            point_type: postgis::ewkb::PointType::Point
-        }.to_hex_ewkb();
+            point_type: postgis::ewkb::PointType::Point,
+        }
+        .to_hex_ewkb();
 
-        format!("{names}\t{source}\t{props}\t{geom}\n",
+        format!(
+            "{names}\t{source}\t{props}\t{geom}\n",
             names = serde_json::to_string(&self.names.names).unwrap_or(String::from("")),
             source = self.source,
             props = serde_json::value::Value::from(self.props),
@@ -140,12 +147,13 @@ impl Network {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Tokens, Context};
+    use crate::{Context, Tokens};
     use std::collections::HashMap;
 
     #[test]
     fn test_network_simple_geom() {
-        let feat: geojson::GeoJson = String::from(r#"{
+        let feat: geojson::GeoJson = String::from(
+            r#"{
             "type":"Feature",
             "properties":{
                 "id":6052094,
@@ -154,12 +162,15 @@ mod tests {
                 "type":"LineString",
                 "coordinates":[[-77.008941,38.859243],[-77.008447,38.859],[-77.0081173,38.8588497]]
             }
-        }"#).parse().unwrap();
+        }"#,
+        )
+        .parse()
+        .unwrap();
 
         let context = Context::new(
             String::from("us"),
             Some(String::from("dc")),
-            Tokens::new(HashMap::new(), HashMap::new())
+            Tokens::new(HashMap::new(), HashMap::new()),
         );
 
         let net = Network::new(feat, &context).unwrap();
@@ -168,9 +179,15 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "1 network synonym must have greater priority: [InputName { display: \"Main St\", priority: -1 }, InputName { display: \"E Main St\", priority: -1 }]")]
+    #[should_panic(
+        expected = "1 network synonym must have greater priority: [InputName { display: \"Main St\", priority: -1 }, InputName { display: \"E Main St\", priority: -1 }]"
+    )]
     fn test_network_invalid_priority() {
-        let context = Context::new(String::from("us"), None, Tokens::new(HashMap::new(), HashMap::new()));
+        let context = Context::new(
+            String::from("us"),
+            None,
+            Tokens::new(HashMap::new(), HashMap::new()),
+        );
 
         let feat: geojson::GeoJson = String::from(r#"{
             "type": "Feature",

--- a/native/src/types/polygon.rs
+++ b/native/src/types/polygon.rs
@@ -12,37 +12,45 @@ pub struct Polygon {
     pub props: serde_json::Map<String, serde_json::Value>,
 
     /// Simple representation of Lng/Lat geometry
-    pub geom: Vec<geojson::PolygonType>
+    pub geom: Vec<geojson::PolygonType>,
 }
 
 impl Polygon {
     pub fn new(feat: geojson::GeoJson) -> Result<Self, String> {
         let feat = match feat {
             geojson::GeoJson::Feature(feat) => feat,
-            _ => { return Err(String::from("Not a GeoJSON Feature")); }
+            _ => {
+                return Err(String::from("Not a GeoJSON Feature"));
+            }
         };
 
         let props = match feat.properties {
             Some(props) => props,
-            None => { return Err(String::from("Feature has no properties")); }
+            None => {
+                return Err(String::from("Feature has no properties"));
+            }
         };
 
         let geom = match feat.geometry {
             Some(geom) => match geom.value {
                 geojson::Value::Polygon(py) => vec![py],
                 geojson::Value::MultiPolygon(mpy) => mpy,
-                _ => { return Err(String::from("Polygon must have (Multi)Polygon geometry")); }
+                _ => {
+                    return Err(String::from("Polygon must have (Multi)Polygon geometry"));
+                }
             },
-            None => { return Err(String::from("Polygon must have geometry")); }
+            None => {
+                return Err(String::from("Polygon must have geometry"));
+            }
         };
 
         Ok(Polygon {
             id: match feat.id {
                 Some(geojson::feature::Id::Number(id)) => id.as_i64(),
-                _ => None
+                _ => None,
             },
             props: props,
-            geom: geom
+            geom: geom,
         })
     }
 
@@ -53,24 +61,22 @@ impl Polygon {
     pub fn to_tsv(self) -> String {
         let mut twkb = postgis::twkb::MultiPolygon {
             polygons: Vec::with_capacity(self.geom.len()),
-            ids: None
+            ids: None,
         };
 
         for py in self.geom {
             let mut poly = postgis::twkb::Polygon {
-                rings: Vec::with_capacity(py.len())
+                rings: Vec::with_capacity(py.len()),
             };
 
             for py_ring in py {
                 let mut ring = postgis::twkb::LineString {
-                    points: Vec::with_capacity(py_ring.len())
+                    points: Vec::with_capacity(py_ring.len()),
                 };
 
                 for pt in py_ring {
-                    ring.points.push(postgis::twkb::Point {
-                        x: pt[0],
-                        y: pt[1],
-                    });
+                    ring.points
+                        .push(postgis::twkb::Point { x: pt[0], y: pt[1] });
                 }
 
                 poly.rings.push(ring);
@@ -82,10 +88,12 @@ impl Polygon {
         let geom = postgis::ewkb::EwkbMultiPolygon {
             geom: &twkb,
             srid: Some(4326),
-            point_type: postgis::ewkb::PointType::Point
-        }.to_hex_ewkb();
+            point_type: postgis::ewkb::PointType::Point,
+        }
+        .to_hex_ewkb();
 
-        format!("{props}\t{geom}\n",
+        format!(
+            "{props}\t{geom}\n",
             props = serde_json::value::Value::from(self.props),
             geom = geom
         )

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -1,8 +1,4 @@
-use crate::text::{
-    distance,
-    is_numbered,
-    is_routish
-};
+use crate::text::{distance, is_numbered, is_routish};
 
 use crate::types::Names;
 use geocoder_abbreviations::TokenType;
@@ -11,7 +7,7 @@ use geocoder_abbreviations::TokenType;
 pub struct Link<'a> {
     pub id: i64,
     pub maxscore: f64,
-    pub names: &'a Names
+    pub names: &'a Names,
 }
 
 impl<'a> Link<'a> {
@@ -19,7 +15,7 @@ impl<'a> Link<'a> {
         Link {
             id: id,
             maxscore: 0.0,
-            names: names
+            names: names,
         }
     }
 }
@@ -27,14 +23,14 @@ impl<'a> Link<'a> {
 #[derive(Debug, PartialEq)]
 pub struct LinkResult {
     pub id: i64,
-    pub score: f64
+    pub score: f64,
 }
 
 impl LinkResult {
     pub fn new(id: i64, score: f64) -> Self {
         LinkResult {
             id: id,
-            score: score
+            score: score,
         }
     }
 }
@@ -84,25 +80,27 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                     for tk in &name.tokenized {
                         match tk.token_type {
                             Some(TokenType::Cardinal) => {
-                                if potential_name.has_type(Some(TokenType::Cardinal)) && !potential_name.tokenized.contains(tk) {
+                                if potential_name.has_type(Some(TokenType::Cardinal))
+                                    && !potential_name.tokenized.contains(tk)
+                                {
                                     continue 'outer;
                                 }
-                            },
+                            }
                             Some(TokenType::Way) => {
-                                if potential_name.has_type(Some(TokenType::Way)) && !potential_name.tokenized.contains(tk) {
+                                if potential_name.has_type(Some(TokenType::Way))
+                                    && !potential_name.tokenized.contains(tk)
+                                {
                                     continue 'outer;
                                 }
-                            },
-                            _ => ()
+                            }
+                            _ => (),
                         }
                     }
                 } else {
-
                     // A cardinaled primary can exactly match a non-cardinaled potential
                     //
                     // N Main St => Main St
-                    if
-                        name.has_type(Some(TokenType::Cardinal))
+                    if name.has_type(Some(TokenType::Cardinal))
                         && !potential_name.has_type(Some(TokenType::Cardinal))
                         && name.remove_type_string(Some(TokenType::Cardinal)) == potential_tokenized
                     {
@@ -113,7 +111,10 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                 // Don't bother considering if the tokenless forms don't share a starting letter
                 // this might require adjustment for countries with addresses that have leading tokens
                 // which aren't properly stripped from the token list
-                if potential_tokenless.len() > 0 && tokenless.len() > 0 && potential_tokenless.get(0..1) != tokenless.get(0..1) {
+                if potential_tokenless.len() > 0
+                    && tokenless.len() > 0
+                    && potential_tokenless.get(0..1) != tokenless.get(0..1)
+                {
                     continue;
                 }
 
@@ -121,8 +122,7 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                 // doesn't match (1st != 11th)
                 let name_numbered = is_numbered(name);
                 let name_routish = is_routish(name);
-                if
-                    (name_numbered.is_some() && name_numbered != is_numbered(potential_name))
+                if (name_numbered.is_some() && name_numbered != is_numbered(potential_name))
                     || (name_routish.is_some() && name_routish != is_routish(potential_name))
                 {
                     continue;
@@ -132,17 +132,20 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                 let mut lev_score: Option<f64> = None;
 
                 if tokenless.len() > 0 && potential_tokenless.len() > 0 {
-                    lev_score = Some((0.25 * distance(&tokenized, &potential_tokenized) as f64) + (0.75 * distance(&tokenless, &potential_tokenless) as f64));
-                } else if (tokenless.len() > 0 && potential_tokenless.len() == 0) || (tokenless.len() == 0 && potential_tokenless.len() > 0) {
+                    lev_score = Some(
+                        (0.25 * distance(&tokenized, &potential_tokenized) as f64)
+                            + (0.75 * distance(&tokenless, &potential_tokenless) as f64),
+                    );
+                } else if (tokenless.len() > 0 && potential_tokenless.len() == 0)
+                    || (tokenless.len() == 0 && potential_tokenless.len() > 0)
+                {
                     lev_score = Some(distance(&tokenized, &potential_tokenized) as f64);
                 } else {
+                    let atoks: Vec<String> =
+                        name.tokenized.iter().map(|x| x.token.to_owned()).collect();
 
-                    let atoks: Vec<String> = name.tokenized
-                        .iter()
-                        .map(|x| x.token.to_owned())
-                        .collect();
-
-                    let mut ntoks: Vec<String> = potential_name.tokenized
+                    let mut ntoks: Vec<String> = potential_name
+                        .tokenized
                         .iter()
                         .map(|x| x.token.to_owned())
                         .collect();
@@ -150,7 +153,6 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                     let ntoks_len = ntoks.len() as f64;
 
                     let mut a_match = 0;
-
 
                     for atok in &atoks {
                         // If there are dup tokens ensure they match a unique token ie Saint Street => st st != main st
@@ -160,8 +162,8 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                             Some(index) => {
                                 ntoks.remove(*index);
                                 a_match = a_match + 1;
-                            },
-                            None => ()
+                            }
+                            None => (),
                         };
                     }
 
@@ -174,7 +176,10 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                     }
                 }
 
-                let score = 100.0 - (((2.0 * lev_score.unwrap()) / (potential_tokenized.len() as f64 + tokenized.len() as f64)) * 100.0);
+                let score = 100.0
+                    - (((2.0 * lev_score.unwrap())
+                        / (potential_tokenized.len() as f64 + tokenized.len() as f64))
+                        * 100.0);
 
                 if score > potential.maxscore {
                     potential.maxscore = score;
@@ -189,7 +194,7 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
         match max {
             None => {
                 max = Some(potential);
-            },
+            }
             Some(current_max) => {
                 if potential.maxscore > current_max.maxscore {
                     max = Some(potential);
@@ -201,23 +206,26 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
     match max {
         Some(max) => {
             if max.maxscore > 70.0 {
-                Some(LinkResult::new(max.id, (max.maxscore * 100.0).round() / 100.0))
+                Some(LinkResult::new(
+                    max.id,
+                    (max.maxscore * 100.0).round() / 100.0,
+                ))
             } else {
                 None
             }
-        },
-        None => None
+        }
+        None => None,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
-    use crate::{Context, Tokens, Name, Names};
     use crate::text::ParsedToken;
+    use crate::{Context, Name, Names, Tokens};
     use geocoder_abbreviations::TokenType;
-    
+    use std::collections::HashMap;
+
     #[test]
     fn test_de_linker() {
         let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
@@ -261,25 +269,82 @@ mod tests {
     fn test_linker() {
         let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
         let mut regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
-        tokens.insert(String::from("saint"), ParsedToken::new(String::from("st"), None));
-        tokens.insert(String::from("street"), ParsedToken::new(String::from("st"), Some(TokenType::Way)));
-        tokens.insert(String::from("st"), ParsedToken::new(String::from("st"), Some(TokenType::Way)));
-        tokens.insert(String::from("lake"), ParsedToken::new(String::from("lk"), None));
-        tokens.insert(String::from("lk"), ParsedToken::new(String::from("lk"), None));
-        tokens.insert(String::from("road"), ParsedToken::new(String::from("rd"), Some(TokenType::Way)));
-        tokens.insert(String::from("rd"), ParsedToken::new(String::from("rd"), Some(TokenType::Way)));
-        tokens.insert(String::from("avenue"), ParsedToken::new(String::from("ave"), Some(TokenType::Way)));
-        tokens.insert(String::from("ave"), ParsedToken::new(String::from("ave"), Some(TokenType::Way)));
-        tokens.insert(String::from("west"), ParsedToken::new(String::from("w"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("east"), ParsedToken::new(String::from("e"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("south"), ParsedToken::new(String::from("s"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("north"), ParsedToken::new(String::from("n"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("northwest"), ParsedToken::new(String::from("nw"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("nw"), ParsedToken::new(String::from("nw"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("n"), ParsedToken::new(String::from("n"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("s"), ParsedToken::new(String::from("s"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("w"), ParsedToken::new(String::from("w"), Some(TokenType::Cardinal)));
-        tokens.insert(String::from("e"), ParsedToken::new(String::from("e"), Some(TokenType::Cardinal)));
+        tokens.insert(
+            String::from("saint"),
+            ParsedToken::new(String::from("st"), None),
+        );
+        tokens.insert(
+            String::from("street"),
+            ParsedToken::new(String::from("st"), Some(TokenType::Way)),
+        );
+        tokens.insert(
+            String::from("st"),
+            ParsedToken::new(String::from("st"), Some(TokenType::Way)),
+        );
+        tokens.insert(
+            String::from("lake"),
+            ParsedToken::new(String::from("lk"), None),
+        );
+        tokens.insert(
+            String::from("lk"),
+            ParsedToken::new(String::from("lk"), None),
+        );
+        tokens.insert(
+            String::from("road"),
+            ParsedToken::new(String::from("rd"), Some(TokenType::Way)),
+        );
+        tokens.insert(
+            String::from("rd"),
+            ParsedToken::new(String::from("rd"), Some(TokenType::Way)),
+        );
+        tokens.insert(
+            String::from("avenue"),
+            ParsedToken::new(String::from("ave"), Some(TokenType::Way)),
+        );
+        tokens.insert(
+            String::from("ave"),
+            ParsedToken::new(String::from("ave"), Some(TokenType::Way)),
+        );
+        tokens.insert(
+            String::from("west"),
+            ParsedToken::new(String::from("w"), Some(TokenType::Cardinal)),
+        );
+        tokens.insert(
+            String::from("east"),
+            ParsedToken::new(String::from("e"), Some(TokenType::Cardinal)),
+        );
+        tokens.insert(
+            String::from("south"),
+            ParsedToken::new(String::from("s"), Some(TokenType::Cardinal)),
+        );
+        tokens.insert(
+            String::from("north"),
+            ParsedToken::new(String::from("n"), Some(TokenType::Cardinal)),
+        );
+        tokens.insert(
+            String::from("northwest"),
+            ParsedToken::new(String::from("nw"), Some(TokenType::Cardinal)),
+        );
+        tokens.insert(
+            String::from("nw"),
+            ParsedToken::new(String::from("nw"), Some(TokenType::Cardinal)),
+        );
+        tokens.insert(
+            String::from("n"),
+            ParsedToken::new(String::from("n"), Some(TokenType::Cardinal)),
+        );
+        tokens.insert(
+            String::from("s"),
+            ParsedToken::new(String::from("s"), Some(TokenType::Cardinal)),
+        );
+        tokens.insert(
+            String::from("w"),
+            ParsedToken::new(String::from("w"), Some(TokenType::Cardinal)),
+        );
+        tokens.insert(
+            String::from("e"),
+            ParsedToken::new(String::from("e"), Some(TokenType::Cardinal)),
+        );
 
         let context = Context::new(String::from("us"), None, Tokens::new(tokens, regex_tokens));
 
@@ -295,39 +360,75 @@ mod tests {
             let b_name5 = Names::new(vec![Name::new("v st ne", 0, None, &context)], &context);
             let b_name6 = Names::new(vec![Name::new("u st nw", 0, None, &context)], &context);
             let b_name7 = Names::new(vec![Name::new("t st nw", 0, None, &context)], &context);
-            let b_name8 = Names::new(vec![Name::new("rhode is av ne", 0, None, &context)], &context);
-            let b_name9 = Names::new(vec![Name::new("n capitol st ne", 0, None, &context)], &context);
-            let b_name10 = Names::new(vec![Name::new("n capitol st nw", 0, None, &context)], &context);
+            let b_name8 = Names::new(
+                vec![Name::new("rhode is av ne", 0, None, &context)],
+                &context,
+            );
+            let b_name9 = Names::new(
+                vec![Name::new("n capitol st ne", 0, None, &context)],
+                &context,
+            );
+            let b_name10 = Names::new(
+                vec![Name::new("n capitol st nw", 0, None, &context)],
+                &context,
+            );
             let b_name11 = Names::new(vec![Name::new("elm st nw", 0, None, &context)], &context);
             let b_name12 = Names::new(vec![Name::new("bates st nw", 0, None, &context)], &context);
             let b_name13 = Names::new(vec![Name::new("s st nw", 0, None, &context)], &context);
-            let b_name14 = Names::new(vec![Name::new("rhode is av nw", 0, None, &context)], &context);
+            let b_name14 = Names::new(
+                vec![Name::new("rhode is av nw", 0, None, &context)],
+                &context,
+            );
             let b_name15 = Names::new(vec![Name::new("r st nw", 0, None, &context)], &context);
-            let b_name16 = Names::new(vec![Name::new("randolph pl ne", 0, None, &context)], &context);
+            let b_name16 = Names::new(
+                vec![Name::new("randolph pl ne", 0, None, &context)],
+                &context,
+            );
             let b_name17 = Names::new(vec![Name::new("rt 1", 0, None, &context)], &context);
-            let b_name18 = Names::new(vec![Name::new("lincoln rd ne", 0, None, &context)], &context);
+            let b_name18 = Names::new(
+                vec![Name::new("lincoln rd ne", 0, None, &context)],
+                &context,
+            );
             let b_name19 = Names::new(vec![Name::new("quincy pl ne", 0, None, &context)], &context);
             let b_name20 = Names::new(vec![Name::new("1st st nw", 0, None, &context)], &context);
             let b_name21 = Names::new(vec![Name::new("porter st ne", 0, None, &context)], &context);
             let b_name22 = Names::new(vec![Name::new("quincy pl nw", 0, None, &context)], &context);
-            let b_name23 = Names::new(vec![Name::new("florida av ne", 0, None, &context)], &context);
-            let b_name24 = Names::new(vec![Name::new("richardson pl nw", 0, None, &context)], &context);
+            let b_name23 = Names::new(
+                vec![Name::new("florida av ne", 0, None, &context)],
+                &context,
+            );
+            let b_name24 = Names::new(
+                vec![Name::new("richardson pl nw", 0, None, &context)],
+                &context,
+            );
             let b_name25 = Names::new(vec![Name::new("1st st ne", 0, None, &context)], &context);
             let b_name26 = Names::new(vec![Name::new("q st ne", 0, None, &context)], &context);
-            let b_name27 = Names::new(vec![Name::new("florida av nw", 0, None, &context)], &context);
+            let b_name27 = Names::new(
+                vec![Name::new("florida av nw", 0, None, &context)],
+                &context,
+            );
             let b_name28 = Names::new(vec![Name::new("p st ne", 0, None, &context)], &context);
             let b_name29 = Names::new(vec![Name::new("s st ne", 0, None, &context)], &context);
             let b_name30 = Names::new(vec![Name::new("r st ne", 0, None, &context)], &context);
             let b_name31 = Names::new(vec![Name::new("seaton pl ne", 0, None, &context)], &context);
-            let b_name32 = Names::new(vec![Name::new("randolph pl nw", 0, None, &context)], &context);
-            let b_name33 = Names::new(vec![Name::new("anna j cooper cir nw", 0, None, &context)], &context);
+            let b_name32 = Names::new(
+                vec![Name::new("randolph pl nw", 0, None, &context)],
+                &context,
+            );
+            let b_name33 = Names::new(
+                vec![Name::new("anna j cooper cir nw", 0, None, &context)],
+                &context,
+            );
             let b_name34 = Names::new(vec![Name::new("p st nw", 0, None, &context)], &context);
             let b_name35 = Names::new(vec![Name::new("q st nw", 0, None, &context)], &context);
             let b_name36 = Names::new(vec![Name::new("4th st nw", 0, None, &context)], &context);
             let b_name37 = Names::new(vec![Name::new("v st nw", 0, None, &context)], &context);
             let b_name38 = Names::new(vec![Name::new("3rd st nw", 0, None, &context)], &context);
             let b_name39 = Names::new(vec![Name::new("seaton pl nw", 0, None, &context)], &context);
-            let b_name40 = Names::new(vec![Name::new("flagler pl nw", 0, None, &context)], &context);
+            let b_name40 = Names::new(
+                vec![Name::new("flagler pl nw", 0, None, &context)],
+                &context,
+            );
             let b_name41 = Names::new(vec![Name::new("2nd st nw", 0, None, &context)], &context);
             let b_name42 = Names::new(vec![Name::new("thomas st nw", 0, None, &context)], &context);
 
@@ -374,7 +475,7 @@ mod tests {
                 Link::new(40, &b_name39),
                 Link::new(41, &b_name40),
                 Link::new(42, &b_name41),
-                Link::new(43, &b_name42)
+                Link::new(43, &b_name42),
             ];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(14, 100.0)));
         }
@@ -396,14 +497,17 @@ mod tests {
         {
             let a_name = Names::new(vec![Name::new("N Umpqua St", 0, None, &context)], &context);
 
-            let b_1_name = Names::new(vec![Name::new("Umpqua Street", 0, None, &context)], &context);
-            let b_2_name = Names::new(vec![Name::new("South Umpqua Street", 0, None, &context)], &context);
+            let b_1_name = Names::new(
+                vec![Name::new("Umpqua Street", 0, None, &context)],
+                &context,
+            );
+            let b_2_name = Names::new(
+                vec![Name::new("South Umpqua Street", 0, None, &context)],
+                &context,
+            );
 
             let a = Link::new(1, &a_name);
-            let b = vec![
-                Link::new(2, &b_1_name),
-                Link::new(3, &b_2_name)
-            ];
+            let b = vec![Link::new(2, &b_1_name), Link::new(3, &b_2_name)];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 100.0)));
         }
 
@@ -416,7 +520,10 @@ mod tests {
         }
 
         {
-            let a_name = Names::new(vec![Name::new("Saint Peter Street", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("Saint Peter Street", 0, None, &context)],
+                &context,
+            );
             let b_name = Names::new(vec![Name::new("St Peter St", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
@@ -432,16 +539,28 @@ mod tests {
         }
 
         {
-            let a_name = Names::new(vec![Name::new("US Route 50 East", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("US Route 50 West", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("US Route 50 East", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("US Route 50 West", 0, None, &context)],
+                &context,
+            );
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 98.08)));
         }
 
         {
-            let a_name = Names::new(vec![Name::new("11th Street West", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("11th Avenue West", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("11th Street West", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("11th Avenue West", 0, None, &context)],
+                &context,
+            );
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 92.11)));
@@ -460,7 +579,7 @@ mod tests {
                 Link::new(2, &b_name1),
                 Link::new(3, &b_name2),
                 Link::new(4, &b_name3),
-                Link::new(5, &b_name4)
+                Link::new(5, &b_name4),
             ];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 100.0)));
         }
@@ -478,7 +597,7 @@ mod tests {
                 Link::new(2, &b_name1),
                 Link::new(3, &b_name2),
                 Link::new(4, &b_name3),
-                Link::new(5, &b_name4)
+                Link::new(5, &b_name4),
             ];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 100.0)));
         }
@@ -490,29 +609,29 @@ mod tests {
             let b_name2 = Names::new(vec![Name::new("Ola Avg", 0, None, &context)], &context);
 
             let a = Link::new(1, &a_name);
-            let b = vec![
-                Link::new(2, &b_name1),
-                Link::new(3, &b_name2)
-            ];
+            let b = vec![Link::new(2, &b_name1), Link::new(3, &b_name2)];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 80.0)));
         }
 
         {
-            let a_name = Names::new(vec![Name::new("Avenue Street", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("Avenue Street", 0, None, &context)],
+                &context,
+            );
 
             let b_name1 = Names::new(vec![Name::new("Ave", 0, None, &context)], &context);
             let b_name2 = Names::new(vec![Name::new("Avenida", 0, None, &context)], &context);
 
             let a = Link::new(1, &a_name);
-            let b = vec![
-                Link::new(2, &b_name1),
-                Link::new(3, &b_name2)
-            ];
+            let b = vec![Link::new(2, &b_name1), Link::new(3, &b_name2)];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 77.78)));
         }
 
         {
-            let a_name = Names::new(vec![Name::new("Avenue Street", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("Avenue Street", 0, None, &context)],
+                &context,
+            );
 
             let b_name1 = Names::new(vec![Name::new("Avenue", 0, None, &context)], &context);
             let b_name2 = Names::new(vec![Name::new("Avenue", 0, None, &context)], &context);
@@ -522,13 +641,16 @@ mod tests {
             let b = vec![
                 Link::new(2, &b_name1),
                 Link::new(3, &b_name2),
-                Link::new(4, &b_name3)
+                Link::new(4, &b_name3),
             ];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 77.78)));
         }
 
         {
-            let a_name = Names::new(vec![Name::new("Main Street West", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("Main Street West", 0, None, &context)],
+                &context,
+            );
 
             let b_name1 = Names::new(vec![Name::new("Main Road", 0, None, &context)], &context);
             let b_name2 = Names::new(vec![Name::new("Main Avenue", 0, None, &context)], &context);
@@ -538,14 +660,20 @@ mod tests {
             let b = vec![
                 Link::new(2, &b_name1),
                 Link::new(3, &b_name2),
-                Link::new(4, &b_name3)
+                Link::new(4, &b_name3),
             ];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(4, 100.0)));
         }
 
         {
-            let a_name = Names::new(vec![Name::new("Lake Street West", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("West Lake Street", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("Lake Street West", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("West Lake Street", 0, None, &context)],
+                &context,
+            );
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
@@ -563,7 +691,7 @@ mod tests {
             let b = vec![
                 Link::new(2, &b_name1),
                 Link::new(3, &b_name2),
-                Link::new(4, &b_name3)
+                Link::new(4, &b_name3),
             ];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 85.71)));
         }
@@ -571,17 +699,23 @@ mod tests {
         {
             let a_name = Names::new(vec![Name::new("S Street NW", 0, None, &context)], &context);
 
-            let b_name1 = Names::new(vec![Name::new("P Street Northeast", 0, None, &context)], &context);
+            let b_name1 = Names::new(
+                vec![Name::new("P Street Northeast", 0, None, &context)],
+                &context,
+            );
             let b_name2 = Names::new(vec![Name::new("S Street NW", 0, None, &context)], &context);
             let b_name3 = Names::new(vec![Name::new("S Street NE", 0, None, &context)], &context);
-            let b_name4 = Names::new(vec![Name::new("Bates Street NW", 0, None, &context)], &context);
+            let b_name4 = Names::new(
+                vec![Name::new("Bates Street NW", 0, None, &context)],
+                &context,
+            );
 
             let a = Link::new(1, &a_name);
             let b = vec![
                 Link::new(2, &b_name1),
                 Link::new(3, &b_name2),
                 Link::new(4, &b_name3),
-                Link::new(5, &b_name4)
+                Link::new(5, &b_name4),
             ];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(3, 100.0)));
         }
@@ -590,48 +724,84 @@ mod tests {
         // The following tests should *NOT* match one of the given potential matches
 
         {
-            let a_name = Names::new(vec![Name::new("1st Street West", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("2nd Street West", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("1st Street West", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("2nd Street West", 0, None, &context)],
+                &context,
+            );
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, false), None);
         }
 
         {
-            let a_name = Names::new(vec![Name::new("1st Street West", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("3rd Street West", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("1st Street West", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("3rd Street West", 0, None, &context)],
+                &context,
+            );
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, false), None);
         }
 
         {
-            let a_name = Names::new(vec![Name::new("1st Street West", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("4th Street West", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("1st Street West", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("4th Street West", 0, None, &context)],
+                &context,
+            );
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, false), None);
         }
 
         {
-            let a_name = Names::new(vec![Name::new("11th Street West", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("21st Street West", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("11th Street West", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("21st Street West", 0, None, &context)],
+                &context,
+            );
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, false), None);
         }
 
         {
-            let a_name = Names::new(vec![Name::new("US Route 60 East", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("US Route 51 West", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("US Route 60 East", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("US Route 51 West", 0, None, &context)],
+                &context,
+            );
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, false), None);
         }
 
         {
-            let a_name = Names::new(vec![Name::new("West Main Street", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("West Saint Street", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("West Main Street", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("West Saint Street", 0, None, &context)],
+                &context,
+            );
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, false), None);
@@ -639,7 +809,10 @@ mod tests {
 
         {
             let a_name = Names::new(vec![Name::new("Main Street", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("Anne Boulevard", 0, None, &context)], &context);
+            let b_name = Names::new(
+                vec![Name::new("Anne Boulevard", 0, None, &context)],
+                &context,
+            );
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, false), None);
@@ -658,7 +831,10 @@ mod tests {
         }
 
         {
-            let a_name = Names::new(vec![Name::new("Saint Peter Street", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("Saint Peter Street", 0, None, &context)],
+                &context,
+            );
             let b_name = Names::new(vec![Name::new("St Peter St", 0, None, &context)], &context);
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
@@ -666,7 +842,10 @@ mod tests {
         }
 
         {
-            let a_name = Names::new(vec![Name::new("Main Street West", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("Main Street West", 0, None, &context)],
+                &context,
+            );
             let b_name = Names::new(vec![Name::new("Main Street", 0, None, &context)], &context);
 
             let a = Link::new(1, &a_name);
@@ -676,7 +855,10 @@ mod tests {
 
         {
             let a_name = Names::new(vec![Name::new("Main West", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("Main Street West", 0, None, &context)], &context);
+            let b_name = Names::new(
+                vec![Name::new("Main Street West", 0, None, &context)],
+                &context,
+            );
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
@@ -711,8 +893,14 @@ mod tests {
         }
 
         {
-            let a_name = Names::new(vec![Name::new("Lake Street West", 0, None, &context)], &context);
-            let b_name1 = Names::new(vec![Name::new("West Lake Street", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("Lake Street West", 0, None, &context)],
+                &context,
+            );
+            let b_name1 = Names::new(
+                vec![Name::new("West Lake Street", 0, None, &context)],
+                &context,
+            );
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name1)];
@@ -730,7 +918,10 @@ mod tests {
 
         {
             let a_name = Names::new(vec![Name::new("East Main", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("Main North East", 0, None, &context)], &context);
+            let b_name = Names::new(
+                vec![Name::new("Main North East", 0, None, &context)],
+                &context,
+            );
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
@@ -740,16 +931,28 @@ mod tests {
         // === Intentional Strict Non-Matches ===
         // The following tests should *NOT* match one of the given potential matches in strict mode
         {
-            let a_name = Names::new(vec![Name::new("US Route 50 East", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("US Route 50 West", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("US Route 50 East", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("US Route 50 West", 0, None, &context)],
+                &context,
+            );
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, true), None);
         }
 
         {
-            let a_name = Names::new(vec![Name::new("West Main Street", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("West Saint Street", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("West Main Street", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("West Saint Street", 0, None, &context)],
+                &context,
+            );
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, true), None);
@@ -774,8 +977,14 @@ mod tests {
         }
 
         {
-            let a_name = Names::new(vec![Name::new("East Main Street", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("West Main Street", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("East Main Street", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("West Main Street", 0, None, &context)],
+                &context,
+            );
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
@@ -783,13 +992,15 @@ mod tests {
         }
 
         {
-            let a_name = Names::new(vec![Name::new("Main Street Ave", 0, None, &context)], &context);
+            let a_name = Names::new(
+                vec![Name::new("Main Street Ave", 0, None, &context)],
+                &context,
+            );
             let b_name = Names::new(vec![Name::new("Main Street", 0, None, &context)], &context);
 
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, true), None);
         }
-
     }
 }


### PR DESCRIPTION
Existing source isn't `cargo fmt` compliant, so we often end up with changes that include unrelated formatting changes due to editors automatically applying formatting fixes. This makes PRs harder to review and makes history less useful as unrelated changes are included in blame output.

This PR does the following:

- runs `cargo fmt` on all existing rust code
- requires all new rust code to have been formatted with `cargo fmt`
- adds `.git-blame-ignore-revs` to allow ignoring these formatting changes in `git blame`

Once this is merged you can configure `git blame` to ignore the formatting changes by running:

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```