### PR TITLE
Add support to skip negative lookahead for Singapore, Iceland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ## Version History
 
+### v28.8.0
+- :bug: Add support to skip negative lookahead for Singapore, Iceland.
+
 ### v28.7.9
 - :arrow_up: Upgrade geocoder-abbreviations to 4.6.9 to include token fix for Sweden. 
 

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -92,6 +92,8 @@ impl Tokens {
             String::from("GB"),
             String::from("CA"),
             String::from("IE"),
+            String::from("IS"),
+            String::from("SG"),
         ]; // add countries that are using english tokens here to get around lookahead token replacement errors
 
         let mut tokenized: Vec<Tokenized> = Vec::with_capacity(tokens.len());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/pt2itp",
-  "version": "28.7.9",
+  "version": "28.8.0",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",


### PR DESCRIPTION
To update Singapore, Iceland indexes, add Singapore, Iceland to list that support to skip negative lookahead, so that EN language code can be applied.