### PR TITLE
Ignore lookahead token replacement errors Ireland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## Version History
 
+### v28.7.7
+- :bug: Add support to skip negative lookahead for Ireland
+- :arrow_up: Upgrade geocoder-abbreviations to 4.6.6 to include token additions for Latvia and Bulgaria. 
+
 ### v28.7.6
 - :bug: Add support to skip negative lookahead for Canada
 - :arrow_up: Upgrade geocoder-abbreviations to 4.6.4. 

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -86,7 +86,7 @@ impl Tokens {
     pub fn process(&self, text: &String, country: &String) -> Vec<Tokenized> {
         let mut tokens = self.tokenize(&text);
         let mut normalized_full_text = diacritics(&text.to_lowercase());
-        let skip_regex_list = vec![String::from("US"), String::from("GB"), String::from("CA")]; // add countries that are using english tokens here to get around lookahead token replacement errors
+        let skip_regex_list = vec![String::from("US"), String::from("GB"), String::from("CA"), String::from("IE")]; // add countries that are using english tokens here to get around lookahead token replacement errors
 
         let mut tokenized: Vec<Tokenized> = Vec::with_capacity(tokens.len());
         if !country.is_empty() && !skip_regex_list.contains(&country) {

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -86,7 +86,12 @@ impl Tokens {
     pub fn process(&self, text: &String, country: &String) -> Vec<Tokenized> {
         let mut tokens = self.tokenize(&text);
         let mut normalized_full_text = diacritics(&text.to_lowercase());
-        let skip_regex_list = vec![String::from("US"), String::from("GB"), String::from("CA"), String::from("IE")]; // add countries that are using english tokens here to get around lookahead token replacement errors
+        let skip_regex_list = vec![
+            String::from("US"),
+            String::from("GB"),
+            String::from("CA"),
+            String::from("IE"),
+        ]; // add countries that are using english tokens here to get around lookahead token replacement errors
 
         let mut tokenized: Vec<Tokenized> = Vec::with_capacity(tokens.len());
         if !country.is_empty() && !skip_regex_list.contains(&country) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@mapbox/carmen": "27.2.0",
     "@mapbox/eslint-config-geocoding": "^2.0.2",
-    "@mapbox/geocoder-abbreviations": "4.6.4",
+    "@mapbox/geocoder-abbreviations": "4.6.6",
     "@mapbox/geojson-area": "^0.2.2",
     "@mapbox/mbtiles": "^0.11.0",
     "@mapbox/tile-cover": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,10 +190,10 @@
   resolved "https://registry.yarnpkg.com/@mapbox/eslint-config-geocoding/-/eslint-config-geocoding-2.0.2.tgz#0dab7b9cc7827f4426dcff707e06e6b7be134136"
   integrity sha512-SZRaSgVLYJuTMQ/N2bb+4gdsQcuP5p6zboiIAi55l0d82LMMx3YL1RUqxOSRkJVU7Y4oO1+AYkJMLLcSbYgXAQ==
 
-"@mapbox/geocoder-abbreviations@4.6.4":
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/@mapbox/geocoder-abbreviations/-/geocoder-abbreviations-4.6.4.tgz#2f1703e089d751e9ef4a9fdf7d2aba488fc924fe"
-  integrity sha512-ObgORWqEI/vtrlHknHv2LN3ZbJGATUTOJ2mjuqKMe/GqAUpC2hELqNnwhFHLEmmvxk746/N0jL/uNHyqYCNgVw==
+"@mapbox/geocoder-abbreviations@4.6.6":
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/@mapbox/geocoder-abbreviations/-/geocoder-abbreviations-4.6.6.tgz#9e5c8a6ced4e39d8ab40eb0bfa2993f5195f3b2c"
+  integrity sha512-wW+lfD2tWw4x5/26wSNQGyRWuMMzUqy9fnhbecqY8gM/gGaqopTvgC5vdlRbB/Zatgk41WXh6UG7tg+ERWfVew==
   dependencies:
     tape "^4.6.3"
     union-find "^1.0.2"


### PR DESCRIPTION
Skip look ahead regex for Ireland.

Upgrade the version of geocoder-abbreviations to pull in tokens for Latvia and Bulgaria.