### PR TITLE
Update geocoder-abbreviations version in Rust

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1.0"
 serde = "1.0"
 fancy-regex = "0.1.0"
 memchr = "2.0.2"
-geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", tag = "v4.6.4" }
+geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", tag = "v4.6.8" }
 unicode-segmentation = "1.3.0"
 kodama = "0.1"
 


### PR DESCRIPTION
Update to version 4.6.8 of geocoder-abbreviations