### PR TITLE
Abbreviation matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,17 +212,21 @@ don't change/break the CLI interface.
 ## Tests
 
 To run the entire JS & Rust test suite:
+
 ```
 npm run test
 ```
 
 To run only the Cargo test suite:
-```
-npm run cargo_all
-````
 
-To run only a specific Cargo test:
 ```
-npm run cargo_one
+npm run cargo
 ```
-- This will run on the test you specify (ie. `util::linker::tests::test_fr_linker`), as well as print any print statements you have added throughout your code.
+
+To run a specific Cargo test:
+
+```
+npm run cargo_individual --my_test=<path_to_test>
+```
+
+- This will run only the test you specify (ie. `npm run cargo_one --my_test=util::linker::tests::test_be_linker`), as well as print any print statements you have added throughout your code.

--- a/README.md
+++ b/README.md
@@ -208,3 +208,21 @@ don't change/break the CLI interface.
 └┤ Hypenated Primary Address Number - The hyphen is significant and should not be omitted.
  │ Different hyphenated standards represent different things. wikipedia: Queens Addresses
 ```
+
+## Tests
+
+To run the entire JS & Rust test suite:
+```
+npm run test
+```
+
+To run only the Cargo test suite:
+```
+npm run cargo_all
+````
+
+To run only a specific Cargo test:
+```
+npm run cargo_one
+```
+- This will run on the test you specify (ie. `util::linker::tests::test_fr_linker`, as well as print any print statements you have added throughout your code.

--- a/README.md
+++ b/README.md
@@ -225,4 +225,4 @@ To run only a specific Cargo test:
 ```
 npm run cargo_one
 ```
-- This will run on the test you specify (ie. `util::linker::tests::test_fr_linker`, as well as print any print statements you have added throughout your code.
+- This will run on the test you specify (ie. `util::linker::tests::test_fr_linker`), as well as print any print statements you have added throughout your code.

--- a/lib/post/props.js
+++ b/lib/post/props.js
@@ -24,7 +24,7 @@ function post(feat, opts) {
         const occurances = {};
         const current_vals = [];
 
-        // Generate Flat array of properties & Occurance Count
+        // Generate Flat array of properties & Occurrence Count
         for (const prop of feat.properties.address_props) {
             occurances[prop[desired_prop]] = occurances[prop[desired_prop]] ? occurances[prop[desired_prop]] + 1 : 1;
 

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "geocoder-abbreviations"
 version = "0.1.0"
-source = "git+https://github.com/mapbox/geocoder-abbreviations?rev=28a25062c4ea7e90f453952a60daf7775da0e13e#28a25062c4ea7e90f453952a60daf7775da0e13e"
+source = "git+https://github.com/mapbox/geocoder-abbreviations?tag=v4.6.0#002e99f9f6032ec3c52ac63e9949adccdeb2c05d"
 dependencies = [
  "alphanumeric-sort",
  "fancy-regex",

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "geocoder-abbreviations"
 version = "0.1.0"
-source = "git+https://github.com/mapbox/geocoder-abbreviations?tag=v4.5.0#d618a6b52b03492402452a1b19aebc8e5aa8ceaf"
+source = "git+https://github.com/mapbox/geocoder-abbreviations?rev=28a25062c4ea7e90f453952a60daf7775da0e13e#28a25062c4ea7e90f453952a60daf7775da0e13e"
 dependencies = [
  "alphanumeric-sort",
  "fancy-regex",

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "geocoder-abbreviations"
 version = "0.1.0"
-source = "git+https://github.com/mapbox/geocoder-abbreviations?rev=28a25062c4ea7e90f453952a60daf7775da0e13e#28a25062c4ea7e90f453952a60daf7775da0e13e"
+source = "git+https://github.com/mapbox/geocoder-abbreviations?tag=v4.6.1#11383cce53f85a146837f49237b68946bcd94f81"
 dependencies = [
  "alphanumeric-sort",
  "fancy-regex",

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "geocoder-abbreviations"
 version = "0.1.0"
-source = "git+https://github.com/mapbox/geocoder-abbreviations?tag=v4.6.0#002e99f9f6032ec3c52ac63e9949adccdeb2c05d"
+source = "git+https://github.com/mapbox/geocoder-abbreviations?rev=28a25062c4ea7e90f453952a60daf7775da0e13e#28a25062c4ea7e90f453952a60daf7775da0e13e"
 dependencies = [
  "alphanumeric-sort",
  "fancy-regex",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1.0"
 serde = "1.0"
 fancy-regex = "0.1.0"
 memchr = "2.0.2"
-geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", tag = "v4.6.0" }
+geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "28a25062c4ea7e90f453952a60daf7775da0e13e" }
 unicode-segmentation = "1.3.0"
 kodama = "0.1"
 

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1.0"
 serde = "1.0"
 fancy-regex = "0.1.0"
 memchr = "2.0.2"
-geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "28a25062c4ea7e90f453952a60daf7775da0e13e" }
+geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", tag = "v4.6.1" }
 unicode-segmentation = "1.3.0"
 kodama = "0.1"
 

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1.0"
 serde = "1.0"
 fancy-regex = "0.1.0"
 memchr = "2.0.2"
-geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "28a25062c4ea7e90f453952a60daf7775da0e13e" }
+geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", tag = "v4.6.0" }
 unicode-segmentation = "1.3.0"
 kodama = "0.1"
 

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1.0"
 serde = "1.0"
 fancy-regex = "0.1.0"
 memchr = "2.0.2"
-geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "54da997e73d8ddf15b32e03bc7cf5faa7b6c225e" }
+geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "28a25062c4ea7e90f453952a60daf7775da0e13e" }
 unicode-segmentation = "1.3.0"
 kodama = "0.1"
 

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -1419,4 +1419,54 @@ mod tests {
             assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
         }
     }
+    #[test]
+    fn test_it_linker() {
+        let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
+        let regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
+        let context = Context::new(
+            String::from("it"),
+            None,
+            Tokens::generate(vec![String::from("it")]),
+        );
+        {
+            let a_name = Names::new(vec![Name::new("Via Angelo Silvio Novaro", 0, None, &context)], &context);
+            let b_name = Names::new(
+                vec![Name::new("Via A. S. Novaro", 0, None, &context)],
+                &context,
+            );
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
+        }
+    }
+    #[test]
+    fn test_be_linker() {
+        let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
+        let regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
+        let context = Context::new(
+            String::from("fr"),
+            None,
+            Tokens::generate(vec![String::from("fr")]),
+        );
+        {
+            let a_name = Names::new(vec![Name::new("rue de la reine astrid", 0, None, &context)], &context);
+            let b_name = Names::new(
+                vec![Name::new("rue reine astrid", 0, None, &context)],
+                &context,
+            );
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 91.18)));
+        }
+        {
+            let a_name = Names::new(vec![Name::new("grand'place", 0, None, &context)], &context);
+            let b_name = Names::new(
+                vec![Name::new("grand place", 0, None, &context)],
+                &context,
+            );
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
+        }
+    }
 }

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -75,23 +75,21 @@ fn is_abbrev(token: &String, token_list: &Vec<String>) -> (bool, Vec<String>) {
 fn check_substring(token_list_one: Vec<String>, mut token_list_two: Vec<String>) -> bool {
     for word in &token_list_one {
         let ntok_index = &token_list_two.iter().position(|r| r == word);
-        let mut abbrev_match: bool = false;
         match ntok_index {
             Some(index) => {
                 token_list_two.remove(*index);
             }
             None => {
-                if token_list_two.len() > 0 {
+                if !token_list_two.is_empty() {
                     // if abbreviation is found return stripped through abbreviated index value
-                    let check_abbreviation: (bool, Vec<String>) = is_abbrev(word, &token_list_two);
-                    abbrev_match = check_abbreviation.0;
-                    token_list_two = check_abbreviation.1;
-                }
-                if !abbrev_match {
-                    return false;
+                    let (abbrev_match, remaining_tokens) = is_abbrev(word, &token_list_two);
+                    if !abbrev_match {
+                        return false;
+                    }
+                    token_list_two = remaining_tokens;
                 }
             }
-        };
+        }
     }
     return true;
 }
@@ -247,17 +245,14 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                         .map(|x| x.token.to_owned())
                         .collect();
 
-                    let mut subset_match: bool = true;
-                    let address_length: usize = atoks.len();
-                    let network_length: usize = ntoks.len();
-                    // compare smaller list against larger list. all tokens in the smaller list must be in the larger list
-                    if network_length > address_length {
-                        // Check if all tokens in the address are present within the network
-                        subset_match = check_substring(atoks, ntoks);
+                    // Compare smaller list against larger list. Sll tokens in the smaller list must be in the larger list
+                    // ie. check if all tokens in the address are present within the network
+                    // OR check if all tokens in the network are preset within the address
+                    let subset_match = if ntoks.len() > atoks.len() {
+                        check_substring(atoks, ntoks)
                     } else {
-                        // Check if all tokens in the network are preset within the address
-                        subset_match = check_substring(ntoks, atoks);
-                    }
+                        check_substring(ntoks, atoks)
+                    };
 
                     if subset_match {
                         // subset match successful
@@ -302,6 +297,39 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
     }
 }
 
+#[macro_export]
+macro_rules! build_lang_context {
+    ($language:expr) => {
+        Context::new(
+            String::from($language),
+            None,
+            Tokens::generate(vec![String::from($language)]),
+        );
+    };
+}
+
+#[macro_export]
+macro_rules! assert_linker_eq {
+    ($language:expr; $name_a:expr; $name_b:expr; $strict_mode:expr; $expected_return:expr) => {
+        println!("{}", $name_a);
+        println!("{}", $name_b);
+        let context = build_lang_context!($language);
+        let a_name = Names::new(vec![Name::new($name_a, 0, None, &context)], &context);
+        let b_name = Names::new(vec![Name::new($name_b, 0, None, &context)], &context);
+        let a = Link::new(1, &a_name);
+        let b = vec![Link::new(2, &b_name)];
+
+        if $expected_return == 0.0 {
+            assert_eq!(linker(a, b, $strict_mode), None);
+        } else {
+            assert_eq!(
+                linker(a, b, $strict_mode),
+                Some(LinkResult::new(2, $expected_return))
+            );
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -309,45 +337,6 @@ mod tests {
     use crate::{Context, Name, Names, Tokens};
     use geocoder_abbreviations::TokenType;
     use std::collections::HashMap;
-
-    #[test]
-    fn test_de_linker() {
-        let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let context = Context::new(
-            String::from("de"),
-            None,
-            Tokens::generate(vec![String::from("de")]),
-        );
-
-        {
-            let a_name = Names::new(
-                vec![Name::new("weserstrandstrasse", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new("weserstrandstr", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));
-        }
-        {
-            let a_name = Names::new(vec![Name::new("kuferstr", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("kuferstrasse", 0, None, &context)], &context);
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));
-        }
-        {
-            let a_name = Names::new(vec![Name::new("kuferstraße", 0, None, &context)], &context);
-            let b_name = Names::new(vec![Name::new("kuferstrasse", 0, None, &context)], &context);
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, true), Some(LinkResult::new(2, 100.0)));
-        }
-    }
 
     #[test]
     fn test_linker() {
@@ -1093,380 +1082,106 @@ mod tests {
     }
 
     #[test]
-    fn test_fr_linker() {
-        let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let context = Context::new(
-            String::from("fr"),
-            None,
-            Tokens::generate(vec![String::from("fr")]),
-        );
+    fn test_de_linker() {
         {
-            let a_name = Names::new(
-                vec![Name::new("saint martin rue de l'eglise", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new("rue de l'eglise", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
+            assert_linker_eq!("de"; "weserstrandstrasse"; "weserstrandstr"; false; 100.0);
         }
-
         {
-            let a_name = Names::new(
-                vec![Name::new(
-                    "saint martin ruet de l'eglise encore",
-                    0,
-                    None,
-                    &context,
-                )],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new("rue de l'eglise", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
+            assert_linker_eq!("de"; "kuferstr"; "kuferstrasse"; false; 100.0);
         }
-
         {
-            let a_name = Names::new(
-                vec![Name::new("rue de l'eglise", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new(
-                    "saint martin ruet de l'eglise encore",
-                    0,
-                    None,
-                    &context,
-                )],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
-        }
-
-        {
-            let a_name = Names::new(
-                vec![Name::new("rue de l'eglise saint martin", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new("rue de l'eglise", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
-        }
-
-        {
-            let a_name = Names::new(
-                vec![Name::new("rue de saint martin", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new("rue de saint marten", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 92.86)));
-        }
-
-        {
-            let a_name = Names::new(
-                vec![Name::new("impasse sourdoire", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new("impasse de la sourdoire", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 90.63)));
-        }
-
-        {
-            let a_name = Names::new(
-                vec![Name::new("place francois mitterrand", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new(
-                    "place de la republique francois mitterrand",
-                    0,
-                    None,
-                    &context,
-                )],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
-        }
-
-        {
-            let a_name = Names::new(
-                vec![Name::new(
-                    "place francois mitterrand l'eglise",
-                    0,
-                    None,
-                    &context,
-                )],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new(
-                    "place de la republique francois mitterrand",
-                    0,
-                    None,
-                    &context,
-                )],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), None);
+            assert_linker_eq!("de"; "kuferstraße"; "kuferstrasse"; false; 100.0);
         }
     }
+
+    #[test]
+    fn test_fr_linker() {
+        {
+            assert_linker_eq!("fr"; "saint martin rue de l'eglise"; "rue de l'eglise"; false; 70.01);
+        }
+        {
+            assert_linker_eq!("fr"; "saint martin ruet de l'eglise encore"; "rue de l'eglise"; false; 70.01);
+        }
+        {
+            assert_linker_eq!("fr"; "rue de l'eglise"; "saint martin ruet de l'eglise encore"; false; 70.01);
+        }
+        {
+            assert_linker_eq!("fr"; "rue de l'eglise saint martin"; "rue de l'eglise"; false; 70.01);
+        }
+        {
+            assert_linker_eq!("fr"; "rue de saint martin"; "rue de saint marten"; false; 92.86);
+        }
+        {
+            assert_linker_eq!("fr"; "impasse sourdoire"; "impasse de la sourdoire"; false; 90.63);
+        }
+        {
+            assert_linker_eq!("fr"; "place francois mitterrand"; "place de la republique francois mitterrand"; false; 70.01);
+        }
+        {
+            assert_linker_eq!("fr"; "place francois mitterrand l'eglise"; "place de la republique francois mitterrand"; false; 0.0);
+        }
+    }
+
     #[test]
     fn test_es_linker() {
-        let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let context = Context::new(
-            String::from("es"),
-            None,
-            Tokens::generate(vec![String::from("es")]),
-        );
         {
-            let a_name = Names::new(
-                vec![Name::new("carrer de ramon casas", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new("cl ramon casas", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 95.16)));
+            assert_linker_eq!("es"; "carrer de ramon casas"; "cl ramon casas"; false; 95.16);
         }
         {
-            let a_name = Names::new(
-                vec![Name::new("carrer de l'onze de setembre", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new("cl onze de setembre", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 92.5)));
+            assert_linker_eq!("es"; "carrer de l'onze de setembre"; "cl onze de setembre"; false; 92.5);
         }
         {
-            let a_name = Names::new(
-                vec![Name::new("passatge de llessami", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(vec![Name::new("pj llessami", 0, None, &context)], &context);
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 94.0)));
+            assert_linker_eq!("es"; "passatge de llessami"; "pj llessami"; false; 94.0);
         }
         {
-            let a_name = Names::new(
-                vec![Name::new("GV Corts Catalanes", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new(
-                    "Gran Via De Les Corts Catalanes",
-                    0,
-                    None,
-                    &context,
-                )],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 91.86)));
+            assert_linker_eq!("es"; "GV Corts Catalanes"; "Gran Via De Les Corts Catalanes"; false; 91.86);
         }
         {
-            let a_name = Names::new(
-                vec![Name::new("cl f garcia lorca", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new("cl federico garcia lorca", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
+            assert_linker_eq!("es"; "cl f garcia lorca"; "cl federico garcia lorca"; false; 70.01);
         }
         // "nrta" consecutive in "nuestra" --> pass
         {
-            let a_name = Names::new(vec![Name::new("bo ntra", 0, None, &context)], &context);
-            let b_name = Names::new(
-                vec![Name::new("barrio nuestra", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
+            assert_linker_eq!("es"; "bo ntra"; "barrio nuestra"; false; 70.01);
         }
         // "nrta" not consecutive in "nuestra" --> fail
         {
-            let a_name = Names::new(vec![Name::new("bo nrta", 0, None, &context)], &context);
-            let b_name = Names::new(
-                vec![Name::new("barrio nuestra", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), None);
+            assert_linker_eq!("es"; "bo nrta"; "barrio nuestra"; false; 0.0);
         }
     }
+
     #[test]
     fn test_sk_linker() {
-        let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let context = Context::new(
-            String::from("sk"),
-            None,
-            Tokens::generate(vec![String::from("sk")]),
-        );
         {
-            let a_name = Names::new(vec![Name::new("M. Pišúta", 0, None, &context)], &context);
-            let b_name = Names::new(
-                vec![Name::new("Milana Pišúta", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
+            assert_linker_eq!("sk"; "M. Pišúta"; "Milana Pišúta"; false; 70.01);
         }
         {
-            let a_name = Names::new(
-                vec![Name::new("Andreja Kostolného", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new("A. Kostolného", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
+            assert_linker_eq!("sk"; "Andreja Kostolného"; "A. Kostolného"; false; 70.01);
         }
         {
-            let a_name = Names::new(
-                vec![Name::new("A. Kostolného", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new(
-                    "Andreja Kostolného Kostolného",
-                    0,
-                    None,
-                    &context,
-                )],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
+            assert_linker_eq!("sk"; "A. Kostolného"; "Ak. Kostolného"; false; 92.0);
         }
         {
-            let a_name = Names::new(
-                vec![Name::new("Ak. Kostolného", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new(
-                    "Andreja Kostolného Kostolného",
-                    0,
-                    None,
-                    &context,
-                )],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), None);
+            assert_linker_eq!("sk"; "Ak. Kostolného"; "Andreja Kostolného Kostolného"; false; 0.0);
         }
         {
-            let a_name = Names::new(
-                vec![Name::new("Andja Kostolného", 0, None, &context)],
-                &context,
-            );
-            let b_name = Names::new(
-                vec![Name::new("Andreja Kostlného Kostolného", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
+            assert_linker_eq!("sk"; "Andja Kostolného"; "Andreja Kostlného Kostolného"; false; 70.01);
         }
     }
+
     #[test]
     fn test_it_linker() {
-        let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let context = Context::new(
-            String::from("it"),
-            None,
-            Tokens::generate(vec![String::from("it")]),
-        );
         {
-            let a_name = Names::new(vec![Name::new("Via Angelo Silvio Novaro", 0, None, &context)], &context);
-            let b_name = Names::new(
-                vec![Name::new("Via A. S. Novaro", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
+            assert_linker_eq!("it"; "Via Angelo Silvio Novaro"; "Via A. S. Novaro"; false; 70.01);
         }
     }
+
     #[test]
     fn test_be_linker() {
-        let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let context = Context::new(
-            String::from("fr"),
-            None,
-            Tokens::generate(vec![String::from("fr")]),
-        );
         {
-            let a_name = Names::new(vec![Name::new("rue de la reine astrid", 0, None, &context)], &context);
-            let b_name = Names::new(
-                vec![Name::new("rue reine astrid", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 91.18)));
+            assert_linker_eq!("fr"; "rue de la reine astrid"; "rue reine astrid"; false; 91.18);
         }
         {
-            let a_name = Names::new(vec![Name::new("grand'place", 0, None, &context)], &context);
-            let b_name = Names::new(
-                vec![Name::new("grand place", 0, None, &context)],
-                &context,
-            );
-            let a = Link::new(1, &a_name);
-            let b = vec![Link::new(2, &b_name)];
-            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
+            assert_linker_eq!("fr"; "grand'place"; "grand place"; false; 70.01);
         }
     }
 }

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -70,7 +70,7 @@ fn is_abbrev(token: &String, token_list: &Vec<String>) -> (bool, Vec<String>) {
     return (false, token_list.to_vec());
 }
 
-// comparing address token list against network token list or network token list
+// compare address token list against network token list or network token list
 // against address token list
 fn check_substring(token_list_one: Vec<String>, mut token_list_two: Vec<String>) -> bool {
     for word in &token_list_one {
@@ -82,7 +82,7 @@ fn check_substring(token_list_one: Vec<String>, mut token_list_two: Vec<String>)
             }
             None => {
                 if token_list_two.len() > 0 {
-                    // return stripped through abbreviated index value
+                    // if abbreviation is found return stripped through abbreviated index value
                     let check_abbreviation: (bool, Vec<String>) = is_abbrev(word, &token_list_two);
                     abbrev_match = check_abbreviation.0;
                     token_list_two = check_abbreviation.1;
@@ -250,7 +250,7 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                     let mut subset_match: bool = true;
                     let address_length: usize = atoks.len();
                     let network_length: usize = ntoks.len();
-                    // if network length is greater than address length then all of address need to be in network
+                    // compare smaller list against larger list. all tokens in the smaller list must be in the larger list
                     if network_length > address_length {
                         // Check if all tokens in the address are present within the network
                         subset_match = check_substring(atoks, ntoks);

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -316,15 +316,22 @@ macro_rules! assert_linker_eq {
         let b_name = Names::new(vec![Name::new($name_b, 0, None, &context)], &context);
         let a = Link::new(1, &a_name);
         let b = vec![Link::new(2, &b_name)];
+        assert_eq!(
+            linker(a, b, $strict_mode),
+            Some(LinkResult::new(2, $expected_return))
+        );
+    };
+}
 
-        if $expected_return == 0.0 {
-            assert_eq!(linker(a, b, $strict_mode), None);
-        } else {
-            assert_eq!(
-                linker(a, b, $strict_mode),
-                Some(LinkResult::new(2, $expected_return))
-            );
-        }
+#[macro_export]
+macro_rules! assert_linker_no_match {
+    ($language:expr; $name_a:expr; $name_b:expr; $strict_mode:expr) => {
+        let context = build_lang_context!($language);
+        let a_name = Names::new(vec![Name::new($name_a, 0, None, &context)], &context);
+        let b_name = Names::new(vec![Name::new($name_b, 0, None, &context)], &context);
+        let a = Link::new(1, &a_name);
+        let b = vec![Link::new(2, &b_name)];
+        assert_eq!(linker(a, b, false), None)
     };
 }
 
@@ -1116,7 +1123,7 @@ mod tests {
             assert_linker_eq!("fr"; "place francois mitterrand"; "place de la republique francois mitterrand"; false; 70.01);
         }
         {
-            assert_linker_eq!("fr"; "place francois mitterrand l'eglise"; "place de la republique francois mitterrand"; false; 0.0);
+            assert_linker_no_match!("fr"; "place francois mitterrand l'eglise"; "place de la republique francois mitterrand"; false);
         }
     }
 
@@ -1143,7 +1150,7 @@ mod tests {
         }
         // "nrta" not consecutive in "nuestra" --> fail
         {
-            assert_linker_eq!("es"; "bo nrta"; "barrio nuestra"; false; 0.0);
+            assert_linker_no_match!("es"; "bo nrta"; "barrio nuestra"; false);
         }
     }
 
@@ -1159,7 +1166,7 @@ mod tests {
             assert_linker_eq!("sk"; "A. Kostolného"; "Ak. Kostolného"; false; 92.0);
         }
         {
-            assert_linker_eq!("sk"; "Ak. Kostolného"; "Andreja Kostolného Kostolného"; false; 0.0);
+            assert_linker_no_match!("sk"; "Ak. Kostolného"; "Andreja Kostolného Kostolného"; false);
         }
         {
             assert_linker_eq!("sk"; "Andja Kostolného"; "Andreja Kostlného Kostolného"; false; 70.01);

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -35,14 +35,33 @@ impl LinkResult {
     }
 }
 
+fn substr_match(pattern: &str, full: &str) -> bool {
+    let mut pattern_chars = pattern.chars();
+    let mut full_chars = full.chars();
+    
+    'outer: for p in &mut pattern_chars {
+        for f in &mut full_chars {
+            if f == p {
+                continue 'outer;
+            }
+        }
+        return false;
+    } 
+    true
+}
+
 // loop through token list. if abbrev is in token list remove token_list items through matching list index value
 fn is_abbrev(abbrev: &String, token_list: &Vec<String>) -> (bool, Vec<String>) {
     for (index, x) in token_list.iter().enumerate() {
-        if x.starts_with(abbrev) {
-            return (true, token_list[index + 1..].to_vec());
-        }
-        if abbrev.starts_with(x) {
-            return (true, token_list[index + 1..].to_vec());
+        if abbrev.chars().nth(0).unwrap() == x.chars().nth(0).unwrap() {
+            let substring_match: bool = substr_match(x, abbrev);
+            if substring_match {
+                return (true, token_list[index + 1..].to_vec());
+            }
+            let substring_match: bool = substr_match(abbrev, x);
+            if substring_match {
+                return (true, token_list[index + 1..].to_vec());
+            }
         }
     }
     return (false, token_list.to_vec());
@@ -1296,6 +1315,37 @@ mod tests {
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 91.86)));
         }
+        {
+            let a_name = Names::new(
+                vec![Name::new("cl f garcia lorca", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new(
+                    "cl federico garcia lorca",
+                    0,
+                    None,
+                    &context,
+                )],
+                &context,
+            );
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
+        }
+            {
+            let a_name = Names::new(
+                vec![Name::new("bo ntra", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("barrio nuestra", 0, None, &context)],
+                &context,
+            );
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
+        }
     }
     #[test]
     fn test_sk_linker() {
@@ -1354,6 +1404,19 @@ mod tests {
             let a = Link::new(1, &a_name);
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, false), None);
+        }
+        {
+            let a_name = Names::new(
+                vec![Name::new("Andja Kostolného", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("Andreja Kostlného Kostolného", 0, None, &context)],
+                &context,
+            );
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
         }
     }
 }

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -310,7 +310,7 @@ macro_rules! build_lang_context {
 
 #[macro_export]
 macro_rules! assert_linker_eq {
-    ($language:expr; $name_a:expr; $name_b:expr; $strict_mode:expr; $expected_return:expr) => {
+    ($language:expr, $name_a:expr, $name_b:expr, $strict_mode:expr, $expected_return:expr) => {
         let context = build_lang_context!($language);
         let a_name = Names::new(vec![Name::new($name_a, 0, None, &context)], &context);
         let b_name = Names::new(vec![Name::new($name_b, 0, None, &context)], &context);
@@ -325,13 +325,13 @@ macro_rules! assert_linker_eq {
 
 #[macro_export]
 macro_rules! assert_linker_no_match {
-    ($language:expr; $name_a:expr; $name_b:expr; $strict_mode:expr) => {
+    ($language:expr, $name_a:expr, $name_b:expr, $strict_mode:expr) => {
         let context = build_lang_context!($language);
         let a_name = Names::new(vec![Name::new($name_a, 0, None, &context)], &context);
         let b_name = Names::new(vec![Name::new($name_b, 0, None, &context)], &context);
         let a = Link::new(1, &a_name);
         let b = vec![Link::new(2, &b_name)];
-        assert_eq!(linker(a, b, false), None)
+        assert_eq!(linker(a, b, $strict_mode), None)
     };
 }
 
@@ -1089,104 +1089,198 @@ mod tests {
     #[test]
     fn test_de_linker() {
         {
-            assert_linker_eq!("de"; "weserstrandstrasse"; "weserstrandstr"; false; 100.0);
+            assert_linker_eq!("de", "weserstrandstrasse", "weserstrandstr", false, 100.0);
         }
         {
-            assert_linker_eq!("de"; "kuferstr"; "kuferstrasse"; false; 100.0);
+            assert_linker_eq!("de", "kuferstr", "kuferstrasse", false, 100.0);
         }
         {
-            assert_linker_eq!("de"; "kuferstraße"; "kuferstrasse"; false; 100.0);
+            assert_linker_eq!("de", "kuferstraße", "kuferstrasse", false, 100.0);
         }
     }
 
     #[test]
     fn test_fr_linker() {
         {
-            assert_linker_eq!("fr"; "saint martin rue de l'eglise"; "rue de l'eglise"; false; 70.01);
+            assert_linker_eq!(
+                "fr",
+                "saint martin rue de l'eglise",
+                "rue de l'eglise",
+                false,
+                70.01
+            );
         }
         {
-            assert_linker_eq!("fr"; "saint martin ruet de l'eglise encore"; "rue de l'eglise"; false; 70.01);
+            assert_linker_eq!(
+                "fr",
+                "saint martin ruet de l'eglise encore",
+                "rue de l'eglise",
+                false,
+                70.01
+            );
         }
         {
-            assert_linker_eq!("fr"; "rue de l'eglise"; "saint martin ruet de l'eglise encore"; false; 70.01);
+            assert_linker_eq!(
+                "fr",
+                "rue de l'eglise",
+                "saint martin ruet de l'eglise encore",
+                false,
+                70.01
+            );
         }
         {
-            assert_linker_eq!("fr"; "rue de l'eglise saint martin"; "rue de l'eglise"; false; 70.01);
+            assert_linker_eq!(
+                "fr",
+                "rue de l'eglise saint martin",
+                "rue de l'eglise",
+                false,
+                70.01
+            );
         }
         {
-            assert_linker_eq!("fr"; "rue de saint martin"; "rue de saint marten"; false; 92.86);
+            assert_linker_eq!(
+                "fr",
+                "rue de saint martin",
+                "rue de saint marten",
+                false,
+                92.86
+            );
         }
         {
-            assert_linker_eq!("fr"; "impasse sourdoire"; "impasse de la sourdoire"; false; 90.63);
+            assert_linker_eq!(
+                "fr",
+                "impasse sourdoire",
+                "impasse de la sourdoire",
+                false,
+                90.63
+            );
         }
         {
-            assert_linker_eq!("fr"; "place francois mitterrand"; "place de la republique francois mitterrand"; false; 70.01);
+            assert_linker_eq!(
+                "fr",
+                "place francois mitterrand",
+                "place de la republique francois mitterrand",
+                false,
+                70.01
+            );
         }
         {
-            assert_linker_no_match!("fr"; "place francois mitterrand l'eglise"; "place de la republique francois mitterrand"; false);
+            assert_linker_no_match!(
+                "fr",
+                "place francois mitterrand l'eglise",
+                "place de la republique francois mitterrand",
+                false
+            );
         }
     }
 
     #[test]
     fn test_es_linker() {
         {
-            assert_linker_eq!("es"; "carrer de ramon casas"; "cl ramon casas"; false; 95.16);
+            assert_linker_eq!(
+                "es",
+                "carrer de ramon casas",
+                "cl ramon casas",
+                false,
+                95.16
+            );
         }
         {
-            assert_linker_eq!("es"; "carrer de l'onze de setembre"; "cl onze de setembre"; false; 92.5);
+            assert_linker_eq!(
+                "es",
+                "carrer de l'onze de setembre",
+                "cl onze de setembre",
+                false,
+                92.5
+            );
         }
         {
-            assert_linker_eq!("es"; "passatge de llessami"; "pj llessami"; false; 94.0);
+            assert_linker_eq!("es", "passatge de llessami", "pj llessami", false, 94.0);
         }
         {
-            assert_linker_eq!("es"; "GV Corts Catalanes"; "Gran Via De Les Corts Catalanes"; false; 91.86);
+            assert_linker_eq!(
+                "es",
+                "GV Corts Catalanes",
+                "Gran Via De Les Corts Catalanes",
+                false,
+                91.86
+            );
         }
         {
-            assert_linker_eq!("es"; "cl f garcia lorca"; "cl federico garcia lorca"; false; 70.01);
+            assert_linker_eq!(
+                "es",
+                "cl f garcia lorca",
+                "cl federico garcia lorca",
+                false,
+                70.01
+            );
         }
         // "nrta" consecutive in "nuestra" --> pass
         {
-            assert_linker_eq!("es"; "bo ntra"; "barrio nuestra"; false; 70.01);
+            assert_linker_eq!("es", "bo ntra", "barrio nuestra", false, 70.01);
         }
         // "nrta" not consecutive in "nuestra" --> fail
         {
-            assert_linker_no_match!("es"; "bo nrta"; "barrio nuestra"; false);
+            assert_linker_no_match!("es", "bo nrta", "barrio nuestra", false);
         }
     }
 
     #[test]
     fn test_sk_linker() {
         {
-            assert_linker_eq!("sk"; "M. Pišúta"; "Milana Pišúta"; false; 70.01);
+            assert_linker_eq!("sk", "M. Pišúta", "Milana Pišúta", false, 70.01);
         }
         {
-            assert_linker_eq!("sk"; "Andreja Kostolného"; "A. Kostolného"; false; 70.01);
+            assert_linker_eq!("sk", "Andreja Kostolného", "A. Kostolného", false, 70.01);
         }
         {
-            assert_linker_eq!("sk"; "A. Kostolného"; "Ak. Kostolného"; false; 92.0);
+            assert_linker_eq!("sk", "A. Kostolného", "Ak. Kostolného", false, 92.0);
         }
         {
-            assert_linker_no_match!("sk"; "Ak. Kostolného"; "Andreja Kostolného Kostolného"; false);
+            assert_linker_no_match!(
+                "sk",
+                "Ak. Kostolného",
+                "Andreja Kostolného Kostolného",
+                false
+            );
         }
         {
-            assert_linker_eq!("sk"; "Andja Kostolného"; "Andreja Kostlného Kostolného"; false; 70.01);
+            assert_linker_eq!(
+                "sk",
+                "Andja Kostolného",
+                "Andreja Kostlného Kostolného",
+                false,
+                70.01
+            );
         }
     }
 
     #[test]
     fn test_it_linker() {
         {
-            assert_linker_eq!("it"; "Via Angelo Silvio Novaro"; "Via A. S. Novaro"; false; 70.01);
+            assert_linker_eq!(
+                "it",
+                "Via Angelo Silvio Novaro",
+                "Via A. S. Novaro",
+                false,
+                70.01
+            );
         }
     }
 
     #[test]
     fn test_be_linker() {
         {
-            assert_linker_eq!("fr"; "rue de la reine astrid"; "rue reine astrid"; false; 91.18);
+            assert_linker_eq!(
+                "fr",
+                "rue de la reine astrid",
+                "rue reine astrid",
+                false,
+                91.18
+            );
         }
         {
-            assert_linker_eq!("fr"; "grand'place"; "grand place"; false; 70.01);
+            assert_linker_eq!("fr", "grand'place", "grand place", false, 70.01);
         }
     }
 }

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -257,7 +257,7 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                     if subset_match {
                         // subset match successful
                         score = 70.01;
-                    }
+                    };
                 }
 
                 if score > potential.maxscore {
@@ -308,7 +308,7 @@ mod tests {
     #[test]
     fn test_de_linker() {
         let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let mut regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
+        let regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
         let context = Context::new(
             String::from("de"),
             None,
@@ -1090,7 +1090,7 @@ mod tests {
     #[test]
     fn test_fr_linker() {
         let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let mut regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
+        let regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
         let context = Context::new(
             String::from("fr"),
             None,
@@ -1236,7 +1236,7 @@ mod tests {
     #[test]
     fn test_es_linker() {
         let mut tokens: HashMap<String, ParsedToken> = HashMap::new();
-        let mut regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
+        let regex_tokens: HashMap<String, ParsedToken> = HashMap::new();
         let context = Context::new(
             String::from("es"),
             None,

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -1329,5 +1329,31 @@ mod tests {
             let b = vec![Link::new(2, &b_name)];
             assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
         }
+        {
+            let a_name = Names::new(
+                vec![Name::new("A. Kostolného", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("Andreja Kostolného Kostolného", 0, None, &context)],
+                &context,
+            );
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, false), Some(LinkResult::new(2, 70.01)));
+        }
+        {
+            let a_name = Names::new(
+                vec![Name::new("Ak. Kostolného", 0, None, &context)],
+                &context,
+            );
+            let b_name = Names::new(
+                vec![Name::new("Andreja Kostolného Kostolného", 0, None, &context)],
+                &context,
+            );
+            let a = Link::new(1, &a_name);
+            let b = vec![Link::new(2, &b_name)];
+            assert_eq!(linker(a, b, false), None);
+        }
     }
 }

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -311,8 +311,6 @@ macro_rules! build_lang_context {
 #[macro_export]
 macro_rules! assert_linker_eq {
     ($language:expr; $name_a:expr; $name_b:expr; $strict_mode:expr; $expected_return:expr) => {
-        println!("{}", $name_a);
-        println!("{}", $name_b);
         let context = build_lang_context!($language);
         let a_name = Names::new(vec![Name::new($name_a, 0, None, &context)], &context);
         let b_name = Names::new(vec![Name::new($name_b, 0, None, &context)], &context);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@mapbox/carmen": "27.2.0",
     "@mapbox/eslint-config-geocoding": "^2.0.2",
-    "@mapbox/geocoder-abbreviations": "4.6.0",
+    "@mapbox/geocoder-abbreviations": "git+https://github.com/mapbox/geocoder-abbreviations.git#28a25062c4ea7e90f453952a60daf7775da0e13e",
     "@mapbox/geojson-area": "^0.2.2",
     "@mapbox/mbtiles": "^0.11.0",
     "@mapbox/tile-cover": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "coverage-upload": "coveralls < ./coverage.lcov",
     "pretest": "test/pretest.js",
     "test": "tape test/*.test.js && cd native && cargo test --release",
-    "cargo_all": "cd native && cargo test --release",
-    "cargo_one": "cd native && cargo test --release -- --exact util::linker::tests::test_fr_linker -- --nocapture",
+    "cargo": "cd native && cargo test --release",
+    "cargo_individual": "cd native && cargo test --release -- --exact $npm_config_test -- --nocapture",
     "format": "cd native/ && cargo fmt -- --check"
   },
   "binary": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "coverage-upload": "coveralls < ./coverage.lcov",
     "pretest": "test/pretest.js",
     "test": "tape test/*.test.js && cd native && cargo test --release",
+    "cargo_all": "cd native && cargo test --release",
+    "cargo_one": "cd native && cargo test --release -- --exact util::linker::tests::test_fr_linker -- --nocapture",
     "format": "cd native/ && cargo fmt -- --check"
   },
   "binary": {
@@ -30,7 +32,7 @@
   "dependencies": {
     "@mapbox/carmen": "27.2.0",
     "@mapbox/eslint-config-geocoding": "^2.0.2",
-    "@mapbox/geocoder-abbreviations": "git+https://github.com/mapbox/geocoder-abbreviations.git#54da997e73d8ddf15b32e03bc7cf5faa7b6c225e",
+    "@mapbox/geocoder-abbreviations": "4.6.0",
     "@mapbox/geojson-area": "^0.2.2",
     "@mapbox/mbtiles": "^0.11.0",
     "@mapbox/tile-cover": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@mapbox/carmen": "27.2.0",
     "@mapbox/eslint-config-geocoding": "^2.0.2",
-    "@mapbox/geocoder-abbreviations": "git+https://github.com/mapbox/geocoder-abbreviations.git#28a25062c4ea7e90f453952a60daf7775da0e13e",
+    "@mapbox/geocoder-abbreviations": "4.6.0",
     "@mapbox/geojson-area": "^0.2.2",
     "@mapbox/mbtiles": "^0.11.0",
     "@mapbox/tile-cover": "^3.0.2",

--- a/test/test-de.test.js
+++ b/test/test-de.test.js
@@ -66,17 +66,17 @@ test('create index from geojson', (t) => {
 });
 
 test('query from new index', (t) => {
-    exec(`${__dirname}/../node_modules/.bin/carmen --query "5 Haupt Strasse" ${carmenIndex} --tokens ${abbr} | grep "1.00 5 Haupt Strasse" | tr -d '\n'`, (err, res) => {
+    exec(`${__dirname}/../node_modules/.bin/carmen --query "5 Haupt Strasse" ${carmenIndex} --tokens ${abbr} | grep "1.00 5 Hauptstrasse" | tr -d '\n'`, (err, res) => {
         t.ifError(err);
-        t.equal(res.split(',')[0], '- 1.00 5 Haupt Strasse', 'Finds 5 Haupt Strasse');
+        t.equal(res.split(',')[0], '- 1.00 5 Hauptstrasse', 'Finds 5 Hauptstrasse');
         t.end();
     });
 });
 
 test('query for new index', (t) => {
-    exec(`${__dirname}/../node_modules/.bin/carmen --query "5 Hauptstrasse" ${carmenIndex} --tokens ${abbr} | grep "1.00 5 Haupt Strasse" | tr -d '\n'`, (err, res) => {
+    exec(`${__dirname}/../node_modules/.bin/carmen --query "5 Hauptstrasse" ${carmenIndex} --tokens ${abbr} | grep "1.00 5 Hauptstrasse" | tr -d '\n'`, (err, res) => {
         t.ifError(err);
-        t.equal(res.split(',')[0], '- 1.00 5 Haupt Strasse', 'Finds 5 "Hauptstrasse" as "Haupt Strasse"');
+        t.equal(res.split(',')[0], '- 1.00 5 Hauptstrasse', 'Finds 5 "Hauptstrasse" as "Hauptstrasse"');
         t.end();
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,10 +190,9 @@
   resolved "https://registry.yarnpkg.com/@mapbox/eslint-config-geocoding/-/eslint-config-geocoding-2.0.2.tgz#0dab7b9cc7827f4426dcff707e06e6b7be134136"
   integrity sha512-SZRaSgVLYJuTMQ/N2bb+4gdsQcuP5p6zboiIAi55l0d82LMMx3YL1RUqxOSRkJVU7Y4oO1+AYkJMLLcSbYgXAQ==
 
-"@mapbox/geocoder-abbreviations@4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/geocoder-abbreviations/-/geocoder-abbreviations-4.5.0.tgz#71c37c9b0c577400f331152ac7b50a6a5a2cdf37"
-  integrity sha512-igO5vsbBnvKBwFn25rY0YhTRiT0uX0mP+3xaBwMq3NrW/iWUbc93I7Q21jf6rLssSpRoQ38uviTW68EF4Duwpg==
+"@mapbox/geocoder-abbreviations@git+https://github.com/mapbox/geocoder-abbreviations.git#28a25062c4ea7e90f453952a60daf7775da0e13e":
+  version "4.6.0"
+  resolved "git+https://github.com/mapbox/geocoder-abbreviations.git#28a25062c4ea7e90f453952a60daf7775da0e13e"
   dependencies:
     tape "^4.6.3"
     union-find "^1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,9 +190,10 @@
   resolved "https://registry.yarnpkg.com/@mapbox/eslint-config-geocoding/-/eslint-config-geocoding-2.0.2.tgz#0dab7b9cc7827f4426dcff707e06e6b7be134136"
   integrity sha512-SZRaSgVLYJuTMQ/N2bb+4gdsQcuP5p6zboiIAi55l0d82LMMx3YL1RUqxOSRkJVU7Y4oO1+AYkJMLLcSbYgXAQ==
 
-"@mapbox/geocoder-abbreviations@git+https://github.com/mapbox/geocoder-abbreviations.git#28a25062c4ea7e90f453952a60daf7775da0e13e":
+"@mapbox/geocoder-abbreviations@4.6.0":
   version "4.6.0"
-  resolved "git+https://github.com/mapbox/geocoder-abbreviations.git#28a25062c4ea7e90f453952a60daf7775da0e13e"
+  resolved "https://registry.yarnpkg.com/@mapbox/geocoder-abbreviations/-/geocoder-abbreviations-4.6.0.tgz#05a479e0e1086790154210d1d2a58d8bdb333128"
+  integrity sha512-/IzWWKMRP+yQ3Ejg09OIeWirVx+NNnScRLADeogIK4sgNm46Y9pVpjGx9S0ykGddnBP70Kxa8UIgQBylNGH/mQ==
   dependencies:
     tape "^4.6.3"
     union-find "^1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,10 +190,10 @@
   resolved "https://registry.yarnpkg.com/@mapbox/eslint-config-geocoding/-/eslint-config-geocoding-2.0.2.tgz#0dab7b9cc7827f4426dcff707e06e6b7be134136"
   integrity sha512-SZRaSgVLYJuTMQ/N2bb+4gdsQcuP5p6zboiIAi55l0d82LMMx3YL1RUqxOSRkJVU7Y4oO1+AYkJMLLcSbYgXAQ==
 
-"@mapbox/geocoder-abbreviations@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/geocoder-abbreviations/-/geocoder-abbreviations-4.6.0.tgz#05a479e0e1086790154210d1d2a58d8bdb333128"
-  integrity sha512-/IzWWKMRP+yQ3Ejg09OIeWirVx+NNnScRLADeogIK4sgNm46Y9pVpjGx9S0ykGddnBP70Kxa8UIgQBylNGH/mQ==
+"@mapbox/geocoder-abbreviations@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/geocoder-abbreviations/-/geocoder-abbreviations-4.5.0.tgz#71c37c9b0c577400f331152ac7b50a6a5a2cdf37"
+  integrity sha512-igO5vsbBnvKBwFn25rY0YhTRiT0uX0mP+3xaBwMq3NrW/iWUbc93I7Q21jf6rLssSpRoQ38uviTW68EF4Duwpg==
   dependencies:
     tape "^4.6.3"
     union-find "^1.0.2"


### PR DESCRIPTION
In a [previous PR](https://github.com/mapbox/pt2itp/pull/562) we added logic to add the ability to link based on a subset of tokens. This PR extends that, adding the ability to match on abbreviations.

Examples have been added in the test suite:
- M. Pišúta will match with Milana Pišúta
- A. Kostolného will match with Andreja Kostolného Kostolného
- Bo Ntra will match with Barrio Nuestra

Also added a bunch of tests and a note in the README about how to run Cargo tests.

Notes on address orphan differences for various EU countries: https://github.com/mapbox/mapbox-places-address/issues/1196

cc: @mapbox/search-addresses @flatwhite0928 