### PR TITLE
Skip negative lookahead for AU, NZ and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ## Version History
 
+### v28.8.2
+- :bug: Add support to skip negative lookahead for Australia and New Zealand.
+
 ### v28.8.0
 - :bug: Add support to skip negative lookahead for Singapore, Iceland.
 

--- a/native/src/text/tokens.rs
+++ b/native/src/text/tokens.rs
@@ -95,6 +95,8 @@ impl Tokens {
             String::from("IS"),
             String::from("SG"),
             String::from("FI"),
+            String::from("AU"),
+            String::from("NZ"),
         ]; // add countries that are using english tokens here to get around lookahead token replacement errors
 
         let mut tokenized: Vec<Tokenized> = Vec::with_capacity(tokens.len());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/pt2itp",
-  "version": "28.8.1",
+  "version": "28.8.2",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",


### PR DESCRIPTION
### Background
https://github.com/mapbox/mapbox-places-address/pull/1312
This PR is going to skip negative lookahead for AU, NZ, because they use EN tokens, and negative lookahead is just for US. Bump the version of pt2itp.