### PR TITLE
Add missing index for conflate

### DIFF
--- a/native/src/pg/address.rs
+++ b/native/src/pg/address.rs
@@ -103,6 +103,14 @@ impl Table for Address {
 
         conn.execute(
             r#"
+            CREATE INDEX address_number_idx ON address (number);
+        "#,
+            &[],
+        )
+        .unwrap();
+
+        conn.execute(
+            r#"
             CLUSTER address USING address_idx;
         "#,
             &[],


### PR DESCRIPTION
When conflating, each potentially new address is compared to all persistent addresses with the same street number within a certain radius. The query used to extract the potential duplicates from the persistent addresses uses the `address.number` column, which is not indexed. In local testing adding an index on the `address.number` column reduced conflation wall clock time as follows:

| addresses | persistent | w/o index  | w/index   |
| --------- | ---------- | ---------  | --------  |
| 10,000    | 147303     | 1m48.186s  | 0m40.944s |
| 100,000   | 147303     | 15m55.967s | 4m33.374s |

The us/dc/statewide source from OpenAddresses.io is used as the persistent addresses and random samplings of 10,000 and 100,000 addresses from the same source are for the addresses to conflate. This means the benchmark only covers time to detect duplicates, no modifications would be present.

These numbers should be taken with a grain of salt due to the sketchy benchmarking methodology used here (`time`), but after about 1.5 days of effort I was unable to get anything more sophisticated working. That said, the performance gains appear to be significant enough to warrant adding the index.

Future work will be necessary to address the architectural issues that make benchmarking difficult, especially from the rust side.