### PR TITLE
Update to geocoder-abbreviations v4.5.0

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "geocoder-abbreviations"
 version = "0.1.0"
-source = "git+https://github.com/mapbox/geocoder-abbreviations?rev=master#e869239a29449fd9f73adec50f6002403cbd4f96"
+source = "git+https://github.com/mapbox/geocoder-abbreviations?tag=v4.5.0#d618a6b52b03492402452a1b19aebc8e5aa8ceaf"
 dependencies = [
  "alphanumeric-sort",
  "fancy-regex",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1.0"
 serde = "1.0"
 fancy-regex = "0.1.0"
 memchr = "2.0.2"
-geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "master" }
+geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", tag = "v4.5.0" }
 unicode-segmentation = "1.3.0"
 kodama = "0.1"
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@mapbox/carmen": "27.2.0",
     "@mapbox/eslint-config-geocoding": "^2.0.2",
-    "@mapbox/geocoder-abbreviations": "2.4.1",
+    "@mapbox/geocoder-abbreviations": "4.5.0",
     "@mapbox/geojson-area": "^0.2.2",
     "@mapbox/mbtiles": "^0.11.0",
     "@mapbox/tile-cover": "^3.0.2",

--- a/test/test-de.test.js
+++ b/test/test-de.test.js
@@ -11,9 +11,22 @@ const database = 'pt_test';
 const carmenIndex = '/tmp/test-de.mbtiles';
 const output = '/tmp/test-de.err';
 const config = path.resolve(__dirname, './fixtures/test-de/carmen-config.json');
-const abbr = path.resolve(__dirname, '../node_modules/@mapbox/geocoder-abbreviations/tokens/global.js');
-
+const deTokens = require('@mapbox/geocoder-abbreviations')('de');
+const abbr = '/tmp/test-de-abbr.json';
 const db = require('./lib/db');
+
+// Convert the de regex tokens into the global format expected by carmen.
+const tokens = {};
+for (const token of deTokens) {
+    if (!Array.isArray(token) || typeof(token[1]) !== 'object' || !token[1]['regex']) {
+        continue;
+    }
+    const from = token[1]['text'];
+    const to = token[0];
+    tokens[from] = to;
+}
+fs.writeFileSync(abbr, JSON.stringify(tokens));
+
 db.init(test);
 
 // loads address and network data into postgres

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,12 +190,13 @@
   resolved "https://registry.yarnpkg.com/@mapbox/eslint-config-geocoding/-/eslint-config-geocoding-2.0.2.tgz#0dab7b9cc7827f4426dcff707e06e6b7be134136"
   integrity sha512-SZRaSgVLYJuTMQ/N2bb+4gdsQcuP5p6zboiIAi55l0d82LMMx3YL1RUqxOSRkJVU7Y4oO1+AYkJMLLcSbYgXAQ==
 
-"@mapbox/geocoder-abbreviations@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/geocoder-abbreviations/-/geocoder-abbreviations-2.4.1.tgz#6dac6711bcb0a67e08d2ee1d9e737a52d4ad6dfa"
-  integrity sha512-bAj86Mcw1audeZXFR18T1e1cp8hVGr+DrR0bRZB4HoBtiuhH2/OTVyJjmHnKIVcxH/OofOpMoAnA5lJveMyAWw==
+"@mapbox/geocoder-abbreviations@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/geocoder-abbreviations/-/geocoder-abbreviations-4.5.0.tgz#71c37c9b0c577400f331152ac7b50a6a5a2cdf37"
+  integrity sha512-igO5vsbBnvKBwFn25rY0YhTRiT0uX0mP+3xaBwMq3NrW/iWUbc93I7Q21jf6rLssSpRoQ38uviTW68EF4Duwpg==
   dependencies:
     tape "^4.6.3"
+    union-find "^1.0.2"
 
 "@mapbox/geojson-area@0.2.2", "@mapbox/geojson-area@^0.2.2":
   version "0.2.2"
@@ -5623,6 +5624,11 @@ underscore@~1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
   integrity sha1-izixDKze9jM3uLJOT/htRa6lKag=
+
+union-find@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/union-find/-/union-find-1.0.2.tgz#292bac415e6ad3a89535d237010db4a536284e58"
+  integrity sha1-KSusQV5q06iVNdI3AQ20pTYoTlg=
 
 unist-util-stringify-position@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
This bumps geocoder-abbreviations on both the Rust and JavaScript sides. The JavaScript side hasn't been updated in quite a while and requires updating a test to account for changes in the global tokens provided by geocoder-abbreviations.