### PR TITLE
Bump version to include Sweden changes

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "geocoder-abbreviations"
 version = "0.1.0"
-source = "git+https://github.com/mapbox/geocoder-abbreviations?tag=v4.6.4#129527073e73e154c3ceb64d0b9723cb804b293f"
+source = "git+https://github.com/mapbox/geocoder-abbreviations?rev=472f3c8d0d4dd7c3af1b62999fe6f9c5fd0d99b3#472f3c8d0d4dd7c3af1b62999fe6f9c5fd0d99b3"
 dependencies = [
  "alphanumeric-sort",
  "fancy-regex",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1.0"
 serde = "1.0"
 fancy-regex = "0.1.0"
 memchr = "2.0.2"
-geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", tag = "v4.6.8" }
+geocoder-abbreviations = { git = "https://github.com/mapbox/geocoder-abbreviations", rev = "472f3c8d0d4dd7c3af1b62999fe6f9c5fd0d99b3" }
 unicode-segmentation = "1.3.0"
 kodama = "0.1"
 

--- a/native/src/text/replace.rs
+++ b/native/src/text/replace.rs
@@ -197,6 +197,13 @@ mod tests {
             "wilhelm str 3"
         );
         assert_eq!(
+            Regex::new(r"([^ ]+)(gatan)")
+                .unwrap()
+                .replace_all("rudbecksgatan 3", "$1")
+                .unwrap(),
+            "rudbecks 3"
+        );
+        assert_eq!(
             Regex::new(r"(foo) (bar)")
                 .unwrap()
                 .replace_all("foo bar", "$2 $1")

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -99,11 +99,7 @@ impl Tokens {
             for (regex_string, v) in self.regex_tokens.iter() {
                 let re = Regex::new(&format!(r"{}", regex_string)).unwrap();
                 let canonical: &str = &*v.canonical; // convert from std::string::String -> &str
-                println!("tokens regex_string {:?}", regex_string);
-                println!("tokens normalized_full_text {:?}", &normalized_full_text);
-                println!("tokens canonical {:?}", canonical);
                 normalized_full_text = re.replace_all(&normalized_full_text, canonical).to_string();
-                println!("tokens uPDATED normalized_full_text {:?}", normalized_full_text);
                 tokens = self.tokenize(&normalized_full_text);
             }
             for (multi_string, v) in self.multi_tokens.iter() {
@@ -139,7 +135,6 @@ impl Tokens {
     ///
     fn tokenize(&self, text: &String) -> Vec<String> {
         let text = text.trim();
-        println!("address text {:?}", text);
 
         lazy_static! {
             static ref UP: Regex = Regex::new(r"[\^]+").unwrap();
@@ -172,7 +167,6 @@ impl Tokens {
         normalized = APOS_PUNC.replace_all(normalized.as_str(), "").to_string();
         normalized = SPACEPUNC.replace_all(normalized.as_str(), " ").to_string();
         normalized = SPACE.replace_all(normalized.as_str(), " ").to_string();
-        println!("address normalized {:?}", normalized);
 
         let tokens: Vec<String> = normalized
             .split(" ")

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -85,6 +85,7 @@ impl Tokens {
 
     pub fn process(&self, text: &String, country: &String) -> Vec<Tokenized> {
         let mut tokens = self.tokenize(&text);
+
         let mut normalized_full_text = diacritics(&text.to_lowercase());
         let skip_regex_list = vec![
             String::from("US"),
@@ -98,7 +99,11 @@ impl Tokens {
             for (regex_string, v) in self.regex_tokens.iter() {
                 let re = Regex::new(&format!(r"{}", regex_string)).unwrap();
                 let canonical: &str = &*v.canonical; // convert from std::string::String -> &str
+                println!("tokens regex_string {:?}", regex_string);
+                println!("tokens normalized_full_text {:?}", &normalized_full_text);
+                println!("tokens canonical {:?}", canonical);
                 normalized_full_text = re.replace_all(&normalized_full_text, canonical).to_string();
+                println!("tokens uPDATED normalized_full_text {:?}", normalized_full_text);
                 tokens = self.tokenize(&normalized_full_text);
             }
             for (multi_string, v) in self.multi_tokens.iter() {
@@ -134,6 +139,7 @@ impl Tokens {
     ///
     fn tokenize(&self, text: &String) -> Vec<String> {
         let text = text.trim();
+        println!("address text {:?}", text);
 
         lazy_static! {
             static ref UP: Regex = Regex::new(r"[\^]+").unwrap();
@@ -166,6 +172,7 @@ impl Tokens {
         normalized = APOS_PUNC.replace_all(normalized.as_str(), "").to_string();
         normalized = SPACEPUNC.replace_all(normalized.as_str(), " ").to_string();
         normalized = SPACE.replace_all(normalized.as_str(), " ").to_string();
+        println!("address normalized {:?}", normalized);
 
         let tokens: Vec<String> = normalized
             .split(" ")

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -302,7 +302,6 @@ impl Name {
             display = titlecase(&display, &context);
         }
         let tokenized = context.tokens.process(&display, &context.country);
-        println!("tokenized {:?}", tokenized);
 
 
         if context.country == String::from("US") || context.country == String::from("CA") {

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -303,7 +303,6 @@ impl Name {
         }
         let tokenized = context.tokens.process(&display, &context.country);
 
-
         if context.country == String::from("US") || context.country == String::from("CA") {
             display = text::str_remove_octo(&display);
             // penalize less desireable street names

--- a/native/src/types/name.rs
+++ b/native/src/types/name.rs
@@ -302,6 +302,8 @@ impl Name {
             display = titlecase(&display, &context);
         }
         let tokenized = context.tokens.process(&display, &context.country);
+        println!("tokenized {:?}", tokenized);
+
 
         if context.country == String::from("US") || context.country == String::from("CA") {
             display = text::str_remove_octo(&display);

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -119,22 +119,15 @@ fn check_substring(token_list_one: Vec<String>, mut token_list_two: Vec<String>)
 /// reasons.
 ///
 pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<LinkResult> {
-    println!("primary {:?}", primary);
-    println!("potentials {:?}", potentials);
     for name in &primary.names.names {
         let tokenized = name.tokenized_string();
         let tokenless = name.tokenless_string();
-        println!("name {:?}", name);
-        println!("tokenized {:?}", tokenized);
-        println!("tokenless {:?}", tokenless);
 
         for potential in potentials.iter_mut() {
             'outer: for potential_name in &potential.names.names {
                 // Ensure exact matches are always returned before potential short-circuits
                 //
                 // N Main St == N Main St
-                println!("name.tokenized {:?}", name.tokenized);
-                println!("potential_name.tokenized {:?}", potential_name.tokenized);
                 if name.tokenized == potential_name.tokenized {
                     return Some(LinkResult::new(potential.id, 100.0));
                 }
@@ -186,8 +179,6 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
 
                 // Use a weighted average w/ the tokenless dist score if possible
                 let mut lev_score: Option<f64> = None;
-                println!("tokenless {:?}", tokenless);
-                println!("potential_tokenless {:?}", potential_tokenless);
 
 
                 if tokenless.len() > 0 && potential_tokenless.len() > 0 {
@@ -234,7 +225,6 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                         lev_score = Some(distance(&tokenized, &potential_tokenized) as f64);
                     }
                 }
-                println!("lev_score {:?}", lev_score);
 
 
                 let mut score = 100.0
@@ -243,12 +233,6 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                         * 100.0);
 
                 // check for subset matches, overriding scores below the matching criteria
-                println!("score {:?}", score);
-                println!("lev_score {:?}", lev_score);
-                println!("potential_tokenized.len() {:?}", potential_tokenized.len() as f64);
-                println!("tokenized.len() {:?}", tokenized.len() as f64);
-                println!("tokenized {:?}", tokenized);
-                println!("potential_tokenized {:?}", potential_tokenized);
                 if score <= 70.0
                     && tokenized.len() >= 2
                     && potential_tokenized.len() >= 2

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -226,7 +226,6 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                     }
                 }
 
-
                 let mut score = 100.0
                     - (((2.0 * lev_score.unwrap())
                         / (potential_tokenized.len() as f64 + tokenized.len() as f64))

--- a/native/src/util/linker.rs
+++ b/native/src/util/linker.rs
@@ -180,7 +180,6 @@ pub fn linker(primary: Link, mut potentials: Vec<Link>, strict: bool) -> Option<
                 // Use a weighted average w/ the tokenless dist score if possible
                 let mut lev_score: Option<f64> = None;
 
-
                 if tokenless.len() > 0 && potential_tokenless.len() > 0 {
                     lev_score = Some(
                         (0.25 * distance(&tokenized, &potential_tokenized) as f64)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "pretest": "test/pretest.js",
     "test": "tape test/*.test.js && cd native && cargo test --release",
     "cargo": "cd native && cargo test --release",
-    "cargo_individual": "cd native && cargo test --release -- --exact $npm_config_test -- --nocapture",
+    "cargo_individual": "cd native && cargo test --release -- --exact util::linker::tests::test_se_linker -- --nocapture",
     "format": "cd native/ && cargo fmt -- --check"
   },
   "binary": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "pretest": "test/pretest.js",
     "test": "tape test/*.test.js && cd native && cargo test --release",
     "cargo": "cd native && cargo test --release",
-    "cargo_individual": "cd native && cargo test --release -- --exact util::linker::tests::test_se_linker -- --nocapture",
+    "cargo_individual": "cd native && cargo test --release -- --exact $npm_config_test -- --nocapture",
     "format": "cd native/ && cargo fmt -- --check"
   },
   "binary": {


### PR DESCRIPTION
Update geocoder-abbreviation version to include changes in Sweden token. Add tests for Sweden addresses. 