### PR TITLE
Allow house number slashes for Czech Republic and Poland

### DIFF
--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -217,7 +217,7 @@ impl Address {
 
     pub fn std(&mut self, country: &str) -> Result<(), String> {
         // Czech Republic and Poland have addresses in the format of "123/89"
-        // Let's allow those through, but still not 123 1/2, regadless of country
+        // Let's allow those through, but still not 123 1/2, regardless of country
         let slash_excluded_countries = ["pl", "cz"];
         self.number = self.number.to_lowercase();
         let HALF = Regex::new(r"\s1/2$").unwrap();

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -216,8 +216,8 @@ impl Address {
     }
 
     pub fn std(&mut self, country: &str) -> Result<(), String> {
-        // Czech Republic and Poland have addresses in the format of "123/89". Let's allow those through.println!
-        // But still not 123 1/2
+        // Czech Republic and Poland have addresses in the format of "123/89"
+        // Let's allow those through, but still not 123 1/2, regadless of country
         let slash_excluded_countries = ["pl", "cz"];
         self.number = self.number.to_lowercase();
         let HALF = Regex::new(r"\s1/2$").unwrap();

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -548,7 +548,7 @@ mod tests {
             assert_eq!(addr.to_tsv(), "\t0\t[{\"display\":\"Hickory Hills Dr\",\"priority\":-1,\"source\":\"Address\",\"tokenized\":[{\"token\":\"hickory\",\"token_type\":null},{\"token\":\"hls\",\"token_type\":null},{\"token\":\"dr\",\"token_type\":\"Way\"}],\"freq\":1}]\t1272\tTIGER-2016\tfalse\ttrue\t{\"number\":1272,\"source\":\"TIGER-2016\",\"street\":\"Hickory Hills Dr\"}\t0101000020E6100000096C0B88B40D55C00BF02796EB9B4340\n");
         }
 
-        // street value is has a `/`
+        // Poland street value is has a `/`
         {
             let feat: geojson::GeoJson = String::from(r#"{"type":"Feature","properties":{"street":"Hickory Hills Dr","number":"123/89","source":"TIGER-2016","output":false},"interpolate":true, "geometry":{"type":"Point","coordinates":[-84.21414376368934,39.21812703085023]}}"#).parse().unwrap();
 
@@ -561,6 +561,23 @@ mod tests {
             let addr = Address::new(feat, &context).unwrap();
 
             assert_eq!(addr.to_tsv(), "\t0\t[{\"display\":\"Hickory Hills Dr\",\"priority\":-1,\"source\":\"Address\",\"tokenized\":[{\"token\":\"hickory\",\"token_type\":null},{\"token\":\"hills\",\"token_type\":null},{\"token\":\"dr\",\"token_type\":null}],\"freq\":1}]\t123/89\tTIGER-2016\tfalse\ttrue\t{\"number\":\"123/89\",\"source\":\"TIGER-2016\",\"street\":\"Hickory Hills Dr\"}\t0101000020E6100000096C0B88B40D55C00BF02796EB9B4340\n");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Number is not a supported address/unit type")]
+    fn test_address_simple_geom_fail() {
+        // US street value is has a `/`
+        {
+            let feat: geojson::GeoJson = String::from(r#"{"type":"Feature","properties":{"street":"Hickory Hills Dr","number":"123/89","source":"TIGER-2016","output":false},"interpolate":true, "geometry":{"type":"Point","coordinates":[-84.21414376368934,39.21812703085023]}}"#).parse().unwrap();
+
+            let context = Context::new(
+                String::from("us"),
+                Some(String::from("mn")),
+                Tokens::generate(vec![String::from("en")]),
+            );
+
+            let addr = Address::new(feat, &context).unwrap();
         }
     }
 }

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -215,7 +215,7 @@ impl Address {
         })
     }
 
-    pub fn std(&mut self, country: &str) -> Result<(), String> {
+    pub fn std(&mut self, country: &String) -> Result<(), String> {
         self.number = self.number.to_lowercase();
 
         lazy_static! {
@@ -238,6 +238,8 @@ impl Address {
                 r"^\d+(к\d+)?(с\d+)?$"
             ])
             .unwrap();
+            static ref SLASH_EXCLUDED_COUNTRIES: Vec<String> =
+                vec![String::from("pl"), String::from("cz")];
         };
 
         // Remove 1/2 Numbers from addresses as they are not currently supported
@@ -248,13 +250,14 @@ impl Address {
 
         // Czech Republic and Poland have addresses in the format of "123/89"
         // Let's allow those through, but still not 123 1/2, regardless of country
-        let slash_excluded_countries = ["pl", "cz"];
-        if slash_excluded_countries.contains(&country) {
+        if SLASH_EXCLUDED_COUNTRIES.contains(&country) {
             if !SLASH_SUPPORTED.is_match(self.number.as_str()) {
                 return Err(String::from("Number is not a supported address/unit type"));
             }
-        } else if !SUPPORTED.is_match(self.number.as_str()) {
-            return Err(String::from("Number is not a supported address/unit type"));
+        } else {
+            if !SUPPORTED.is_match(self.number.as_str()) {
+                return Err(String::from("Number is not a supported address/unit type"));
+            }
         }
 
         if self.number.len() > 10 {

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -250,18 +250,15 @@ impl Address {
 
         // Czech Republic and Poland have addresses in the format of "123/89"
         // Let's allow those through, but still not 123 1/2, regardless of country
-        if SLASH_EXCLUDED_COUNTRIES.contains(&country) {
-            if !SLASH_SUPPORTED.is_match(self.number.as_str()) {
-                return Err(String::from("Number is not a supported address/unit type"));
-            }
+        let supported = if SLASH_EXCLUDED_COUNTRIES.contains(&country) {
+            &SLASH_SUPPORTED
         } else {
-            if !DEFAULT_SUPPORTED.is_match(self.number.as_str()) {
-                return Err(String::from("Number is not a supported address/unit type"));
-            }
-        }
-
-        if self.number.len() > 10 {
-            return Err(String::from("Number should not exceed 10 chars"));
+            &*DEFAULT_SUPPORTED
+        };
+        println!("country {:?}", country);
+        println!("supported {:?}", supported);
+        if !supported.is_match(self.number.as_str()) {
+            return Err(String::from("Number is not a supported address/unit type"));
         }
 
         Ok(())

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -5,7 +5,7 @@ use regex::{Regex, RegexSet};
 use crate::{hecate, types::name::InputName, Context, Name, Names, Source};
 
 /// A representation of a single Address
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Address {
     /// An optional identifier for the address
     pub id: Option<i64>,
@@ -221,7 +221,7 @@ impl Address {
         lazy_static! {
             static ref HALF: Regex = Regex::new(r"\s1/2$").unwrap();
             static ref UNIT: Regex = Regex::new(r"^(?P<num>\d+)\s(?P<unit>[a-z])$").unwrap();
-            static ref SUPPORTED: RegexSet = RegexSet::new(&[
+            static ref DEFAULT_SUPPORTED: RegexSet = RegexSet::new(&[
                 r"^\d+[a-z]?$",
                 r"^(\d+)-(\d+)[a-z]?$",
                 r"^(\d+)([nsew])(\d+)[a-z]?$",
@@ -255,7 +255,7 @@ impl Address {
                 return Err(String::from("Number is not a supported address/unit type"));
             }
         } else {
-            if !SUPPORTED.is_match(self.number.as_str()) {
+            if !DEFAULT_SUPPORTED.is_match(self.number.as_str()) {
                 return Err(String::from("Number is not a supported address/unit type"));
             }
         }
@@ -573,7 +573,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Number is not a supported address/unit type")]
     fn test_address_simple_geom_fail() {
         // US street value is has a `/`
         {
@@ -585,7 +584,9 @@ mod tests {
                 Tokens::generate(vec![String::from("en")]),
             );
 
-            let addr = Address::new(feat, &context).unwrap();
+            let addr = Address::new(feat, &context);
+            let expected_error = Err(String::from("Number is not a supported address/unit type"));
+            assert_eq!(addr, expected_error);
         }
     }
 }

--- a/native/src/types/address.rs
+++ b/native/src/types/address.rs
@@ -255,10 +255,12 @@ impl Address {
         } else {
             &*DEFAULT_SUPPORTED
         };
-        println!("country {:?}", country);
-        println!("supported {:?}", supported);
         if !supported.is_match(self.number.as_str()) {
             return Err(String::from("Number is not a supported address/unit type"));
+        }
+
+        if self.number.len() > 10 {
+            return Err(String::from("Number should not exceed 10 chars"));
         }
 
         Ok(())


### PR DESCRIPTION
Czech Republic and Poland both have house numbers formatted as `123/45`. We want to allow that format through for only Czech Republic and Poland. Still, the format of `123 1/2` will not be acceptable.