### PR TITLE
Build MacOS binary on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,13 @@ jobs:
     build-mac:
         macos:
             xcode: 12.2
-            steps:
-                - run:
-                    name: "check node version"
-                    command: node -v
-                - run:
-                    name: "check node location"
-                    command: which node
+        steps:
+            - run:
+                name: "check node version"
+                command: node -v
+            - run:
+                name: "check node location"
+                command: which node
     build:
         docker:
             - image: cimg/node:14.19.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,11 @@ jobs:
             xcode: 12.2
             steps:
                 - run:
-                    name: "foo"
-                    command: node -v && which node
+                    name: "check node version"
+                    command: node -v
+                - run:
+                    name: "check node location"
+                    command: which node
     build:
         docker:
             - image: cimg/node:14.19.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,18 @@ jobs:
                 command: which node
             - checkout
             - run:
+                name: "Install postgres"
+                command: brew install postgres
+            - run:
+                name: "Install postgis"
+                command: brew install postgis
+            - run:
+                name: "Start postgres"
+                command: pg_ctl -D /usr/local/var/postgres start
+            - run:
+                name: "Create postgres user"
+                command: /usr/local/opt/postgres/bin/createuser -s postgres
+            - run:
                 name: "Download Rust"
                 command: curl https://sh.rustup.rs -sSf > /tmp/rustup.sh
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,6 @@ jobs:
                 name: "Install Neon"
                 command: "yarn global add neon-cli@0.7.1"
             - run:
-                name: "Neon clean"
-                command: neon clean
-            - run:
                 name: "Neon build"
                 command: neon build --release
     build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ jobs:
             - run:
                 name: "Neon build"
                 command: neon build --release
+            - run:
+                name: "Yarn test"
+                command: yarn test
     build:
         docker:
             - image: cimg/node:14.19.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,8 @@ jobs:
                 name: "yarn install"
                 command: yarn install --ignore-scripts
             - run:
-                name: "check ls"
-                command: ls -la
+                name: "check debug"
+                command: echo $PATH
             - run:
                 name: "Install Neon"
                 command: "yarn global add neon-cli@0.7.1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,9 @@ jobs:
             - run:
                 name: "Yarn Coverage-Upload"
                 command: "yarn run coverage-upload"
+            - run:
+                name: "Publish Release"
+                command: ./scripts/publish.sh
     build:
         docker:
             - image: cimg/node:14.19.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ orbs:
 
 jobs:
     build-mac:
+        resource_class: xlarge
         macos:
             xcode: 12.5.1
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 jobs:
     build-mac:
-        resource_class: xlarge
+        resource_class: large
         macos:
             xcode: 12.5.1
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,8 @@ jobs:
         macos:
             xcode: 12.2
         steps:
+            - node/install:
+                node-version: "14.19.1"
             - run:
                 name: "check node version"
                 command: node -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,11 +29,14 @@ jobs:
                 name: "Source environment"
                 command: source "$HOME/.cargo/env"
             - run:
-                name: "Install Rust"
-                command: sh /tmp/rustup.sh -y
-            - run:
                 name: "yarn install"
                 command: yarn install --ignore-scripts
+            - run:
+                name: "Neon clean"
+                command: neon clean
+            - run:
+                name: "Neon build"
+                command: neon build --release
     build:
         docker:
             - image: cimg/node:14.19.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ jobs:
             xcode: 12.2
         steps:
             - node/install:
-                install-yarn: true
                 node-version: "14.19.1"
             - run:
                 name: "check node version"
@@ -18,8 +17,23 @@ jobs:
                 name: "check node location"
                 command: which node
             - run:
-                name: "yarn build and install"
-                command: yarn build && yarn install
+                name: "Download Rust"
+                command: curl https://sh.rustup.rs -sSf > /tmp/rustup.sh
+            - run:
+                name: "Install Rust"
+                command: sh /tmp/rustup.sh -y
+            - run:
+                name: "Setup path"
+                command: export PATH="$HOME/.cargo/bin:$PATH"
+            - run:
+                name: "Source environment"
+                command: source "$HOME/.cargo/env"
+            - run:
+                name: "Install Rust"
+                command: sh /tmp/rustup.sh -y
+            - run:
+                name: "yarn install"
+                command: yarn install --ignore-scripts
     build:
         docker:
             - image: cimg/node:14.19.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             - checkout
             - run:
                 name: "install mbx-ci"
-                command: "curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci && chmod 755 ./mbx-ci"
+                command: "curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-darwin-amd64 > mbx-ci && chmod 755 ./mbx-ci"
             - run:
                 name: "Install postgres"
                 command: brew install postgres

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
     build-mac:
         macos:
-            xcode: 12.2
+            xcode: 12.5.1
         steps:
             - node/install:
                 node-version: "14.19.1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,3 +146,9 @@ workflows:
                 filters:
                     tags:
                         only: /.*/             
+    build:
+        jobs:
+            - build:
+                filters:
+                    tags:
+                        only: /.*/             

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
                 name: "yarn install"
                 command: yarn install --ignore-scripts
             - run:
+                name: "Install Neon"
+                command: "yarn global add neon-cli@0.7.1"
+            - run:
                 name: "Neon clean"
                 command: neon clean
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,13 @@
 version: 2
 
 jobs:
+    build-mac:
+        macos:
+            xcode: 12.2
+            steps:
+                - run:
+                    name: "foo"
+                    command: node -v && which node
     build:
         docker:
             - image: cimg/node:14.19.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ jobs:
     build-mac:
         macos:
             xcode: 12.5.1
+        environment:
+          MBX_CI_DOMAIN: o619qyc20d.execute-api.us-east-1.amazonaws.com
         steps:
             - node/install:
                 node-version: "14.19.1"
@@ -56,25 +58,6 @@ jobs:
             - run:
                 name: "Neon build"
                 command: neon build --release
-            - run:
-                name: "Cargo Test"
-                command: cd native/ && cargo test --release
-            - run:
-                name: "Cargo Format"
-                command: rustup component add rustfmt && cd native/ && cargo fmt -- --check
-            - run:
-                name: "Yarn Lint"
-                command: "yarn run lint"
-            - run:
-                name: "Yarn PreTest"
-                command: "yarn run pretest"
-            - run:
-                name: "Yarn Coverage"
-                command: "yarn run coverage"
-                no_output_timeout: "12m"
-            - run:
-                name: "Yarn Coverage-Upload"
-                command: "yarn run coverage-upload"
             - run:
                 name: "Publish Release"
                 command: ./scripts/publish.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ jobs:
                 command: which node
             - checkout
             - run:
+                name: "install mbx-ci"
+                command: "curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-linux-amd64 > mbx-ci && chmod 755 ./mbx-ci"
+            - run:
                 name: "Install postgres"
                 command: brew install postgres
             - run:
@@ -54,8 +57,24 @@ jobs:
                 name: "Neon build"
                 command: neon build --release
             - run:
-                name: "Yarn test"
-                command: yarn test
+                name: "Cargo Test"
+                command: cd native/ && cargo test --release
+            - run:
+                name: "Cargo Format"
+                command: rustup component add rustfmt && cd native/ && cargo fmt -- --check
+            - run:
+                name: "Yarn Lint"
+                command: "yarn run lint"
+            - run:
+                name: "Yarn PreTest"
+                command: "yarn run pretest"
+            - run:
+                name: "Yarn Coverage"
+                command: "yarn run coverage"
+                no_output_timeout: "12m"
+            - run:
+                name: "Yarn Coverage-Upload"
+                command: "yarn run coverage-upload"
     build:
         docker:
             - image: cimg/node:14.19.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,12 +73,6 @@ jobs:
 
 workflows:
     version: 2
-    build:
-        jobs:
-            - build:
-                filters:
-                    tags:
-                        only: /.*/             
     build-mac:
         jobs:
             - build-mac:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,3 +79,9 @@ workflows:
                 filters:
                     tags:
                         only: /.*/             
+    build-mac:
+        jobs:
+            - build-mac:
+                filters:
+                    tags:
+                        only: /.*/             

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
                 command: source "$HOME/.cargo/env"
             - run:
                 name: "yarn install"
-                command: yarn install --ignore-scripts
+                command: yarn install
             - run:
                 name: "check debug"
                 command: echo $PATH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
             - run:
                 name: "check node location"
                 command: which node
+            - checkout
             - run:
                 name: "Download Rust"
                 command: curl https://sh.rustup.rs -sSf > /tmp/rustup.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
                 name: "yarn install"
                 command: yarn install --ignore-scripts
             - run:
+                name: "check ls"
+                command: ls -la
+            - run:
                 name: "Install Neon"
                 command: "yarn global add neon-cli@0.7.1"
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,25 @@ jobs:
                 name: "Neon build"
                 command: neon build --release
             - run:
+                name: "Cargo Test"
+                command: cd native/ && cargo test --release
+            - run:
+                name: "Cargo Format"
+                command: rustup component add rustfmt && cd native/ && cargo fmt -- --check
+            - run:
+                name: "Yarn Lint"
+                command: "yarn run lint"
+            - run:
+                name: "Yarn PreTest"
+                command: "yarn run pretest"
+            - run:
+                name: "Yarn Coverage"
+                command: "yarn run coverage"
+                no_output_timeout: "12m"
+            - run:
+                name: "Yarn Coverage-Upload"
+                command: "yarn run coverage-upload"
+            - run:
                 name: "Publish Release"
                 command: ./scripts/publish.sh
     build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+
+orbs:
+  node: circleci/node@5.0.2
 
 jobs:
     build-mac:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
             xcode: 12.2
         steps:
             - node/install:
+                install-yarn: true
                 node-version: "14.19.1"
             - run:
                 name: "check node version"
@@ -16,6 +17,9 @@ jobs:
             - run:
                 name: "check node location"
                 command: which node
+            - run:
+                name: "yarn build and install"
+                command: yarn build && yarn install
     build:
         docker:
             - image: cimg/node:14.19.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## Version History
 
+### v29.0.3-dev
+
+- :tada: Build MacOS binary
+
 ### v29.0.2
 - :arrow_up: Upgrade geocoder-abbreviations to 4.6.11 to include new language. Allow Cyrillic characters. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## Version History
 
-### v29.0.3-dev1
+### v29.0.3-dev2
 
 - :tada: Build MacOS binary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## Version History
 
-### v29.0.3-dev2
+### v29.0.3-dev3
 
 - :tada: Build MacOS binary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## Version History
 
-### v29.0.3-dev3
+### v29.0.3-dev4
 
 - :tada: Build MacOS binary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## Version History
 
-### v29.0.3-dev
+### v29.0.3-dev1
 
 - :tada: Build MacOS binary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@
 
 ## Version History
 
-### v29.0.3-dev4
-
-- :tada: Build MacOS binary
+### v29.0.3
+- :tada: Build and release MacOS binary on CircleCI
 
 ### v29.0.2
 - :arrow_up: Upgrade geocoder-abbreviations to 4.6.11 to include new language. Allow Cyrillic characters. 

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 
 [lib]
 name = "pt2itp"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [build-dependencies]
 neon-build = "0.7.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/pt2itp",
-  "version": "29.0.3-dev2",
+  "version": "29.0.3-dev3",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/pt2itp",
-  "version": "29.0.3-dev3",
+  "version": "29.0.3-dev4",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/pt2itp",
-  "version": "29.0.3-dev4",
+  "version": "29.0.3",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/pt2itp",
-  "version": "29.0.2",
+  "version": "29.0.3-dev",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/pt2itp",
-  "version": "29.0.3-dev",
+  "version": "29.0.3-dev1",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/pt2itp",
-  "version": "29.0.3-dev1",
+  "version": "29.0.3-dev2",
   "license": "BSD-2-Clause ",
   "description": "Attach interpolation values given a road network and address points",
   "main": "index.js",

--- a/scripts/upload_asset.sh
+++ b/scripts/upload_asset.sh
@@ -3,7 +3,7 @@
 set -eu
 
 token="$NODE_PRE_GYP_GITHUB_TOKEN"
-platform=$(uname)
+platform=$(uname | tr '[:upper:]' '[:lower:]')
 
 # https://gist.github.com/stefanbuck/ce788fee19ab6eb0b4447a85fc99f447
 GH_API="https://api.github.com"
@@ -13,7 +13,7 @@ tag="$CIRCLE_TAG"
 GH_REPO="$GH_API/repos/$owner/$repo"
 GH_TAGS="$GH_REPO/releases/tags/$tag"
 AUTH="Authorization: token $token"
-file_path="build/stage/$tag/node-v83-${platform,,}-x64.tar.gz"
+file_path="build/stage/$tag/node-v83-$platform-x64.tar.gz"
 
 function generate_post_data()
 {

--- a/scripts/upload_asset.sh
+++ b/scripts/upload_asset.sh
@@ -3,6 +3,7 @@
 set -eu
 
 token="$NODE_PRE_GYP_GITHUB_TOKEN"
+platform=$(uname)
 
 # https://gist.github.com/stefanbuck/ce788fee19ab6eb0b4447a85fc99f447
 GH_API="https://api.github.com"
@@ -12,7 +13,7 @@ tag="$CIRCLE_TAG"
 GH_REPO="$GH_API/repos/$owner/$repo"
 GH_TAGS="$GH_REPO/releases/tags/$tag"
 AUTH="Authorization: token $token"
-file_path="build/stage/$tag/node-v83-linux-x64.tar.gz"
+file_path="build/stage/$tag/node-v83-${platform,,}-x64.tar.gz"
 
 function generate_post_data()
 {


### PR DESCRIPTION
This PR:

- Builds MacOS binary on CircleCI
- Publishes that MacOS binary to Github
- Changes Cargo.toml crate-type from dylib to cdylib (looks like might have been added incorrectly from neon config creator)

Once merged:

- [ ] Tag and push tag
- [ ] Publish to NPM