### PR TITLE
Revert comma replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ## Version History
 
+### v28.7.0
+- :rocket: Add support for the ability to link an address to a network and vice versa based on substring comparison.
+
 ### v28.5.1
 - :bug: Update version
 

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -296,12 +296,8 @@ impl Name {
         source: Option<Source>,
         context: &Context,
     ) -> Self {
-        let mut display = display.to_string().replace(r#"""#, "");
-        let re = Regex::new(r#","#).unwrap();
-        let disp_str: &str = &*display; // convert from std::string::String -> &str
-        if re.is_match(disp_str) {
-            println!("comma: {}", disp_str)
-        };
+        let mut display = display.to_string().replace(r#"""#, "").replace(r#","#, ""); // commas are not allowed as they are used to delimit synonyms on output
+        
         // only title case non-generated names
         if source != Some(Source::Generated) {
             display = titlecase(&display, &context);

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -296,6 +296,7 @@ impl Name {
         context: &Context,
     ) -> Self {
         let mut display = display.to_string().replace(r#"""#, "").replace(r#","#, ""); // commas are not allowed as they are used to delimit synonyms on output
+        
         // only title case non-generated names
         if source != Some(Source::Generated) {
             display = titlecase(&display, &context);

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -2,6 +2,7 @@ use crate::text::titlecase;
 use crate::Tokenized;
 use crate::{text, Context};
 use geocoder_abbreviations::TokenType;
+use regex::Regex;
 use std::collections::HashMap;
 
 ///
@@ -295,8 +296,12 @@ impl Name {
         source: Option<Source>,
         context: &Context,
     ) -> Self {
-        let mut display = display.to_string().replace(r#"""#, "").replace(r#","#, ""); // commas are not allowed as they are used to delimit synonyms on output
-        
+        let mut display = display.to_string().replace(r#"""#, "");
+        let re = Regex::new(r#","#).unwrap();
+        let disp_str: &str = &*display; // convert from std::string::String -> &str
+        if re.is_match(disp_str) {
+            println!("comma: {}", disp_str)
+        };
         // only title case non-generated names
         if source != Some(Source::Generated) {
             display = titlecase(&display, &context);

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -2,7 +2,6 @@ use crate::text::titlecase;
 use crate::Tokenized;
 use crate::{text, Context};
 use geocoder_abbreviations::TokenType;
-use regex::Regex;
 use std::collections::HashMap;
 
 ///
@@ -297,7 +296,7 @@ impl Name {
         context: &Context,
     ) -> Self {
         let mut display = display.to_string().replace(r#"""#, "").replace(r#","#, ""); // commas are not allowed as they are used to delimit synonyms on output
-        
+
         // only title case non-generated names
         if source != Some(Source::Generated) {
             display = titlecase(&display, &context);

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -295,7 +295,7 @@ impl Name {
         source: Option<Source>,
         context: &Context,
     ) -> Self {
-        let mut display = display.to_string().replace(r#"""#, "");
+        let mut display = display.to_string().replace(r#"""#, "").replace(r#","#, ""); // commas are not allowed as they are used to delimit synonyms on output
         // only title case non-generated names
         if source != Some(Source::Generated) {
             display = titlecase(&display, &context);
@@ -486,7 +486,7 @@ mod tests {
         assert_eq!(
             Name::new(String::from(","), 0, None, &context),
             Name {
-                display: String::from(","),
+                display: String::from(""),
                 priority: 0,
                 source: None,
                 tokenized: vec![],

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -1064,25 +1064,6 @@ mod tests {
         );
         {
             let a_name = Names::new(
-                vec![Name::new(
-                    "Rue Du Dix Neuf Mars 1962,D 149.10",
-                    0,
-                    None,
-                    &context,
-                )],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new("Rue Du 19 Mars 1962", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), None); // needs to match on multi-word Dix Neuf == 19
-        }
-
-        {
-            let a_name = Names::new(
                 vec![Name::new("saint martin rue de l'eglise", 0, None, &context)],
                 &context,
             );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/pt2itp",
-  "version": "28.6.2",
+  "version": "28.7.0",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",


### PR DESCRIPTION
Reverting the removal of the comma replace (https://github.com/mapbox/pt2itp/pull/562/files#diff-8efa67297e11471a42b629b95222be2aR298), bump pt2itp version, and add changelog.